### PR TITLE
feat(audiences): add community sync to PUT endpoint

### DIFF
--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -35,6 +35,7 @@ class UpdateAudienceInput:
 
     name: str | None = None
     description: str | None = None
+    subreddit_names: list[str] | None = None
 
 
 class CreateAudienceUseCase:
@@ -81,12 +82,20 @@ class UpdateAudienceUseCase:
         if not audience:
             return None
 
+        if input_data.subreddit_names is not None:
+            communities = self.repository.sync_communities(
+                audience_id, input_data.subreddit_names
+            )
+            communities_count = len(communities)
+        else:
+            communities_count = len(audience.communities)
+
         return AudienceDTO(
             id=audience.id,
             name=audience.name,
             description=audience.description,
             user_id=audience.user_id,
-            communities_count=len(audience.communities),
+            communities_count=communities_count,
         )
 
 

--- a/app/modules/audiences/infra/repositories/audience_repository.py
+++ b/app/modules/audiences/infra/repositories/audience_repository.py
@@ -142,6 +142,36 @@ class AudienceRepository:
         self.db.commit()
         return True
 
+    def sync_communities(
+        self,
+        audience_id: UUID,
+        subreddit_names: list[str],
+    ) -> list[AudienceCommunity]:
+        """
+        Sincroniza comunidades de uma audiência com a lista desejada.
+        Remove as que não estão na lista, adiciona as novas.
+        """
+        current = self.get_communities(audience_id)
+        current_names = {c.subreddit_name for c in current}
+        desired_names = {name.lower() for name in subreddit_names}
+
+        to_remove = current_names - desired_names
+        to_add = desired_names - current_names
+
+        if to_remove:
+            self.db.query(AudienceCommunity).filter(
+                AudienceCommunity.audience_id == audience_id,
+                AudienceCommunity.subreddit_name.in_(to_remove),
+            ).delete(synchronize_session="fetch")
+
+        for name in to_add:
+            self.db.add(
+                AudienceCommunity(audience_id=audience_id, subreddit_name=name)
+            )
+
+        self.db.commit()
+        return self.get_communities(audience_id)
+
     def get_communities(self, audience_id: UUID) -> list[AudienceCommunity]:
         """
         Lista comunidades de uma audiência.

--- a/app/routes/audiences.py
+++ b/app/routes/audiences.py
@@ -39,6 +39,7 @@ class CreateAudienceRequest(BaseModel):
 class UpdateAudienceRequest(BaseModel):
     name: str | None = None
     description: str | None = None
+    subreddit_names: list[str] | None = None
 
 
 class AddCommunityRequest(BaseModel):
@@ -128,6 +129,7 @@ def update_audience(
     input_data = UpdateAudienceInput(
         name=request.name,
         description=request.description,
+        subreddit_names=request.subreddit_names,
     )
     updated = use_case.execute(audience_id, input_data)
     return vars(updated)


### PR DESCRIPTION
## Summary

- Add `subreddit_names` field to `PUT /audiences/{id}` for bulk community sync
- Backend diffs current vs desired communities and adds/removes accordingly
- Backward compatible: omitting `subreddit_names` preserves existing communities
- Segmented `.rest` test files by domain (auth, communities, topics, audiences) — local only, gitignored

## Behavior

| Input | Result |
|-------|--------|
| `subreddit_names: ["a", "b", "c"]` | Sync: removes missing, adds new |
| `subreddit_names: []` | Removes all communities |
| `subreddit_names: null` or omitted | No changes to communities |

## Files changed

- `app/modules/audiences/infra/repositories/audience_repository.py` — new `sync_communities()` method
- `app/modules/audiences/application/use_cases/manage_audience_use_case.py` — `UpdateAudienceInput` + `UpdateAudienceUseCase` updated
- `app/routes/audiences.py` — `UpdateAudienceRequest` accepts `subreddit_names`

## Test plan

- [ ] PUT with smaller list → communities removed
- [ ] PUT with larger list → communities added
- [ ] PUT with `[]` → all communities removed
- [ ] PUT without `subreddit_names` → communities unchanged
- [ ] POST/DELETE individual community endpoints still work

Closes #25