### PR TITLE
feat(audiences): bind audiences to authenticated user with ownership check

### DIFF
--- a/alembic/versions/e4f5a6b7c8d9_add_fk_audiences_user_id.py
+++ b/alembic/versions/e4f5a6b7c8d9_add_fk_audiences_user_id.py
@@ -1,0 +1,53 @@
+"""add FK audiences.user_id -> users.id and set NOT NULL
+
+Revision ID: e4f5a6b7c8d9
+Revises: d311c4623083
+Create Date: 2026-02-20 15:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e4f5a6b7c8d9'
+down_revision: Union[str, Sequence[str], None] = 'd311c4623083'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Remover audiências órfãs (user_id NULL) que não podem ser vinculadas
+    op.execute("DELETE FROM audiences WHERE user_id IS NULL")
+
+    # 2. Tornar user_id NOT NULL
+    op.alter_column(
+        'audiences',
+        'user_id',
+        existing_type=sa.UUID(),
+        nullable=False,
+    )
+
+    # 3. Adicionar FK para users.id
+    op.create_foreign_key(
+        'fk_audiences_user_id',
+        'audiences',
+        'users',
+        ['user_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('fk_audiences_user_id', 'audiences', type_='foreignkey')
+    op.alter_column(
+        'audiences',
+        'user_id',
+        existing_type=sa.UUID(),
+        nullable=True,
+    )

--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -15,7 +15,7 @@ class AudienceDTO:
     id: UUID
     name: str
     description: str | None
-    user_id: UUID | None
+    user_id: UUID
     communities_count: int
 
 
@@ -24,8 +24,9 @@ class CreateAudienceInput:
     """Input para criar audiência."""
 
     name: str
+    user_id: UUID
     description: str | None = None
-    user_id: UUID | None = None
+    community_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -37,7 +38,7 @@ class UpdateAudienceInput:
 
 
 class CreateAudienceUseCase:
-    """Cria uma nova audiência."""
+    """Cria uma nova audiência com comunidades opcionais."""
 
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
@@ -48,12 +49,18 @@ class CreateAudienceUseCase:
             description=input_data.description,
             user_id=input_data.user_id,
         )
+
+        for subreddit_name in input_data.community_ids:
+            self.repository.add_community(audience.id, subreddit_name)
+
+        communities_count = len(input_data.community_ids)
+
         return AudienceDTO(
             id=audience.id,
             name=audience.name,
             description=audience.description,
             user_id=audience.user_id,
-            communities_count=0,
+            communities_count=communities_count,
         )
 
 

--- a/app/modules/audiences/domain/entities/audience.py
+++ b/app/modules/audiences/domain/entities/audience.py
@@ -19,7 +19,12 @@ class Audience(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(200), nullable=False, index=True)
     description = Column(Text, nullable=True)
-    user_id = Column(UUID(as_uuid=True), nullable=True, index=True)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/app/routes/audiences.py
+++ b/app/routes/audiences.py
@@ -20,14 +20,20 @@ from app.modules.audiences.application.use_cases.manage_audience_use_case import
     UpdateAudienceInput,
     UpdateAudienceUseCase,
 )
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
 from app.modules.shared.infra.database.database import get_db
 
 router = APIRouter(prefix="/audiences", tags=["Audiences"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
 
 
 class CreateAudienceRequest(BaseModel):
     name: str
     description: str | None = None
+    community_ids: list[str] = []
 
 
 class UpdateAudienceRequest(BaseModel):
@@ -39,109 +45,158 @@ class AddCommunityRequest(BaseModel):
     subreddit_name: str
 
 
-@router.get("")
-def list_audiences(current_user: User = Depends(get_current_user), db=Depends(get_db)):
-    """
-    Lista todas as audiências com dados agregados para os cards.
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuário é dono da audiência ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
 
-    Returns:
-        Lista de cards com: name, total_subs, total_members, growth_week, icons
+
+@router.get("")
+def list_audiences(
+    current_user: User = Depends(get_current_user), db=Depends(get_db)
+):
+    """
+    Lista audiências do usuário autenticado.
+    Superuser vê todas.
     """
     use_case = ListAudienceCardsUseCase(db)
-    cards = use_case.execute()
+    user_id = None if current_user.is_superuser else current_user.id
+    cards = use_case.execute(user_id)
     return {"audiences": [vars(card) for card in cards]}
 
 
