### PR TITLE
feat: audience topic extraction with background analysis pipeline

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -45,6 +45,7 @@ from app.modules.shared.domain.entities import related_sub  # noqa: E402
 from app.modules.similar_communities.domain.entities import community_embedding  # noqa: E402
 from app.modules.similar_communities.domain.entities import user_feedback  # noqa: E402
 from app.modules.audience_templates.domain.entities import audience_template  # noqa: E402
+from app.modules.audience_topics.domain.entities import audience_topic  # noqa: E402
 
 target_metadata = [LegacyBase.metadata, Base.metadata]
 

--- a/alembic/versions/a8b9c0d1e2f3_add_audience_topics.py
+++ b/alembic/versions/a8b9c0d1e2f3_add_audience_topics.py
@@ -1,0 +1,65 @@
+"""add audience_topic_analyses and audience_topics tables
+
+Revision ID: a8b9c0d1e2f3
+Revises: f7a8b9c0d1e2
+Create Date: 2026-02-21
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSON
+
+# revision identifiers, used by Alembic.
+revision: str = "a8b9c0d1e2f3"
+down_revision: Union[str, None] = "f7a8b9c0d1e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audience_topic_analyses",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "audience_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audiences.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("status", sa.String(20), nullable=False, default="processing", index=True),
+        sa.Column("communities_fingerprint", sa.String(64), nullable=False, index=True),
+        sa.Column("total_topics", sa.Integer, nullable=True),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "audience_topics",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "analysis_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audience_topic_analyses.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("growth_percentage", sa.Float, nullable=True),
+        sa.Column("mention_frequency", sa.Float, nullable=True),
+        sa.Column("mention_period", sa.String(10), nullable=True),
+        sa.Column("post_count", sa.Integer, nullable=True),
+        sa.Column("communities", JSON, nullable=True),
+        sa.Column("rank", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audience_topics")
+    op.drop_table("audience_topic_analyses")

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app.config import settings
 from app.routes import (
     auth_router,
     audience_templates_router,
+    audience_topics_router,
     audiences_router,
     communities_router,
     similar_communities_router,
@@ -64,6 +65,7 @@ app.include_router(auth_router)
 app.include_router(topics_router)
 app.include_router(audiences_router)
 app.include_router(audience_templates_router)
+app.include_router(audience_topics_router)
 app.include_router(similar_communities_router)
 app.include_router(communities_router)
 

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/prompts/topic_extraction_prompts.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/prompts/topic_extraction_prompts.py
@@ -1,0 +1,84 @@
+def extract_topics_prompt(
+    audience_name: str,
+    audience_description: str | None,
+    community_names: list[str],
+    posts_text: str,
+    total_posts: int,
+) -> str:
+    communities_str = ", ".join(f"r/{name}" for name in community_names)
+    desc_line = f"\nAudience description: {audience_description}" if audience_description else ""
+
+    return f"""You are an expert Reddit analyst specializing in trend detection and topic extraction.
+
+Audience: "{audience_name}"{desc_line}
+Communities: {communities_str}
+Total posts analyzed: {total_posts}
+
+Below are the titles and text from recent posts across these communities:
+
+{posts_text}
+
+---
+
+TASK: Identify the most discussed and trending topics across these communities.
+
+For each topic you identify:
+1. Give it a clear, concise name (2-4 words)
+2. Write a one-sentence description explaining the topic in context of this audience
+3. Estimate how frequently this topic is mentioned: provide a number and period (day/week/month)
+4. Count how many posts relate to this topic
+5. List which communities discuss it and how many posts per community
+
+Extract up to 200 topics, ranked by relevance and frequency.
+
+IMPORTANT: Focus on recurring THEMES, not individual posts. Group similar discussions together.
+Examples of good topics: "Health issues", "Training tips", "Product recommendations", "Budget concerns"
+Examples of bad topics: "John's post about his dog" (too specific), "Random" (too vague)
+
+Respond in this exact format, one topic per line:
+NAME|DESCRIPTION|FREQUENCY_NUMBER|FREQUENCY_PERIOD|POST_COUNT|COMMUNITIES
+
+Where COMMUNITIES is a semicolon-separated list of "subreddit_name:count"
+
+Example line:
+Health issues|Physical or mental conditions affecting pets that require attention|3|month|15|DogAdvice:10;CatAdvice:5
+
+Do NOT include any other text, headers, or numbering. Just the pipe-delimited lines."""
+
+
+def estimate_growth_prompt(
+    topics_text: str,
+    audience_name: str,
+) -> str:
+    return f"""You are an expert in Reddit trend analysis.
+
+Audience: "{audience_name}"
+
+Below are topics extracted from recent community discussions, with their mention frequency:
+
+{topics_text}
+
+---
+
+TASK: Estimate the growth percentage for each topic.
+
+Growth means how much MORE this topic is being discussed compared to its usual baseline.
+Consider:
+- Higher frequency + more communities = likely growing
+- Niche topics appearing across multiple communities = strong growth signal
+- Common/generic topics = lower growth unless unusually frequent
+
+Assign a growth percentage between 0% and 500%:
+- 0-50%: Stable, normal discussion levels
+- 50-100%: Moderate growth, gaining traction
+- 100-200%: Strong growth, clearly trending
+- 200-500%: Viral growth, major trend
+
+Respond with one line per topic in this exact format:
+TOPIC_NAME|GROWTH_PERCENTAGE
+
+Example:
+Health issues|400
+Training tips|150
+
+Do NOT include any other text. Just the pipe-delimited lines."""

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/state.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/state.py
@@ -1,0 +1,33 @@
+from typing import TypedDict
+
+
+class PostData(TypedDict):
+    id: str
+    subreddit: str
+    title: str
+    selftext: str
+    score: int
+    num_comments: int
+    created_utc: float
+
+
+class ExtractedTopic(TypedDict):
+    name: str
+    description: str
+    growth_percentage: float | None
+    mention_frequency: float | None
+    mention_period: str | None  # "day", "week", "month"
+    post_count: int
+    communities: list[dict]  # [{"name": "sub", "post_count": N}]
+    rank: int
+
+
+class TopicExtractionState(TypedDict):
+    audience_name: str
+    audience_description: str | None
+    community_names: list[str]
+    posts: list[PostData]
+    total_posts: int
+
+    # Populated by nodes
+    extracted_topics: list[ExtractedTopic]

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/topic_extraction_agent.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/topic_extraction_agent.py
@@ -1,0 +1,209 @@
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.audience_topics.application.use_cases.extract_topics_use_case.agent.prompts.topic_extraction_prompts import (
+    estimate_growth_prompt,
+    extract_topics_prompt,
+)
+from app.modules.audience_topics.application.use_cases.extract_topics_use_case.agent.state import (
+    ExtractedTopic,
+    TopicExtractionState,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_POSTS_CHARS = 80_000  # Limit to avoid exceeding context window
+
+
+def _get_llm() -> ChatOpenAI:
+    return ChatOpenAI(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        temperature=0,
+    )
+
+
+def _build_posts_text(posts: list[dict], max_chars: int = MAX_POSTS_CHARS) -> str:
+    """Builds a text block from posts, truncating to fit context window."""
+    lines = []
+    total_chars = 0
+
+    for post in posts:
+        title = post.get("title", "").strip()
+        selftext = post.get("selftext", "").strip()
+        subreddit = post.get("subreddit", "")
+
+        # Truncate long selftext
+        if len(selftext) > 300:
+            selftext = selftext[:300] + "..."
+
+        line = f"[r/{subreddit}] {title}"
+        if selftext:
+            line += f"\n  {selftext}"
+
+        if total_chars + len(line) > max_chars:
+            break
+
+        lines.append(line)
+        total_chars += len(line)
+
+    return "\n\n".join(lines)
+
+
+# ── Node 1: Extract topics from posts ───────────────────────────────────────
+
+
+def extract_topics(state: TopicExtractionState) -> dict:
+    """LLM extracts recurring topics from collected posts."""
+    posts = state["posts"]
+    if not posts:
+        return {"extracted_topics": []}
+
+    posts_text = _build_posts_text(posts)
+    llm = _get_llm()
+
+    prompt = extract_topics_prompt(
+        audience_name=state["audience_name"],
+        audience_description=state.get("audience_description"),
+        community_names=state["community_names"],
+        posts_text=posts_text,
+        total_posts=state["total_posts"],
+    )
+
+    response = llm.invoke(prompt)
+
+    topics: list[ExtractedTopic] = []
+    rank = 1
+
+    for line in response.content.strip().split("\n"):
+        line = line.strip()
+        if not line or "|" not in line:
+            continue
+
+        parts = line.split("|")
+        if len(parts) < 6:
+            continue
+
+        name = parts[0].strip()
+        description = parts[1].strip()
+
+        try:
+            mention_frequency = float(parts[2].strip())
+        except ValueError:
+            mention_frequency = None
+
+        mention_period = parts[3].strip().lower()
+        if mention_period not in ("day", "week", "month"):
+            mention_period = "month"
+
+        try:
+            post_count = int(parts[4].strip())
+        except ValueError:
+            post_count = 0
+
+        # Parse communities: "DogAdvice:10;CatAdvice:5"
+        communities = []
+        for comm_part in parts[5].strip().split(";"):
+            comm_part = comm_part.strip()
+            if ":" in comm_part:
+                comm_name, comm_count = comm_part.rsplit(":", 1)
+                try:
+                    communities.append({
+                        "name": comm_name.strip(),
+                        "post_count": int(comm_count.strip()),
+                    })
+                except ValueError:
+                    communities.append({"name": comm_name.strip(), "post_count": 0})
+
+        topics.append(
+            ExtractedTopic(
+                name=name,
+                description=description,
+                growth_percentage=None,  # Filled in next node
+                mention_frequency=mention_frequency,
+                mention_period=mention_period,
+                post_count=post_count,
+                communities=communities,
+                rank=rank,
+            )
+        )
+        rank += 1
+
+    logger.info("Extracted %d topics from %d posts", len(topics), len(posts))
+    return {"extracted_topics": topics}
+
+
+# ── Node 2: Estimate growth for each topic ───────────────────────────────────
+
+
+def estimate_growth(state: TopicExtractionState) -> dict:
+    """LLM estimates growth percentage for each extracted topic."""
+    topics = state["extracted_topics"]
+    if not topics:
+        return {"extracted_topics": []}
+
+    # Build topics summary for growth estimation
+    topics_lines = []
+    for t in topics:
+        freq = f"{t['mention_frequency']}/{t['mention_period']}" if t["mention_frequency"] else "unknown"
+        comm_count = len(t["communities"])
+        topics_lines.append(
+            f"{t['name']} — freq: {freq}, posts: {t['post_count']}, communities: {comm_count}"
+        )
+
+    topics_text = "\n".join(topics_lines)
+
+    llm = _get_llm()
+    prompt = estimate_growth_prompt(topics_text, state["audience_name"])
+    response = llm.invoke(prompt)
+
+    # Parse growth results
+    growth_map = {}
+    for line in response.content.strip().split("\n"):
+        line = line.strip()
+        if not line or "|" not in line:
+            continue
+        parts = line.split("|")
+        if len(parts) >= 2:
+            name = parts[0].strip()
+            try:
+                growth = float(parts[1].strip().replace("%", ""))
+                growth_map[name.lower()] = growth
+            except ValueError:
+                continue
+
+    # Apply growth to topics and re-rank by growth
+    for topic in topics:
+        growth = growth_map.get(topic["name"].lower())
+        if growth is not None:
+            topic["growth_percentage"] = growth
+
+    # Re-rank by growth (highest first)
+    topics.sort(
+        key=lambda t: t.get("growth_percentage") or 0,
+        reverse=True,
+    )
+    for i, topic in enumerate(topics):
+        topic["rank"] = i + 1
+
+    logger.info("Estimated growth for %d/%d topics", len(growth_map), len(topics))
+    return {"extracted_topics": topics}
+
+
+# ── Graph assembly ───────────────────────────────────────────────────────────
+
+
+def create_topic_extraction_agent():
+    """Create the LangGraph agent for topic extraction."""
+    workflow = StateGraph(TopicExtractionState)
+
+    workflow.add_node("extract_topics", extract_topics)
+    workflow.add_node("estimate_growth", estimate_growth)
+
+    workflow.add_edge(START, "extract_topics")
+    workflow.add_edge("extract_topics", "estimate_growth")
+    workflow.add_edge("estimate_growth", END)
+
+    return workflow.compile()

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/extract_topics_use_case.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/extract_topics_use_case.py
@@ -1,0 +1,138 @@
+"""Use case that orchestrates topic extraction for an audience."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_topics.application.use_cases.extract_topics_use_case.agent.state import (
+    PostData,
+)
+from app.modules.audience_topics.application.use_cases.extract_topics_use_case.agent.topic_extraction_agent import (
+    create_topic_extraction_agent,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.topics.infra.providers.reddit_provider.generic_reddit_provider import (
+    GenericRedditProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExtractTopicsUseCase:
+    """
+    Coleta posts das comunidades de uma audiência e extrai tópicos via LangGraph.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.reddit_provider = GenericRedditProvider()
+
+    def execute(self, audience_id: UUID, analysis_id: UUID) -> bool:
+        """
+        Executa a extração completa de tópicos.
+
+        Args:
+            audience_id: ID da audiência
+            analysis_id: ID da análise já criada (status: processing)
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        try:
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                self.topic_repo.mark_failed(analysis_id, "Audience not found")
+                return False
+
+            communities = self.audience_repo.get_communities(audience_id)
+            community_names = [c.subreddit_name for c in communities]
+
+            if not community_names:
+                self.topic_repo.mark_failed(analysis_id, "No communities in audience")
+                return False
+
+            # 1. Coletar posts das comunidades
+            logger.info(
+                "Collecting posts for audience '%s' (%d communities)",
+                audience.name,
+                len(community_names),
+            )
+            post_results = self.reddit_provider.collect_posts_for_communities(
+                community_names, posts_per_sort=25
+            )
+
+            # 2. Converter para PostData e deduplicar
+            seen_ids = set()
+            posts: list[PostData] = []
+            for result in post_results:
+                for post in result.posts:
+                    if post.id in seen_ids:
+                        continue
+                    seen_ids.add(post.id)
+                    posts.append(
+                        PostData(
+                            id=post.id,
+                            subreddit=post.subreddit,
+                            title=post.title,
+                            selftext=post.selftext,
+                            score=post.score,
+                            num_comments=post.num_comments,
+                            created_utc=post.created_utc,
+                        )
+                    )
+
+            if not posts:
+                self.topic_repo.mark_failed(analysis_id, "No posts collected")
+                return False
+
+            logger.info("Collected %d unique posts, running extraction agent", len(posts))
+
+            # 3. Rodar agente de extração
+            agent = create_topic_extraction_agent()
+            result = agent.invoke({
+                "audience_name": audience.name,
+                "audience_description": audience.description,
+                "community_names": community_names,
+                "posts": posts,
+                "total_posts": len(posts),
+                "extracted_topics": [],
+            })
+
+            extracted = result.get("extracted_topics", [])
+
+            if not extracted:
+                self.topic_repo.mark_failed(analysis_id, "No topics extracted")
+                return False
+
+            # 4. Salvar tópicos no banco
+            self.topic_repo.save_topics(analysis_id, extracted)
+
+            # 5. Marcar como pronto
+            self.topic_repo.mark_ready(analysis_id, total_topics=len(extracted))
+
+            # 6. Limpar análises antigas
+            self.topic_repo.delete_old_analyses(audience_id, keep_latest=2)
+
+            logger.info(
+                "Topic extraction complete for audience '%s': %d topics",
+                audience.name,
+                len(extracted),
+            )
+            return True
+
+        except Exception as e:
+            logger.exception("Topic extraction failed for audience %s", audience_id)
+            try:
+                self.topic_repo.mark_failed(analysis_id, str(e))
+            except Exception:
+                pass
+            return False

--- a/app/modules/audience_topics/application/use_cases/trigger_topic_analysis_use_case.py
+++ b/app/modules/audience_topics/application/use_cases/trigger_topic_analysis_use_case.py
@@ -1,0 +1,87 @@
+"""Triggers topic analysis in background when audience communities change."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerTopicAnalysisUseCase:
+    """
+    Verifica se a análise de tópicos precisa ser reprocessada
+    e dispara em background thread se necessário.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+
+    def execute(self, audience_id: UUID) -> None:
+        """
+        Verifica e dispara análise se necessário.
+        Não bloqueia — retorna imediatamente.
+        """
+        communities = self.audience_repo.get_communities(audience_id)
+        community_names = [c.subreddit_name for c in communities]
+
+        if not community_names:
+            logger.info("Skipping topic analysis — no communities in audience %s", audience_id)
+            return
+
+        # Gerar fingerprint da composição atual
+        fingerprint = AudienceTopicRepository.generate_fingerprint(community_names)
+
+        # Verificar se já existe análise com mesmo fingerprint (ready ou processing)
+        existing = self.topic_repo.find_by_fingerprint(audience_id, fingerprint)
+        if existing:
+            logger.info(
+                "Skipping topic analysis — existing analysis (status=%s) for audience %s",
+                existing.status,
+                audience_id,
+            )
+            return
+
+        # Criar registro de análise com status "processing"
+        analysis = self.topic_repo.create_analysis(audience_id, fingerprint)
+        logger.info(
+            "Triggering topic analysis for audience %s (analysis %s)",
+            audience_id,
+            analysis.id,
+        )
+
+        # Disparar em background
+        self._run_in_background(audience_id, analysis.id)
+
+    def _run_in_background(self, audience_id: UUID, analysis_id: UUID) -> None:
+        """Dispara extração de tópicos em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.audience_topics.application.use_cases.extract_topics_use_case.extract_topics_use_case import (
+                    ExtractTopicsUseCase,
+                )
+
+                use_case = ExtractTopicsUseCase(db)
+                use_case.execute(audience_id, analysis_id)
+            except Exception:
+                logger.exception(
+                    "Background topic extraction failed for audience %s", audience_id
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/audience_topics/domain/entities/audience_topic.py
+++ b/app/modules/audience_topics/domain/entities/audience_topic.py
@@ -1,0 +1,83 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class AudienceTopicAnalysis(Base):
+    """
+    Registro de uma análise de tópicos de uma audiência.
+    Cada vez que as comunidades mudam, uma nova análise é criada.
+    """
+
+    __tablename__ = "audience_topic_analyses"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(
+        String(20), nullable=False, default="processing", index=True
+    )  # processing, ready, failed
+    communities_fingerprint = Column(String(64), nullable=False, index=True)
+    total_topics = Column(Integer, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    topics = relationship(
+        "AudienceTopic",
+        back_populates="analysis",
+        cascade="all, delete-orphan",
+    )
+
+
+class AudienceTopic(Base):
+    """
+    Tópico extraído de uma análise de audiência.
+    """
+
+    __tablename__ = "audience_topics"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audience_topic_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name = Column(String(200), nullable=False)
+    description = Column(Text, nullable=True)
+    growth_percentage = Column(Float, nullable=True)
+    mention_frequency = Column(Float, nullable=True)
+    mention_period = Column(String(10), nullable=True)  # day, week, month
+    post_count = Column(Integer, nullable=True)
+    communities = Column(JSON, nullable=True)  # [{"name": "sub", "post_count": 5}]
+    rank = Column(Integer, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    analysis = relationship("AudienceTopicAnalysis", back_populates="topics")

--- a/app/modules/audience_topics/infra/repositories/audience_topic_repository.py
+++ b/app/modules/audience_topics/infra/repositories/audience_topic_repository.py
@@ -1,0 +1,191 @@
+import hashlib
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_topics.domain.entities.audience_topic import (
+    AudienceTopic,
+    AudienceTopicAnalysis,
+)
+
+
+class AudienceTopicRepository:
+    """Repositório para operações com análises de tópicos de audiências."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def generate_fingerprint(community_names: list[str]) -> str:
+        """Gera fingerprint SHA256 das comunidades ordenadas."""
+        sorted_names = sorted(n.lower() for n in community_names)
+        content = ":".join(sorted_names)
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def find_latest_ready(self, audience_id: UUID) -> AudienceTopicAnalysis | None:
+        """Busca a análise mais recente com status 'ready'."""
+        return (
+            self.db.query(AudienceTopicAnalysis)
+            .filter(
+                AudienceTopicAnalysis.audience_id == audience_id,
+                AudienceTopicAnalysis.status == "ready",
+            )
+            .order_by(AudienceTopicAnalysis.created_at.desc())
+            .first()
+        )
+
+    def find_latest_by_audience(self, audience_id: UUID) -> AudienceTopicAnalysis | None:
+        """Busca a análise mais recente (qualquer status)."""
+        return (
+            self.db.query(AudienceTopicAnalysis)
+            .filter(AudienceTopicAnalysis.audience_id == audience_id)
+            .order_by(AudienceTopicAnalysis.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, audience_id: UUID, fingerprint: str
+    ) -> AudienceTopicAnalysis | None:
+        """Busca análise por fingerprint (mesma composição de comunidades)."""
+        return (
+            self.db.query(AudienceTopicAnalysis)
+            .filter(
+                AudienceTopicAnalysis.audience_id == audience_id,
+                AudienceTopicAnalysis.communities_fingerprint == fingerprint,
+                AudienceTopicAnalysis.status.in_(["ready", "processing"]),
+            )
+            .order_by(AudienceTopicAnalysis.created_at.desc())
+            .first()
+        )
+
+    def create_analysis(
+        self, audience_id: UUID, fingerprint: str
+    ) -> AudienceTopicAnalysis:
+        """Cria um novo registro de análise com status 'processing'."""
+        analysis = AudienceTopicAnalysis(
+            audience_id=audience_id,
+            communities_fingerprint=fingerprint,
+            status="processing",
+        )
+        self.db.add(analysis)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_ready(
+        self, analysis_id: UUID, total_topics: int
+    ) -> AudienceTopicAnalysis | None:
+        """Marca análise como pronta."""
+        analysis = (
+            self.db.query(AudienceTopicAnalysis)
+            .filter(AudienceTopicAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "ready"
+        analysis.total_topics = total_topics
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_failed(
+        self, analysis_id: UUID, error_message: str
+    ) -> AudienceTopicAnalysis | None:
+        """Marca análise como falha."""
+        analysis = (
+            self.db.query(AudienceTopicAnalysis)
+            .filter(AudienceTopicAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "failed"
+        analysis.error_message = error_message
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def save_topics(
+        self, analysis_id: UUID, topics: list[dict]
+    ) -> list[AudienceTopic]:
+        """Salva lista de tópicos extraídos."""
+        entities = []
+        for topic_data in topics:
+            topic = AudienceTopic(
+                analysis_id=analysis_id,
+                name=topic_data["name"],
+                description=topic_data.get("description"),
+                growth_percentage=topic_data.get("growth_percentage"),
+                mention_frequency=topic_data.get("mention_frequency"),
+                mention_period=topic_data.get("mention_period"),
+                post_count=topic_data.get("post_count"),
+                communities=topic_data.get("communities"),
+                rank=topic_data.get("rank"),
+            )
+            self.db.add(topic)
+            entities.append(topic)
+
+        self.db.commit()
+        return entities
+
+    def get_topics(
+        self,
+        analysis_id: UUID,
+        sort_by: str = "rank",
+        limit: int = 200,
+        offset: int = 0,
+    ) -> list[AudienceTopic]:
+        """Lista tópicos de uma análise com ordenação."""
+        query = self.db.query(AudienceTopic).filter(
+            AudienceTopic.analysis_id == analysis_id
+        )
+
+        if sort_by == "growth":
+            query = query.order_by(AudienceTopic.growth_percentage.desc().nullslast())
+        elif sort_by == "frequency":
+            query = query.order_by(AudienceTopic.mention_frequency.desc().nullslast())
+        elif sort_by == "name":
+            query = query.order_by(AudienceTopic.name.asc())
+        else:
+            query = query.order_by(AudienceTopic.rank.asc().nullslast())
+
+        return query.offset(offset).limit(limit).all()
+
+    def get_topic_by_id(self, topic_id: UUID) -> AudienceTopic | None:
+        """Busca um tópico por ID."""
+        return (
+            self.db.query(AudienceTopic)
+            .filter(AudienceTopic.id == topic_id)
+            .first()
+        )
+
+    def delete_old_analyses(self, audience_id: UUID, keep_latest: int = 2) -> int:
+        """Remove análises antigas, mantendo as N mais recentes."""
+        latest_ids = (
+            self.db.query(AudienceTopicAnalysis.id)
+            .filter(AudienceTopicAnalysis.audience_id == audience_id)
+            .order_by(AudienceTopicAnalysis.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(AudienceTopicAnalysis)
+            .filter(
+                AudienceTopicAnalysis.audience_id == audience_id,
+                AudienceTopicAnalysis.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -1,11 +1,17 @@
+import logging
 from dataclasses import dataclass, field
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.modules.audience_topics.application.use_cases.trigger_topic_analysis_use_case import (
+    TriggerTopicAnalysisUseCase,
+)
 from app.modules.audiences.infra.repositories.audience_repository import (
     AudienceRepository,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -43,6 +49,7 @@ class CreateAudienceUseCase:
 
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
+        self.trigger_topics = TriggerTopicAnalysisUseCase(db)
 
     def execute(self, input_data: CreateAudienceInput) -> AudienceDTO:
         audience = self.repository.create(
@@ -55,6 +62,10 @@ class CreateAudienceUseCase:
             self.repository.add_community(audience.id, subreddit_name)
 
         communities_count = len(input_data.subreddit_names)
+
+        # Dispara análise de tópicos em background se há comunidades
+        if input_data.subreddit_names:
+            self.trigger_topics.execute(audience.id)
 
         return AudienceDTO(
             id=audience.id,
@@ -70,6 +81,7 @@ class UpdateAudienceUseCase:
 
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
+        self.trigger_topics = TriggerTopicAnalysisUseCase(db)
 
     def execute(
         self, audience_id: UUID, input_data: UpdateAudienceInput
@@ -87,6 +99,9 @@ class UpdateAudienceUseCase:
                 audience_id, input_data.subreddit_names
             )
             communities_count = len(communities)
+
+            # Dispara análise de tópicos quando comunidades mudam
+            self.trigger_topics.execute(audience_id)
         else:
             communities_count = len(audience.communities)
 
@@ -114,9 +129,12 @@ class AddCommunityToAudienceUseCase:
 
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
+        self.trigger_topics = TriggerTopicAnalysisUseCase(db)
 
     def execute(self, audience_id: UUID, subreddit_name: str) -> bool:
         result = self.repository.add_community(audience_id, subreddit_name)
+        if result is not None:
+            self.trigger_topics.execute(audience_id)
         return result is not None
 
 
@@ -125,6 +143,10 @@ class RemoveCommunityFromAudienceUseCase:
 
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
+        self.trigger_topics = TriggerTopicAnalysisUseCase(db)
 
     def execute(self, audience_id: UUID, subreddit_name: str) -> bool:
-        return self.repository.remove_community(audience_id, subreddit_name)
+        removed = self.repository.remove_community(audience_id, subreddit_name)
+        if removed:
+            self.trigger_topics.execute(audience_id)
+        return removed

--- a/app/modules/topics/infra/providers/reddit_provider/generic_reddit_provider.py
+++ b/app/modules/topics/infra/providers/reddit_provider/generic_reddit_provider.py
@@ -1,6 +1,49 @@
+import logging
+import time
+from dataclasses import dataclass, field
+
 import requests
 
 from app.modules.topics.domain.errors.fetch_data_error import FetchDataError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RedditPost:
+    """Dados de um post do Reddit."""
+
+    id: str
+    subreddit: str
+    title: str
+    selftext: str
+    score: int
+    num_comments: int
+    created_utc: float
+    link_flair_text: str | None = None
+    upvote_ratio: float | None = None
+    permalink: str | None = None
+
+
+@dataclass
+class RedditComment:
+    """Dados de um comentário do Reddit."""
+
+    id: str
+    body: str
+    score: int
+    created_utc: float
+    author: str | None = None
+    parent_id: str | None = None
+
+
+@dataclass
+class SubredditPostsResult:
+    """Resultado da coleta de posts de um subreddit."""
+
+    subreddit: str
+    posts: list[RedditPost] = field(default_factory=list)
+    sort: str = "hot"
 
 
 class GenericRedditProvider:
@@ -15,12 +58,21 @@ class GenericRedditProvider:
     headers = {
         "User-Agent": "RedditOracle/1.0 (personal research tool)"
     }
+    _rate_limit_delay = 6.0  # ~10 req/min for public API
 
     def __init__(self):
         """
         Inicializa o provider
         """
         self.timeout = 10
+        self._last_request_time = 0.0
+
+    def _respect_rate_limit(self):
+        """Aguarda o delay mínimo entre requests para não exceder 10 req/min."""
+        elapsed = time.time() - self._last_request_time
+        if elapsed < self._rate_limit_delay:
+            time.sleep(self._rate_limit_delay - elapsed)
+        self._last_request_time = time.time()
 
     def list_popular_topics(self):
         """
@@ -103,3 +155,164 @@ class GenericRedditProvider:
                 f"Failed to fetch community: {community_response.status_code}"
             )
         return community_response.json()
+
+    def get_subreddit_posts(
+        self,
+        subreddit_name: str,
+        sort: str = "hot",
+        limit: int = 25,
+        time_filter: str = "week",
+    ) -> SubredditPostsResult:
+        """
+        Busca posts de um subreddit.
+
+        Args:
+            subreddit_name: Nome do subreddit (sem r/)
+            sort: Tipo de ordenação (hot, top, new, rising)
+            limit: Número de posts (max 100 por request)
+            time_filter: Filtro de tempo para sort=top (hour, day, week, month, year, all)
+
+        Returns:
+            SubredditPostsResult com lista de posts
+        """
+        self._respect_rate_limit()
+
+        url = f"https://www.reddit.com/r/{subreddit_name}/{sort}.json"
+        params = {"limit": min(limit, 100)}
+        if sort == "top":
+            params["t"] = time_filter
+
+        try:
+            response = requests.get(
+                url, params=params, headers=self.headers, timeout=self.timeout
+            )
+            if response.status_code != 200:
+                logger.warning(
+                    "Failed to fetch posts from r/%s: %d",
+                    subreddit_name,
+                    response.status_code,
+                )
+                return SubredditPostsResult(subreddit=subreddit_name, sort=sort)
+
+            data = response.json()
+            posts = []
+
+            for child in data.get("data", {}).get("children", []):
+                post_data = child.get("data", {})
+                posts.append(
+                    RedditPost(
+                        id=post_data.get("id", ""),
+                        subreddit=post_data.get("subreddit", subreddit_name),
+                        title=post_data.get("title", ""),
+                        selftext=post_data.get("selftext", ""),
+                        score=post_data.get("score", 0),
+                        num_comments=post_data.get("num_comments", 0),
+                        created_utc=post_data.get("created_utc", 0),
+                        link_flair_text=post_data.get("link_flair_text"),
+                        upvote_ratio=post_data.get("upvote_ratio"),
+                        permalink=post_data.get("permalink"),
+                    )
+                )
+
+            logger.info("Fetched %d posts from r/%s (%s)", len(posts), subreddit_name, sort)
+            return SubredditPostsResult(subreddit=subreddit_name, posts=posts, sort=sort)
+
+        except requests.RequestException as e:
+            logger.warning("Error fetching posts from r/%s: %s", subreddit_name, e)
+            return SubredditPostsResult(subreddit=subreddit_name, sort=sort)
+
+    def get_post_comments(
+        self,
+        subreddit_name: str,
+        post_id: str,
+        limit: int = 50,
+    ) -> list[RedditComment]:
+        """
+        Busca comentários de um post.
+
+        Args:
+            subreddit_name: Nome do subreddit
+            post_id: ID do post
+            limit: Número máximo de comentários
+
+        Returns:
+            Lista de RedditComment
+        """
+        self._respect_rate_limit()
+
+        url = f"https://www.reddit.com/r/{subreddit_name}/comments/{post_id}.json"
+        params = {"limit": min(limit, 200)}
+
+        try:
+            response = requests.get(
+                url, params=params, headers=self.headers, timeout=self.timeout
+            )
+            if response.status_code != 200:
+                logger.warning(
+                    "Failed to fetch comments for post %s: %d",
+                    post_id,
+                    response.status_code,
+                )
+                return []
+
+            data = response.json()
+            comments = []
+
+            # Response is an array: [post_listing, comments_listing]
+            if len(data) < 2:
+                return []
+
+            for child in data[1].get("data", {}).get("children", []):
+                comment_data = child.get("data", {})
+                if child.get("kind") != "t1":
+                    continue
+                comments.append(
+                    RedditComment(
+                        id=comment_data.get("id", ""),
+                        body=comment_data.get("body", ""),
+                        score=comment_data.get("score", 0),
+                        created_utc=comment_data.get("created_utc", 0),
+                        author=comment_data.get("author"),
+                        parent_id=comment_data.get("parent_id"),
+                    )
+                )
+
+            logger.info("Fetched %d comments for post %s", len(comments), post_id)
+            return comments
+
+        except requests.RequestException as e:
+            logger.warning("Error fetching comments for post %s: %s", post_id, e)
+            return []
+
+    def collect_posts_for_communities(
+        self,
+        community_names: list[str],
+        posts_per_sort: int = 25,
+    ) -> list[SubredditPostsResult]:
+        """
+        Coleta posts de múltiplas comunidades (hot + top do mês).
+
+        Args:
+            community_names: Lista de nomes de subreddits
+            posts_per_sort: Número de posts por tipo de sort
+
+        Returns:
+            Lista de SubredditPostsResult (2 por comunidade: hot + top)
+        """
+        results = []
+        for name in community_names:
+            hot = self.get_subreddit_posts(name, sort="hot", limit=posts_per_sort)
+            results.append(hot)
+
+            top = self.get_subreddit_posts(
+                name, sort="top", limit=posts_per_sort, time_filter="month"
+            )
+            results.append(top)
+
+        total_posts = sum(len(r.posts) for r in results)
+        logger.info(
+            "Collected %d total posts from %d communities",
+            total_posts,
+            len(community_names),
+        )
+        return results

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -4,6 +4,7 @@ from app.routes.auth import router as auth_router
 from app.routes.topics import router as topics_router
 from app.routes.audiences import router as audiences_router
 from app.routes.audience_templates import router as audience_templates_router
+from app.routes.audience_topics import router as audience_topics_router
 from app.routes.similar_communities import router as similar_communities_router
 from app.routes.communities import router as communities_router
 
@@ -12,6 +13,7 @@ __all__ = [
     "topics_router",
     "audiences_router",
     "audience_templates_router",
+    "audience_topics_router",
     "similar_communities_router",
     "communities_router",
 ]

--- a/app/routes/audience_topics.py
+++ b/app/routes/audience_topics.py
@@ -1,0 +1,199 @@
+"""Routes for audience topic analysis."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.modules.audience_topics.application.use_cases.trigger_topic_analysis_use_case import (
+    TriggerTopicAnalysisUseCase,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+
+router = APIRouter(prefix="/audiences", tags=["Audience Topics"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuário é dono da audiência ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+@router.get("/{audience_id}/topics")
+def list_audience_topics(
+    audience_id: UUID,
+    sort_by: str = "rank",
+    limit: int = 200,
+    offset: int = 0,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Lista tópicos extraídos de uma audiência.
+
+    Retorna a análise mais recente com status 'ready'.
+    Se não existe ou está em processamento, retorna status correspondente.
+
+    sort_by: rank (padrão), growth, frequency, name
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    topic_repo = AudienceTopicRepository(db)
+
+    # Buscar análise mais recente (qualquer status)
+    latest = topic_repo.find_latest_by_audience(audience_id)
+
+    if not latest:
+        return {
+            "status": "no_analysis",
+            "message": "Nenhuma análise de tópicos encontrada. Adicione comunidades à audiência.",
+            "topics": [],
+            "total_topics": 0,
+        }
+
+    if latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Análise de tópicos em andamento. Tente novamente em alguns minutos.",
+            "topics": [],
+            "total_topics": 0,
+        }
+
+    if latest.status == "failed":
+        return {
+            "status": "failed",
+            "message": f"Análise falhou: {latest.error_message or 'erro desconhecido'}",
+            "topics": [],
+            "total_topics": 0,
+        }
+
+    # Status ready — buscar tópicos
+    topics = topic_repo.get_topics(
+        analysis_id=latest.id,
+        sort_by=sort_by,
+        limit=limit,
+        offset=offset,
+    )
+
+    return {
+        "status": "ready",
+        "analysis_id": str(latest.id),
+        "total_topics": latest.total_topics,
+        "completed_at": latest.completed_at.isoformat() if latest.completed_at else None,
+        "topics": [
+            {
+                "id": str(t.id),
+                "name": t.name,
+                "description": t.description,
+                "growth_percentage": t.growth_percentage,
+                "mention_frequency": t.mention_frequency,
+                "mention_period": t.mention_period,
+                "post_count": t.post_count,
+                "communities": t.communities,
+                "rank": t.rank,
+            }
+            for t in topics
+        ],
+    }
+
+
+@router.get("/{audience_id}/topics/{topic_id}")
+def get_audience_topic_detail(
+    audience_id: UUID,
+    topic_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Retorna detalhe completo de um tópico específico.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    topic_repo = AudienceTopicRepository(db)
+    topic = topic_repo.get_topic_by_id(topic_id)
+
+    if not topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+
+    return {
+        "id": str(topic.id),
+        "name": topic.name,
+        "description": topic.description,
+        "growth_percentage": topic.growth_percentage,
+        "mention_frequency": topic.mention_frequency,
+        "mention_period": topic.mention_period,
+        "post_count": topic.post_count,
+        "communities": topic.communities,
+        "rank": topic.rank,
+        "created_at": topic.created_at.isoformat() if topic.created_at else None,
+    }
+
+
+@router.post("/{audience_id}/topics/refresh", status_code=202)
+def refresh_audience_topics(
+    audience_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Força reprocessamento da análise de tópicos.
+    Útil quando o usuário quer dados atualizados.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    communities = audience_repo.get_communities(audience_id)
+    if not communities:
+        raise HTTPException(
+            status_code=400,
+            detail="Audiência não possui comunidades para análise",
+        )
+
+    topic_repo = AudienceTopicRepository(db)
+
+    # Verificar se já há uma análise em processamento
+    latest = topic_repo.find_latest_by_audience(audience_id)
+    if latest and latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Já existe uma análise em andamento.",
+        }
+
+    # Criar nova análise (ignora fingerprint — força reprocessamento)
+    community_names = [c.subreddit_name for c in communities]
+    fingerprint = AudienceTopicRepository.generate_fingerprint(community_names)
+    analysis = topic_repo.create_analysis(audience_id, fingerprint)
+
+    trigger = TriggerTopicAnalysisUseCase(db)
+    trigger._run_in_background(audience_id, analysis.id)
+
+    return {
+        "status": "processing",
+        "message": "Análise de tópicos iniciada. Consulte novamente em alguns minutos.",
+        "analysis_id": str(analysis.id),
+    }

--- a/docs/issue-29-audience-topic-analysis.md
+++ b/docs/issue-29-audience-topic-analysis.md
@@ -1,0 +1,199 @@
+# Issue #29 — Análise de Tópicos da Audiência
+
+## Motivação
+
+O sistema permite criar audiências com comunidades vinculadas, mas **não oferecia análise de conteúdo** sobre o que está sendo discutido nessas comunidades. O usuário não tinha como identificar quais temas estão em alta, quais estão crescendo, ou quais são discutidos em múltiplas comunidades da audiência.
+
+### Cenário do usuário
+
+O usuário criou uma audiência "Pet Lovers" com comunidades como r/DogAdvice, r/CatAdvice e r/birding. Ele quer saber: "quais temas estão em alta nessas comunidades?" — por exemplo, "questões de saúde" aparecendo em r/DogAdvice e r/CatAdvice com +400% de crescimento.
+
+---
+
+## Solução Adotada
+
+### Abordagem: Job em background disparado na escrita
+
+Ao invés de analisar sob demanda (quando o usuário abre a aba Topics), a análise é disparada automaticamente quando as comunidades da audiência mudam. Assim, quando o usuário abre a aba, os dados já estão prontos.
+
+```
+POST/PUT/ADD/REMOVE comunidades
+    → TriggerTopicAnalysisUseCase
+        → Calcula fingerprint (SHA256 das comunidades ordenadas)
+        → Já existe análise com mesmo fingerprint? → Skip
+        → Cria análise (status: "processing")
+        → threading.Thread(daemon=True)
+            → ExtractTopicsUseCase
+                → Coleta posts (Reddit .json API)
+                → LangGraph: extract_topics → estimate_growth
+                → Salva tópicos no banco → status: "ready"
+
+GET /audiences/{id}/topics
+    → Busca análise mais recente
+    → "ready"      → retorna tópicos
+    → "processing" → retorna {status: "processing"}
+    → "failed"     → retorna erro
+```
+
+### Decisões arquiteturais
+
+1. **Trigger na escrita vs. na leitura:** Escolhido trigger na escrita para UX instantânea. O usuário não precisa esperar.
+
+2. **Fingerprint para invalidação:** Hash SHA256 das comunidades ordenadas evita reprocessamento quando a composição não mudou (ex: update apenas do nome).
+
+3. **LangGraph com 2 nós:** Nó 1 extrai tópicos dos posts, Nó 2 estima crescimento. Separados para manter cada prompt focado e dentro do limite de contexto.
+
+4. **Reddit public JSON API:** Mantido o padrão existente sem autenticação OAuth (~10 req/min). Rate limit controlado com delay de 6s entre requests. Suficiente para background.
+
+5. **Sem armazenamento de posts:** Posts são coletados, processados pelo agente, e descartados. Apenas os tópicos extraídos são persistidos. Isso evita crescimento excessivo do banco.
+
+---
+
+## Arquivos Criados
+
+### `app/modules/audience_topics/domain/entities/audience_topic.py`
+- Entidade `AudienceTopicAnalysis` — tabela `audience_topic_analyses` (id, audience_id, status, communities_fingerprint, total_topics, error_message, timestamps)
+- Entidade `AudienceTopic` — tabela `audience_topics` (id, analysis_id, name, description, growth_percentage, mention_frequency, mention_period, post_count, communities JSON, rank)
+
+### `alembic/versions/a8b9c0d1e2f3_add_audience_topics.py`
+- Migration criando as duas tabelas com FKs CASCADE para `audiences` e `audience_topic_analyses`
+
+### `app/modules/audience_topics/infra/repositories/audience_topic_repository.py`
+- `generate_fingerprint()` — SHA256 das comunidades ordenadas
+- `find_latest_ready()`, `find_by_fingerprint()` — queries para cache/invalidação
+- `create_analysis()`, `mark_ready()`, `mark_failed()` — ciclo de vida da análise
+- `save_topics()` — salva tópicos em batch
+- `get_topics()` — listagem com ordenação (rank, growth, frequency, name)
+- `delete_old_analyses()` — limpeza, mantém as 2 mais recentes
+
+### `app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/`
+- `state.py` — `TopicExtractionState` com `PostData` e `ExtractedTopic`
+- `prompts/topic_extraction_prompts.py` — `extract_topics_prompt()` e `estimate_growth_prompt()`
+- `topic_extraction_agent.py` — Agente LangGraph com 2 nós: `extract_topics` → `estimate_growth`
+
+### `app/modules/audience_topics/application/use_cases/extract_topics_use_case/extract_topics_use_case.py`
+- Orquestrador: coleta posts via Reddit provider → deduplica → roda agente → salva tópicos → marca como ready
+
+### `app/modules/audience_topics/application/use_cases/trigger_topic_analysis_use_case.py`
+- Verifica fingerprint, cria análise, dispara `ExtractTopicsUseCase` em `threading.Thread(daemon=True)` com `SessionLocal()` própria
+
+### `app/routes/audience_topics.py`
+- `GET /audiences/{id}/topics` — lista tópicos com status e ordenação
+- `GET /audiences/{id}/topics/{topic_id}` — detalhe de um tópico
+- `POST /audiences/{id}/topics/refresh` — força reprocessamento
+
+---
+
+## Arquivos Modificados
+
+### `app/modules/topics/infra/providers/reddit_provider/generic_reddit_provider.py`
+- Novos dataclasses: `RedditPost`, `RedditComment`, `SubredditPostsResult`
+- `_respect_rate_limit()` — delay de 6s entre requests
+- `get_subreddit_posts(subreddit, sort, limit, time_filter)` — busca posts via `/r/{sub}/{sort}.json`
+- `get_post_comments(subreddit, post_id, limit)` — busca comentários via `/r/{sub}/comments/{id}.json`
+- `collect_posts_for_communities(names, posts_per_sort)` — coleta hot + top de múltiplas comunidades
+
+### `app/modules/audiences/application/use_cases/manage_audience_use_case.py`
+- Hooks em 4 use cases: `CreateAudienceUseCase`, `UpdateAudienceUseCase`, `AddCommunityToAudienceUseCase`, `RemoveCommunityFromAudienceUseCase`
+- Cada um chama `TriggerTopicAnalysisUseCase.execute()` após mutação de comunidades
+
+### `app/main.py`
+- Registro do `audience_topics_router`
+
+### `app/routes/__init__.py`
+- Export do `audience_topics_router`
+
+### `alembic/env.py`
+- Import da entidade `audience_topic` para autogenerate
+
+---
+
+## Como Testar
+
+### Teste 1 — Criar audiência (dispara análise em background)
+
+```http
+POST /audiences
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+    "name": "Pet Lovers",
+    "description": "Comunidades de pets",
+    "subreddit_names": ["DogAdvice", "CatAdvice", "birding"]
+}
+```
+
+**Esperado:** Audiência criada. Nos logs, `Triggering topic analysis for audience ...`.
+
+### Teste 2 — Consultar tópicos (em processamento)
+
+```http
+GET /audiences/{audience_id}/topics
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "processing", topics: [], total_topics: 0}`
+
+### Teste 3 — Consultar tópicos (após ~2 minutos)
+
+```http
+GET /audiences/{audience_id}/topics
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "ready", total_topics: N, topics: [{name, description, growth_percentage, ...}]}`
+
+### Teste 4 — Ordenar por crescimento
+
+```http
+GET /audiences/{audience_id}/topics?sort_by=growth
+Authorization: Bearer <token>
+```
+
+**Esperado:** Tópicos ordenados por `growth_percentage` decrescente.
+
+### Teste 5 — Forçar reprocessamento
+
+```http
+POST /audiences/{audience_id}/topics/refresh
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "processing", message: "Análise de tópicos iniciada..."}`. Status 202.
+
+### Teste 6 — Fingerprint evita reprocessamento
+
+```http
+PUT /audiences/{audience_id}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+    "name": "Novo nome"
+}
+```
+
+**Esperado:** Nome atualizado. Análise de tópicos NÃO é disparada (comunidades não mudaram).
+
+---
+
+## Relação com Outras Issues
+
+| Issue | Relação |
+|-------|---------|
+| #25 — Audience Community Sync | Sync dispara análise de tópicos quando `subreddit_names` muda |
+| #23 — Audience Expansion Agent | Mesmo padrão de LangGraph agent e background thread |
+| #17 — Audience User Ownership | Reutiliza `_check_ownership` nas rotas de tópicos |
+
+---
+
+## Melhorias Futuras (Fora do Escopo)
+
+- **Browse all:** Listar todos os posts relacionados a um tópico específico
+- **Patterns:** Detectar padrões recorrentes nos posts de um tópico (ex: perguntas frequentes)
+- **Sentiment:** Análise de sentimento das discussões por tópico
+- **Ask:** Q&A com IA sobre o contexto de um tópico específico
+- **OAuth Reddit:** Migrar para API autenticada (100 req/min) para coleta mais rápida
+- **Histórico de crescimento:** Snapshots periódicos para calcular tendência real ao longo do tempo
+- **Coleta de comentários:** Incluir comentários na análise para tópicos mais ricos


### PR DESCRIPTION
## Summary
- Extrai tópicos trending das comunidades de uma audiência usando agente LangGraph
- Análise roda automaticamente em background quando comunidades mudam (create/update/add/remove)
- Dados prontos quando o usuário abre a aba Topics — sem espera

## O que foi implementado

### Reddit Posts Provider
- `get_subreddit_posts()` — busca posts via `.json` público (hot, top)
- `get_post_comments()` — busca comentários de um post
- `collect_posts_for_communities()` — coleta hot + top de múltiplas comunidades
- Rate limit: 6s entre requests (~10 req/min)

### Entidades + Migration
- `audience_topic_analyses` — registro da análise (status, fingerprint, timestamps)
- `audience_topics` — tópicos extraídos (nome, resumo IA, crescimento, frequência, comunidades)

### Agente LangGraph (2 nós)
- `extract_topics` — LLM analisa posts e identifica até 200 tópicos recorrentes
- `estimate_growth` — LLM estima % de crescimento de cada tópico

### Job em Background
- `TriggerTopicAnalysisUseCase` — verifica fingerprint das comunidades, evita reprocessamento
- Hooks em: `CreateAudienceUseCase`, `UpdateAudienceUseCase`, `AddCommunityToAudienceUseCase`, `RemoveCommunityFromAudienceUseCase`

### Endpoints
- `GET /audiences/{id}/topics` — lista tópicos com ordenação (rank, growth, frequency)
- `GET /audiences/{id}/topics/{topic_id}` — detalhe de um tópico
- `POST /audiences/{id}/topics/refresh` — força reprocessamento

## Test plan
- [ ] Criar audiência com comunidades e verificar que job é disparado (logs)
- [ ] Consultar `GET /audiences/{id}/topics` — deve retornar `status: processing` inicialmente
- [ ] Após ~2min, consultar novamente — deve retornar `status: ready` com tópicos
- [ ] Atualizar comunidades e verificar que nova análise é disparada
- [ ] Verificar que fingerprint evita reprocessamento desnecessário
- [ ] Testar `POST .../topics/refresh` para forçar nova análise

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)