### PR TITLE
fix(stats): prioritize Reddit API subscriber count over SubredditStats

### DIFF
--- a/app/modules/shared/application/services/community_stats_service.py
+++ b/app/modules/shared/application/services/community_stats_service.py
@@ -93,8 +93,8 @@ class CommunityStatsService:
             if icon_url:
                 icon_url = icon_url.replace("&amp;", "&")
 
-        # 4. Se temos growth_data, usar subscribers dela (pode ser mais atual)
-        if growth_data and growth_data.subscribers:
+        # 4. Se NÃO temos subscribers do Reddit, usar da growth_data como fallback
+        if not subscribers and growth_data and growth_data.subscribers:
             subscribers = growth_data.subscribers
 
         # 5. Salvar no banco


### PR DESCRIPTION
## Summary
- Corrige bug onde o subscriber count do Reddit API era sobrescrito por dados desatualizados do SubredditStats.com
- Reddit API passa a ser a fonte primária; SubredditStats é usado apenas como fallback
- Dados de growth (week/month) continuam vindo do SubredditStats normalmente

## Contexto
A comunidade `marketingdigitalbr` aparecia com ~4k subscribers no sistema, enquanto o Reddit real mostra ~41k. O `CommunityStatsService` priorizava o `subscriberCount` do SubredditStats.com sobre o `subscribers` da API do Reddit.

## Mudança
```python
# Antes (sobrescrevia o valor correto do Reddit)
if growth_data and growth_data.subscribers:
    subscribers = growth_data.subscribers

# Depois (Reddit é primário, SubredditStats é fallback)
if not subscribers and growth_data and growth_data.subscribers:
    subscribers = growth_data.subscribers
```

## Impacto
- Arquivo alterado: `app/modules/shared/application/services/community_stats_service.py`
- Nenhum outro arquivo afetado — a lógica de prioridade existe apenas neste ponto

Closes #20