-@router.post("")
-def create_audience(request: CreateAudienceRequest, current_user: User = Depends(get_current_user), db=Depends(get_db)):
+@router.post("", status_code=201)
+def create_audience(
+    request: CreateAudienceRequest,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
     """
-    Cria uma nova audiência.
-
-    Args:
-        request: Nome e descrição da audiência
-
-    Returns:
-        Audiência criada
+    Cria uma nova audiência vinculada ao usuário autenticado.
+    Aceita community_ids para vincular comunidades na criação.
     """
     use_case = CreateAudienceUseCase(db)
     input_data = CreateAudienceInput(
         name=request.name,
         description=request.description,
+        user_id=current_user.id,
+        community_ids=request.community_ids,
     )
     audience = use_case.execute(input_data)
     return vars(audience)
 
 
 @router.get("/{audience_id}")
-def get_audience_card(audience_id: UUID, current_user: User = Depends(get_current_user), db=Depends(get_db)):
+def get_audience_card(
+    audience_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
     """
     Retorna dados agregados de uma audiência para o card.
-
-    Returns:
-        Card com: name, total_subs, total_members, growth_week, growth_month, icons
     """
+    repository = AudienceRepository(db)
+    audience = repository.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
     use_case = GetAudienceCardUseCase(db)
     card = use_case.execute(audience_id)
-    if not card:
-        raise HTTPException(status_code=404, detail="Audience not found")
     return vars(card)
 
 
 @router.put("/{audience_id}")
 def update_audience(
-    audience_id: UUID, request: UpdateAudienceRequest, current_user: User = Depends(get_current_user), db=Depends(get_db)
+    audience_id: UUID,
+    request: UpdateAudienceRequest,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
 ):
     """
     Atualiza uma audiência.
     """
+    repository = AudienceRepository(db)
+    audience = repository.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
     use_case = UpdateAudienceUseCase(db)
     input_data = UpdateAudienceInput(
         name=request.name,
         description=request.description,
     )
-    audience = use_case.execute(audience_id, input_data)
-    if not audience:
-        raise HTTPException(status_code=404, detail="Audience not found")
-    return vars(audience)
+    updated = use_case.execute(audience_id, input_data)
+    return vars(updated)
 
 
 @router.delete("/{audience_id}")
-def delete_audience(audience_id: UUID, current_user: User = Depends(get_current_user), db=Depends(get_db)):
+def delete_audience(
+    audience_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
     """
     Remove uma audiência.
     """
+    repository = AudienceRepository(db)
+    audience = repository.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
     use_case = DeleteAudienceUseCase(db)
-    deleted = use_case.execute(audience_id)
-    if not deleted:
-        raise HTTPException(status_code=404, detail="Audience not found")
+    use_case.execute(audience_id)
     return {"deleted": True}
 
 
 @router.post("/{audience_id}/communities")
 def add_community_to_audience(
-    audience_id: UUID, request: AddCommunityRequest, current_user: User = Depends(get_current_user), db=Depends(get_db)
+    audience_id: UUID,
+    request: AddCommunityRequest,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
 ):
     """
     Adiciona uma comunidade a uma audiência.
-
-    Args:
-        audience_id: ID da audiência
-        request: Nome do subreddit a adicionar
     """
+    repository = AudienceRepository(db)
+    audience = repository.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
     use_case = AddCommunityToAudienceUseCase(db)
     added = use_case.execute(audience_id, request.subreddit_name)
     if not added:
-        raise HTTPException(status_code=404, detail="Audience not found")
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
     return {"added": True, "subreddit_name": request.subreddit_name}
 
 
 @router.delete("/{audience_id}/communities/{subreddit_name}")
 def remove_community_from_audience(
-    audience_id: UUID, subreddit_name: str, current_user: User = Depends(get_current_user), db=Depends(get_db)
+    audience_id: UUID,
+    subreddit_name: str,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
 ):
     """
     Remove uma comunidade de uma audiência.
     """
+    repository = AudienceRepository(db)
+    audience = repository.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
     use_case = RemoveCommunityFromAudienceUseCase(db)
     removed = use_case.execute(audience_id, subreddit_name)
     if not removed:


### PR DESCRIPTION
## Summary

- Adiciona FK `audiences.user_id → users.id` com constraint NOT NULL e CASCADE delete
- Propaga `current_user.id` na criação de audiências (via token JWT)
- Aceita `community_ids: list[str]` no `POST /audiences` para vincular comunidades na criação
- Filtra `GET /audiences` por usuário autenticado (superuser vê todas)
- Valida ownership (dono ou superuser) em todas as operações: GET, PUT, DELETE, add/remove community
- Retorna 403 se não autorizado

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `alembic/versions/e4f5a6b7c8d9_...py` | Nova migration: deleta órfãs, NOT NULL, FK |
| `app/modules/audiences/domain/entities/audience.py` | `user_id` com ForeignKey + nullable=False |
| `app/modules/audiences/application/use_cases/manage_audience_use_case.py` | `user_id` obrigatório, `community_ids` na criação |
| `app/routes/audiences.py` | Ownership check, filtro por user, community_ids no request, status 201 |

## Test plan

- [ ] `POST /audiences` com token → audiência criada com `user_id` do token
- [ ] `POST /audiences` com `community_ids` → comunidades vinculadas na criação
- [ ] `GET /audiences` → retorna apenas audiências do usuário autenticado
- [ ] `GET /audiences` com superuser → retorna todas
- [ ] `PUT /audiences/{id}` de outro usuário → 403
- [ ] `DELETE /audiences/{id}` de outro usuário → 403
- [ ] `PUT /audiences/{id}` com superuser → 200 (acesso permitido)
- [ ] Migration funcional em banco existente

Closes #17