### PR TITLE
fix(identity): unify User model Base with domain models metadata

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -27,7 +27,7 @@ if config.config_file_name is not None:
 # add your model's MetaData object here
 # for 'autogenerate' support
 # Importar o Base e todos os models
-from app.models.base import Base  # noqa: E402
+from app.models.base import Base as LegacyBase  # noqa: E402
 from app.models import (  # noqa: E402
     item_proposta,
     lead,
@@ -36,9 +36,17 @@ from app.models import (  # noqa: E402
     status_lead,
     tarefa_lead,
 )
+from app.modules.shared.infra.database.orm.metadata import Base  # noqa: E402
 from app.modules.identity.domain.entities import user  # noqa: E402
+from app.modules.audiences.domain.entities import audience  # noqa: E402
+from app.modules.shared.domain.entities import community_stats  # noqa: E402
+from app.modules.shared.domain.entities import llm_cache  # noqa: E402
+from app.modules.shared.domain.entities import related_sub  # noqa: E402
+from app.modules.similar_communities.domain.entities import community_embedding  # noqa: E402
+from app.modules.similar_communities.domain.entities import user_feedback  # noqa: E402
+from app.modules.audience_templates.domain.entities import audience_template  # noqa: E402
 
-target_metadata = Base.metadata
+target_metadata = [LegacyBase.metadata, Base.metadata]
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/app/modules/identity/domain/entities/user.py
+++ b/app/modules/identity/domain/entities/user.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from sqlalchemy import Boolean, Column, DateTime, String
 from sqlalchemy.dialects.postgresql import UUID
 
-from app.models.base import Base
+from app.modules.shared.infra.database.orm.metadata import Base
 
 
 class User(Base):

--- a/docs/issue-27-dual-base-no-referenced-table-error.md
+++ b/docs/issue-27-dual-base-no-referenced-table-error.md
@@ -1,0 +1,158 @@
+# Issue #27 — NoReferencedTableError: User model usa Base diferente dos demais models de domínio
+
+## Motivação
+
+Ao chamar `PUT /audiences/{id}` com payload contendo `subreddit_names`, o servidor retornava **500 Internal Server Error** com o seguinte traceback:
+
+```
+sqlalchemy.exc.NoReferencedTableError: Foreign key associated with column 'audiences.user_id'
+could not find table 'users' with which to generate a foreign key to target column 'id'
+```
+
+### Cenário do usuário
+
+O usuário tentou atualizar uma audiência com sync de comunidades (feature adicionada na Issue #25) e recebeu erro 500. O payload enviado:
+
+```json
+{
+    "name": "Marketing Custom",
+    "description": "",
+    "subreddit_names": [
+        "digitalmarketing",
+        "marketing",
+        "marketingdigitalbr",
+        "socialmediamarketing"
+    ]
+}
+```
+
+---
+
+## Análise
+
+### Causa raiz: duas instâncias de Base (declarative base)
+
+O projeto possuía duas instâncias separadas de Base do SQLAlchemy, cada uma com seu próprio registry de metadata:
+
+| Base | Arquivo | Tipo | Models |
+|------|---------|------|--------|
+| Base #1 | `app/models/base.py` | `DeclarativeBase` (SQLAlchemy 2.0) | Lead, Proposta, StatusLead, etc. (legado) |
+| Base #2 | `app/modules/shared/infra/database/orm/metadata.py` | `declarative_base()` (legacy API) | Audience, CommunityStats, LLMCache, etc. (domínio) |
+
+O model `User` importava `Base` de `app.models.base` (Base #1), enquanto `Audience` e todos os outros models de domínio importavam de `app.modules.shared.infra.database.orm.metadata` (Base #2).
+
+Quando o SQLAlchemy tentava resolver `ForeignKey("users.id")` no model `Audience`, ele procurava a tabela `users` no registry de metadata do Base #2 — mas ela estava registrada no Base #1. Resultado: `NoReferencedTableError`.
+
+### Por que o bug surgiu agora?
+
+O bug existia latente desde a Issue #17 (Audience User Ownership), mas só se manifestava em operações que forçavam o SQLAlchemy a resolver o FK em runtime. A feature de community sync (Issue #25) introduziu operações de bulk delete/insert que ativaram essa resolução, expondo o bug.
+
+### Alembic também afetado
+
+O `alembic/env.py` referenciava apenas `Base.metadata` (Base #1) como `target_metadata`, fazendo com que o Alembic só enxergasse os models legados para autogenerate. Os models de domínio não eram rastreados.
+
+---
+
+## Solução Adotada
+
+### Fix 1: Unificar o Base do User com os demais models de domínio
+
+```python
+# Antes (app/modules/identity/domain/entities/user.py)
+from app.models.base import Base
+
+# Depois
+from app.modules.shared.infra.database.orm.metadata import Base
+```
+
+Agora `User` e `Audience` compartilham o mesmo registry de metadata, permitindo que o SQLAlchemy resolva o FK `audiences.user_id → users.id` corretamente.
+
+### Fix 2: Atualizar alembic/env.py para ambos metadata
+
+```python
+# Antes
+from app.models.base import Base
+target_metadata = Base.metadata
+
+# Depois
+from app.models.base import Base as LegacyBase
+from app.modules.shared.infra.database.orm.metadata import Base
+target_metadata = [LegacyBase.metadata, Base.metadata]
+```
+
+Além disso, todos os models de domínio foram importados no `env.py` para que o Alembic os registre no autogenerate:
+
+- `audience`, `user`, `community_stats`, `llm_cache`, `related_sub`, `community_embedding`, `user_feedback`, `audience_template`
+
+---
+
+## Arquivos Modificados
+
+### `app/modules/identity/domain/entities/user.py`
+- Linha 9: troca do import de `app.models.base` para `app.modules.shared.infra.database.orm.metadata`
+
+### `alembic/env.py`
+- Linha 30: `Base` renomeado para `LegacyBase`
+- Linhas 39-47: adicionados imports de todos os models de domínio
+- Linha 49: `target_metadata` agora é lista com ambos metadata
+
+---
+
+## Como Testar
+
+### Teste 1 — PUT com subreddit_names (reprodução do bug)
+
+```http
+PUT /audiences/{audience_id}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+    "name": "Marketing Custom",
+    "description": "",
+    "subreddit_names": ["digitalmarketing", "marketing", "marketingdigitalbr", "socialmediamarketing"]
+}
+```
+
+**Esperado:** 200 OK com `communities_count: 4`. Antes retornava 500.
+
+### Teste 2 — PUT sem subreddit_names (backward compatible)
+
+```http
+PUT /audiences/{audience_id}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+    "name": "Novo nome"
+}
+```
+
+**Esperado:** 200 OK, nome atualizado, comunidades inalteradas.
+
+### Teste 3 — Endpoints unitários de comunidades
+
+```http
+POST /audiences/{audience_id}/communities
+{"subreddit_name": "typescript"}
+
+DELETE /audiences/{audience_id}/communities/typescript
+```
+
+**Esperado:** Ambos funcionam normalmente.
+
+---
+
+## Relação com Outras Issues
+
+| Issue | Relação |
+|-------|---------|
+| #25 — Sync de Comunidades no PUT | O bug se manifestou após essa feature ser mergeada |
+| #17 — Audience User Ownership | FK `audiences.user_id → users.id` é o ponto de falha |
+
+---
+
+## Melhorias Futuras (Fora do Escopo)
+
+- **Unificação completa de Base:** Migrar os models legados (`app/models/`) para o mesmo Base de domínio, eliminando a dualidade
+- **Testes de integridade de FK:** Adicionar teste que valida que todos os ForeignKeys são resolvíveis dentro do mesmo registry de metadata


### PR DESCRIPTION
## Summary
- Corrige `NoReferencedTableError` no `PUT /audiences/{id}` com `subreddit_names`
- Model `User` agora importa `Base` de `app.modules.shared.infra.database.orm.metadata` (mesmo Base dos demais models de domínio)
- `alembic/env.py` atualizado para registrar ambos metadata (legado + domínio) e importar todos os models de domínio

## Causa Raiz
O `User` usava `Base` de `app.models.base` (DeclarativeBase) enquanto `Audience` e demais models usavam `Base` de `app.modules.shared.infra.database.orm.metadata` (declarative_base). Registries de metadata separados impediam a resolução do FK `audiences.user_id → users.id`.

## Arquivos Alterados
- `app/modules/identity/domain/entities/user.py` — troca do import de Base
- `alembic/env.py` — importa ambos Base e todos os models de domínio

## Test plan
- [ ] Fazer PUT /audiences/{id} com `subreddit_names` e verificar que retorna 200
- [ ] Verificar que PUT sem `subreddit_names` continua funcionando (backward compatible)
- [ ] Verificar que `alembic check` não detecta drift nas migrations

Closes #27