### PR TITLE
refactor(audiences): rename community_ids to subreddit_names

### DIFF
--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -26,7 +26,7 @@ class CreateAudienceInput:
     name: str
     user_id: UUID
     description: str | None = None
-    community_ids: list[str] = field(default_factory=list)
+    subreddit_names: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -50,10 +50,10 @@ class CreateAudienceUseCase:
             user_id=input_data.user_id,
         )
 
-        for subreddit_name in input_data.community_ids:
+        for subreddit_name in input_data.subreddit_names:
             self.repository.add_community(audience.id, subreddit_name)
 
-        communities_count = len(input_data.community_ids)
+        communities_count = len(input_data.subreddit_names)
 
         return AudienceDTO(
             id=audience.id,

--- a/app/routes/audiences.py
+++ b/app/routes/audiences.py
@@ -33,7 +33,7 @@ AUDIENCE_NOT_FOUND = "Audience not found"
 class CreateAudienceRequest(BaseModel):
     name: str
     description: str | None = None
-    community_ids: list[str] = []
+    subreddit_names: list[str] = []
 
 
 class UpdateAudienceRequest(BaseModel):
@@ -75,14 +75,14 @@ def create_audience(
 ):
     """
     Cria uma nova audiência vinculada ao usuário autenticado.
-    Aceita community_ids para vincular comunidades na criação.
+    Aceita subreddit_names para vincular comunidades na criação.
     """
     use_case = CreateAudienceUseCase(db)
     input_data = CreateAudienceInput(
         name=request.name,
         description=request.description,
         user_id=current_user.id,
-        community_ids=request.community_ids,
+        subreddit_names=request.subreddit_names,
     )
     audience = use_case.execute(input_data)
     return vars(audience)


### PR DESCRIPTION
## Summary

- Renomeia `community_ids` para `subreddit_names` em `CreateAudienceRequest`, `CreateAudienceInput` e `CreateAudienceUseCase`
- O nome anterior (`community_ids`) sugeria UUIDs, o que poderia gerar confusão. `subreddit_names` reflete exatamente o que é enviado: nomes de subreddits do Reddit, que são identificadores únicos por natureza

## Arquivos modificados

- `app/routes/audiences.py` — campo do request e docstring
- `app/modules/audiences/application/use_cases/manage_audience_use_case.py` — dataclass e use case

## Test plan

- [ ] `POST /audiences` com `subreddit_names: ["python", "rust"]` → 201 com communities_count: 2
- [ ] `POST /audiences` sem `subreddit_names` → 201 com communities_count: 0