### PR TITLE
feat(audiences): add automatic search keyword generation

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -46,6 +46,7 @@ from app.modules.similar_communities.domain.entities import community_embedding 
 from app.modules.similar_communities.domain.entities import user_feedback  # noqa: E402
 from app.modules.audience_templates.domain.entities import audience_template  # noqa: E402
 from app.modules.audience_topics.domain.entities import audience_topic  # noqa: E402
+from app.modules.audience_keywords.domain.entities import audience_keyword  # noqa: E402
 
 target_metadata = [LegacyBase.metadata, Base.metadata]
 

--- a/alembic/versions/b9c0d1e2f3a4_add_audience_keywords.py
+++ b/alembic/versions/b9c0d1e2f3a4_add_audience_keywords.py
@@ -1,0 +1,61 @@
+"""add audience_keyword_analyses and audience_keywords tables
+
+Revision ID: b9c0d1e2f3a4
+Revises: a8b9c0d1e2f3
+Create Date: 2026-02-21
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "b9c0d1e2f3a4"
+down_revision: Union[str, None] = "a8b9c0d1e2f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audience_keyword_analyses",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "audience_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audiences.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("status", sa.String(20), nullable=False, default="processing", index=True),
+        sa.Column("communities_fingerprint", sa.String(64), nullable=False, index=True),
+        sa.Column("total_keywords", sa.Integer, nullable=True),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "audience_keywords",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "analysis_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audience_keyword_analyses.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("keyword", sa.String(200), nullable=False),
+        sa.Column("category", sa.String(50), nullable=True),
+        sa.Column("relevance_score", sa.Integer, nullable=True),
+        sa.Column("rank", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audience_keywords")
+    op.drop_table("audience_keyword_analyses")

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 from app.config import settings
 from app.routes import (
     auth_router,
+    audience_keywords_router,
     audience_templates_router,
     audience_topics_router,
     audiences_router,
@@ -66,6 +67,7 @@ app.include_router(topics_router)
 app.include_router(audiences_router)
 app.include_router(audience_templates_router)
 app.include_router(audience_topics_router)
+app.include_router(audience_keywords_router)
 app.include_router(similar_communities_router)
 app.include_router(communities_router)
 

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/keyword_extraction_agent.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/keyword_extraction_agent.py
@@ -1,0 +1,98 @@
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.audience_keywords.application.use_cases.extract_keywords_use_case.agent.prompts.keyword_extraction_prompts import (
+    extract_keywords_prompt,
+)
+from app.modules.audience_keywords.application.use_cases.extract_keywords_use_case.agent.state import (
+    ExtractedKeyword,
+    KeywordExtractionState,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_CATEGORIES = {"pain_point", "question", "recommendation", "trend", "general"}
+
+
+def _get_llm() -> ChatOpenAI:
+    return ChatOpenAI(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        temperature=0.3,
+    )
+
+
+# ── Node 1: Extract keywords from community context ─────────────────────────
+
+
+def extract_keywords(state: KeywordExtractionState) -> dict:
+    """LLM generates search keywords based on audience community context."""
+    llm = _get_llm()
+
+    prompt = extract_keywords_prompt(
+        audience_name=state["audience_name"],
+        audience_description=state.get("audience_description"),
+        community_names=state["community_names"],
+        community_descriptions=state.get("community_descriptions", []),
+        topics_summary=state.get("topics_summary"),
+    )
+
+    response = llm.invoke(prompt)
+
+    keywords: list[ExtractedKeyword] = []
+    rank = 1
+
+    for line in response.content.strip().split("\n"):
+        line = line.strip()
+        if not line or "|" not in line:
+            continue
+
+        parts = line.split("|")
+        if len(parts) < 3:
+            continue
+
+        keyword = parts[0].strip()
+        category = parts[1].strip().lower()
+        if category not in VALID_CATEGORIES:
+            category = "general"
+
+        try:
+            relevance_score = int(parts[2].strip())
+            relevance_score = max(1, min(10, relevance_score))
+        except ValueError:
+            relevance_score = 5
+
+        keywords.append(
+            ExtractedKeyword(
+                keyword=keyword,
+                category=category,
+                relevance_score=relevance_score,
+                rank=rank,
+            )
+        )
+        rank += 1
+
+    # Sort by relevance score (highest first) and re-rank
+    keywords.sort(key=lambda k: k["relevance_score"], reverse=True)
+    for i, kw in enumerate(keywords):
+        kw["rank"] = i + 1
+
+    logger.info("Extracted %d keywords for audience '%s'", len(keywords), state["audience_name"])
+    return {"extracted_keywords": keywords}
+
+
+# ── Graph assembly ───────────────────────────────────────────────────────────
+
+
+def create_keyword_extraction_agent():
+    """Create the LangGraph agent for keyword extraction."""
+    workflow = StateGraph(KeywordExtractionState)
+
+    workflow.add_node("extract_keywords", extract_keywords)
+
+    workflow.add_edge(START, "extract_keywords")
+    workflow.add_edge("extract_keywords", END)
+
+    return workflow.compile()

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/prompts/keyword_extraction_prompts.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/prompts/keyword_extraction_prompts.py
@@ -1,0 +1,65 @@
+def extract_keywords_prompt(
+    audience_name: str,
+    audience_description: str | None,
+    community_names: list[str],
+    community_descriptions: list[str],
+    topics_summary: str | None,
+) -> str:
+    communities_str = ", ".join(f"r/{name}" for name in community_names)
+    desc_line = f"\nAudience description: {audience_description}" if audience_description else ""
+
+    descriptions_block = ""
+    if community_descriptions:
+        desc_lines = []
+        for name, desc in zip(community_names, community_descriptions):
+            if desc:
+                desc_lines.append(f"- r/{name}: {desc}")
+        if desc_lines:
+            descriptions_block = "\n\nCommunity descriptions:\n" + "\n".join(desc_lines)
+
+    topics_block = ""
+    if topics_summary:
+        topics_block = f"\n\nTrending topics already identified in this audience:\n{topics_summary}"
+
+    return f"""You are an expert Reddit analyst specializing in audience research and keyword discovery.
+
+Audience: "{audience_name}"{desc_line}
+Communities: {communities_str}{descriptions_block}{topics_block}
+
+---
+
+TASK: Generate search keywords that would help a user explore and discover relevant content within this audience's communities.
+
+Generate 15-25 keywords/phrases that:
+1. Reflect real pain points, questions, and interests of the community members
+2. Are specific enough to return relevant results when searched in these communities
+3. Cover different aspects: problems, desires, recommendations, trends, and common questions
+4. Are in the natural language that community members would use
+
+For each keyword, classify its category:
+- pain_point: Problems, frustrations, or challenges people face
+- question: Common questions people ask
+- recommendation: Products, tools, or solutions people seek
+- trend: Emerging topics or growing discussions
+- general: General interest topics
+
+And assign a relevance score (1-10) based on how likely this keyword will surface valuable discussions.
+
+Respond in this exact format, one keyword per line:
+KEYWORD|CATEGORY|RELEVANCE_SCORE
+
+Examples:
+best tools for|recommendation|9
+struggling with|pain_point|8
+how do you|question|7
+anyone tried|recommendation|8
+what's the best|question|9
+frustrated with|pain_point|7
+new to|general|6
+trending in|trend|7
+
+IMPORTANT:
+- Keywords should be contextual to the audience, not generic
+- Include a mix of short phrases (2-3 words) and longer search queries (4-6 words)
+- Focus on terms that reveal user intent (buying, learning, solving, comparing)
+- Do NOT include any other text, headers, or numbering. Just the pipe-delimited lines."""

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/state.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/state.py
@@ -1,0 +1,19 @@
+from typing import TypedDict
+
+
+class ExtractedKeyword(TypedDict):
+    keyword: str
+    category: str | None  # pain_point, question, recommendation, trend, general
+    relevance_score: int  # 1-10
+    rank: int
+
+
+class KeywordExtractionState(TypedDict):
+    audience_name: str
+    audience_description: str | None
+    community_names: list[str]
+    community_descriptions: list[str]
+    topics_summary: str | None
+
+    # Populated by nodes
+    extracted_keywords: list[ExtractedKeyword]

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/extract_keywords_use_case.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/extract_keywords_use_case.py
@@ -1,0 +1,153 @@
+"""Use case that orchestrates keyword extraction for an audience."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_keywords.application.use_cases.extract_keywords_use_case.agent.keyword_extraction_agent import (
+    create_keyword_extraction_agent,
+)
+from app.modules.audience_keywords.infra.repositories.audience_keyword_repository import (
+    AudienceKeywordRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.topics.infra.providers.reddit_provider.generic_reddit_provider import (
+    GenericRedditProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExtractKeywordsUseCase:
+    """
+    Coleta contexto das comunidades de uma audiência e extrai keywords via LangGraph.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.keyword_repo = AudienceKeywordRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.reddit_provider = GenericRedditProvider()
+
+    def execute(self, audience_id: UUID, analysis_id: UUID) -> bool:
+        """
+        Executa a extração completa de keywords.
+
+        Args:
+            audience_id: ID da audiência
+            analysis_id: ID da análise já criada (status: processing)
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        try:
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                self.keyword_repo.mark_failed(analysis_id, "Audience not found")
+                return False
+
+            communities = self.audience_repo.get_communities(audience_id)
+            community_names = [c.subreddit_name for c in communities]
+
+            if not community_names:
+                self.keyword_repo.mark_failed(analysis_id, "No communities in audience")
+                return False
+
+            # 1. Coletar descrições das comunidades
+            logger.info(
+                "Collecting community descriptions for audience '%s' (%d communities)",
+                audience.name,
+                len(community_names),
+            )
+            community_descriptions = self._collect_community_descriptions(community_names)
+
+            # 2. Buscar tópicos já extraídos (se existirem)
+            topics_summary = self._get_topics_summary(audience_id)
+
+            # 3. Rodar agente de extração de keywords
+            logger.info("Running keyword extraction agent for audience '%s'", audience.name)
+            agent = create_keyword_extraction_agent()
+            result = agent.invoke({
+                "audience_name": audience.name,
+                "audience_description": audience.description,
+                "community_names": community_names,
+                "community_descriptions": community_descriptions,
+                "topics_summary": topics_summary,
+                "extracted_keywords": [],
+            })
+
+            extracted = result.get("extracted_keywords", [])
+
+            if not extracted:
+                self.keyword_repo.mark_failed(analysis_id, "No keywords extracted")
+                return False
+
+            # 4. Salvar keywords no banco
+            self.keyword_repo.save_keywords(analysis_id, extracted)
+
+            # 5. Marcar como pronto
+            self.keyword_repo.mark_ready(analysis_id, total_keywords=len(extracted))
+
+            # 6. Limpar análises antigas
+            self.keyword_repo.delete_old_analyses(audience_id, keep_latest=2)
+
+            logger.info(
+                "Keyword extraction complete for audience '%s': %d keywords",
+                audience.name,
+                len(extracted),
+            )
+            return True
+
+        except Exception as e:
+            logger.exception("Keyword extraction failed for audience %s", audience_id)
+            try:
+                self.keyword_repo.mark_failed(analysis_id, str(e))
+            except Exception:
+                pass
+            return False
+
+    def _collect_community_descriptions(self, community_names: list[str]) -> list[str]:
+        """Busca descrições das comunidades via Reddit API."""
+        descriptions = []
+        for name in community_names:
+            try:
+                response = self.reddit_provider.get_community_details(name)
+                data = response.get("data", response)
+                desc = data.get("public_description") or data.get("description") or ""
+                # Truncate long descriptions
+                if len(desc) > 300:
+                    desc = desc[:300] + "..."
+                descriptions.append(desc)
+            except Exception:
+                descriptions.append("")
+        return descriptions
+
+    def _get_topics_summary(self, audience_id: UUID) -> str | None:
+        """Busca resumo dos tópicos já extraídos para enriquecer a geração de keywords."""
+        latest_analysis = self.topic_repo.find_latest_ready(audience_id)
+        if not latest_analysis:
+            return None
+
+        topics = self.topic_repo.get_topics(
+            analysis_id=latest_analysis.id,
+            sort_by="rank",
+            limit=20,
+        )
+
+        if not topics:
+            return None
+
+        lines = []
+        for t in topics:
+            growth = f" (growth: {t.growth_percentage}%)" if t.growth_percentage else ""
+            lines.append(f"- {t.name}: {t.description}{growth}")
+
+        return "\n".join(lines)

--- a/app/modules/audience_keywords/application/use_cases/trigger_keyword_analysis_use_case.py
+++ b/app/modules/audience_keywords/application/use_cases/trigger_keyword_analysis_use_case.py
@@ -1,0 +1,87 @@
+"""Triggers keyword analysis in background when audience communities change."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_keywords.infra.repositories.audience_keyword_repository import (
+    AudienceKeywordRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerKeywordAnalysisUseCase:
+    """
+    Verifica se a análise de keywords precisa ser reprocessada
+    e dispara em background thread se necessário.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.keyword_repo = AudienceKeywordRepository(db)
+
+    def execute(self, audience_id: UUID) -> None:
+        """
+        Verifica e dispara análise se necessário.
+        Não bloqueia — retorna imediatamente.
+        """
+        communities = self.audience_repo.get_communities(audience_id)
+        community_names = [c.subreddit_name for c in communities]
+
+        if not community_names:
+            logger.info("Skipping keyword analysis — no communities in audience %s", audience_id)
+            return
+
+        # Gerar fingerprint da composição atual
+        fingerprint = AudienceKeywordRepository.generate_fingerprint(community_names)
+
+        # Verificar se já existe análise com mesmo fingerprint (ready ou processing)
+        existing = self.keyword_repo.find_by_fingerprint(audience_id, fingerprint)
+        if existing:
+            logger.info(
+                "Skipping keyword analysis — existing analysis (status=%s) for audience %s",
+                existing.status,
+                audience_id,
+            )
+            return
+
+        # Criar registro de análise com status "processing"
+        analysis = self.keyword_repo.create_analysis(audience_id, fingerprint)
+        logger.info(
+            "Triggering keyword analysis for audience %s (analysis %s)",
+            audience_id,
+            analysis.id,
+        )
+
+        # Disparar em background
+        self._run_in_background(audience_id, analysis.id)
+
+    def _run_in_background(self, audience_id: UUID, analysis_id: UUID) -> None:
+        """Dispara extração de keywords em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.audience_keywords.application.use_cases.extract_keywords_use_case.extract_keywords_use_case import (
+                    ExtractKeywordsUseCase,
+                )
+
+                use_case = ExtractKeywordsUseCase(db)
+                use_case.execute(audience_id, analysis_id)
+            except Exception:
+                logger.exception(
+                    "Background keyword extraction failed for audience %s", audience_id
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/audience_keywords/domain/entities/audience_keyword.py
+++ b/app/modules/audience_keywords/domain/entities/audience_keyword.py
@@ -1,0 +1,71 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class AudienceKeywordAnalysis(Base):
+    """
+    Registro de uma análise de keywords de uma audiência.
+    Cada vez que as comunidades mudam, uma nova análise é criada.
+    """
+
+    __tablename__ = "audience_keyword_analyses"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(
+        String(20), nullable=False, default="processing", index=True
+    )  # processing, ready, failed
+    communities_fingerprint = Column(String(64), nullable=False, index=True)
+    total_keywords = Column(Integer, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    keywords = relationship(
+        "AudienceKeyword",
+        back_populates="analysis",
+        cascade="all, delete-orphan",
+    )
+
+
+class AudienceKeyword(Base):
+    """
+    Palavra-chave de busca extraída para uma audiência.
+    """
+
+    __tablename__ = "audience_keywords"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audience_keyword_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    keyword = Column(String(200), nullable=False)
+    category = Column(String(50), nullable=True)  # pain_point, question, recommendation, trend, general
+    relevance_score = Column(Integer, nullable=True)  # 1-10
+    rank = Column(Integer, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    analysis = relationship("AudienceKeywordAnalysis", back_populates="keywords")

--- a/app/modules/audience_keywords/infra/repositories/audience_keyword_repository.py
+++ b/app/modules/audience_keywords/infra/repositories/audience_keyword_repository.py
@@ -1,0 +1,179 @@
+import hashlib
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_keywords.domain.entities.audience_keyword import (
+    AudienceKeyword,
+    AudienceKeywordAnalysis,
+)
+
+
+class AudienceKeywordRepository:
+    """Repositório para operações com análises de keywords de audiências."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def generate_fingerprint(community_names: list[str]) -> str:
+        """Gera fingerprint SHA256 das comunidades ordenadas."""
+        sorted_names = sorted(n.lower() for n in community_names)
+        content = ":".join(sorted_names)
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def find_latest_ready(self, audience_id: UUID) -> AudienceKeywordAnalysis | None:
+        """Busca a análise mais recente com status 'ready'."""
+        return (
+            self.db.query(AudienceKeywordAnalysis)
+            .filter(
+                AudienceKeywordAnalysis.audience_id == audience_id,
+                AudienceKeywordAnalysis.status == "ready",
+            )
+            .order_by(AudienceKeywordAnalysis.created_at.desc())
+            .first()
+        )
+
+    def find_latest_by_audience(self, audience_id: UUID) -> AudienceKeywordAnalysis | None:
+        """Busca a análise mais recente (qualquer status)."""
+        return (
+            self.db.query(AudienceKeywordAnalysis)
+            .filter(AudienceKeywordAnalysis.audience_id == audience_id)
+            .order_by(AudienceKeywordAnalysis.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, audience_id: UUID, fingerprint: str
+    ) -> AudienceKeywordAnalysis | None:
+        """Busca análise por fingerprint (mesma composição de comunidades)."""
+        return (
+            self.db.query(AudienceKeywordAnalysis)
+            .filter(
+                AudienceKeywordAnalysis.audience_id == audience_id,
+                AudienceKeywordAnalysis.communities_fingerprint == fingerprint,
+                AudienceKeywordAnalysis.status.in_(["ready", "processing"]),
+            )
+            .order_by(AudienceKeywordAnalysis.created_at.desc())
+            .first()
+        )
+
+    def create_analysis(
+        self, audience_id: UUID, fingerprint: str
+    ) -> AudienceKeywordAnalysis:
+        """Cria um novo registro de análise com status 'processing'."""
+        analysis = AudienceKeywordAnalysis(
+            audience_id=audience_id,
+            communities_fingerprint=fingerprint,
+            status="processing",
+        )
+        self.db.add(analysis)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_ready(
+        self, analysis_id: UUID, total_keywords: int
+    ) -> AudienceKeywordAnalysis | None:
+        """Marca análise como pronta."""
+        analysis = (
+            self.db.query(AudienceKeywordAnalysis)
+            .filter(AudienceKeywordAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "ready"
+        analysis.total_keywords = total_keywords
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_failed(
+        self, analysis_id: UUID, error_message: str
+    ) -> AudienceKeywordAnalysis | None:
+        """Marca análise como falha."""
+        analysis = (
+            self.db.query(AudienceKeywordAnalysis)
+            .filter(AudienceKeywordAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "failed"
+        analysis.error_message = error_message
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def save_keywords(
+        self, analysis_id: UUID, keywords: list[dict]
+    ) -> list[AudienceKeyword]:
+        """Salva lista de keywords extraídas."""
+        entities = []
+        for kw_data in keywords:
+            keyword = AudienceKeyword(
+                analysis_id=analysis_id,
+                keyword=kw_data["keyword"],
+                category=kw_data.get("category"),
+                relevance_score=kw_data.get("relevance_score"),
+                rank=kw_data.get("rank"),
+            )
+            self.db.add(keyword)
+            entities.append(keyword)
+
+        self.db.commit()
+        return entities
+
+    def get_keywords(
+        self,
+        analysis_id: UUID,
+        sort_by: str = "rank",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[AudienceKeyword]:
+        """Lista keywords de uma análise com ordenação."""
+        query = self.db.query(AudienceKeyword).filter(
+            AudienceKeyword.analysis_id == analysis_id
+        )
+
+        if sort_by == "relevance":
+            query = query.order_by(AudienceKeyword.relevance_score.desc().nullslast())
+        elif sort_by == "keyword":
+            query = query.order_by(AudienceKeyword.keyword.asc())
+        elif sort_by == "category":
+            query = query.order_by(AudienceKeyword.category.asc().nullslast())
+        else:
+            query = query.order_by(AudienceKeyword.rank.asc().nullslast())
+
+        return query.offset(offset).limit(limit).all()
+
+    def delete_old_analyses(self, audience_id: UUID, keep_latest: int = 2) -> int:
+        """Remove análises antigas, mantendo as N mais recentes."""
+        latest_ids = (
+            self.db.query(AudienceKeywordAnalysis.id)
+            .filter(AudienceKeywordAnalysis.audience_id == audience_id)
+            .order_by(AudienceKeywordAnalysis.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(AudienceKeywordAnalysis)
+            .filter(
+                AudienceKeywordAnalysis.audience_id == audience_id,
+                AudienceKeywordAnalysis.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -4,6 +4,9 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.modules.audience_keywords.application.use_cases.trigger_keyword_analysis_use_case import (
+    TriggerKeywordAnalysisUseCase,
+)
 from app.modules.audience_topics.application.use_cases.trigger_topic_analysis_use_case import (
     TriggerTopicAnalysisUseCase,
 )
@@ -50,6 +53,7 @@ class CreateAudienceUseCase:
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
         self.trigger_topics = TriggerTopicAnalysisUseCase(db)
+        self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
 
     def execute(self, input_data: CreateAudienceInput) -> AudienceDTO:
         audience = self.repository.create(
@@ -63,9 +67,10 @@ class CreateAudienceUseCase:
 
         communities_count = len(input_data.subreddit_names)
 
-        # Dispara análise de tópicos em background se há comunidades
+        # Dispara análises em background se há comunidades
         if input_data.subreddit_names:
             self.trigger_topics.execute(audience.id)
+            self.trigger_keywords.execute(audience.id)
 
         return AudienceDTO(
             id=audience.id,
@@ -82,6 +87,7 @@ class UpdateAudienceUseCase:
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
         self.trigger_topics = TriggerTopicAnalysisUseCase(db)
+        self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
 
     def execute(
         self, audience_id: UUID, input_data: UpdateAudienceInput
@@ -100,8 +106,9 @@ class UpdateAudienceUseCase:
             )
             communities_count = len(communities)
 
-            # Dispara análise de tópicos quando comunidades mudam
+            # Dispara análises quando comunidades mudam
             self.trigger_topics.execute(audience_id)
+            self.trigger_keywords.execute(audience_id)
         else:
             communities_count = len(audience.communities)
 
@@ -130,11 +137,13 @@ class AddCommunityToAudienceUseCase:
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
         self.trigger_topics = TriggerTopicAnalysisUseCase(db)
+        self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
 
     def execute(self, audience_id: UUID, subreddit_name: str) -> bool:
         result = self.repository.add_community(audience_id, subreddit_name)
         if result is not None:
             self.trigger_topics.execute(audience_id)
+            self.trigger_keywords.execute(audience_id)
         return result is not None
 
 
@@ -144,9 +153,11 @@ class RemoveCommunityFromAudienceUseCase:
     def __init__(self, db: Session):
         self.repository = AudienceRepository(db)
         self.trigger_topics = TriggerTopicAnalysisUseCase(db)
+        self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
 
     def execute(self, audience_id: UUID, subreddit_name: str) -> bool:
         removed = self.repository.remove_community(audience_id, subreddit_name)
         if removed:
             self.trigger_topics.execute(audience_id)
+            self.trigger_keywords.execute(audience_id)
         return removed

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -5,6 +5,7 @@ from app.routes.topics import router as topics_router
 from app.routes.audiences import router as audiences_router
 from app.routes.audience_templates import router as audience_templates_router
 from app.routes.audience_topics import router as audience_topics_router
+from app.routes.audience_keywords import router as audience_keywords_router
 from app.routes.similar_communities import router as similar_communities_router
 from app.routes.communities import router as communities_router
 
@@ -14,6 +15,7 @@ __all__ = [
     "audiences_router",
     "audience_templates_router",
     "audience_topics_router",
+    "audience_keywords_router",
     "similar_communities_router",
     "communities_router",
 ]

--- a/app/routes/audience_keywords.py
+++ b/app/routes/audience_keywords.py
@@ -1,0 +1,158 @@
+"""Routes for audience keyword analysis."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.modules.audience_keywords.application.use_cases.trigger_keyword_analysis_use_case import (
+    TriggerKeywordAnalysisUseCase,
+)
+from app.modules.audience_keywords.infra.repositories.audience_keyword_repository import (
+    AudienceKeywordRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+
+router = APIRouter(prefix="/audiences", tags=["Audience Keywords"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuário é dono da audiência ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+@router.get("/{audience_id}/keywords")
+def list_audience_keywords(
+    audience_id: UUID,
+    sort_by: str = "rank",
+    limit: int = 50,
+    offset: int = 0,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Lista keywords de busca extraídas de uma audiência.
+
+    Retorna a análise mais recente com status 'ready'.
+    Se não existe ou está em processamento, retorna status correspondente.
+
+    sort_by: rank (padrão), relevance, keyword, category
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    keyword_repo = AudienceKeywordRepository(db)
+
+    # Buscar análise mais recente (qualquer status)
+    latest = keyword_repo.find_latest_by_audience(audience_id)
+
+    if not latest:
+        return {
+            "status": "no_analysis",
+            "message": "Nenhuma análise de keywords encontrada. Adicione comunidades à audiência.",
+            "keywords": [],
+            "total_keywords": 0,
+        }
+
+    if latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Análise de keywords em andamento. Tente novamente em alguns minutos.",
+            "keywords": [],
+            "total_keywords": 0,
+        }
+
+    if latest.status == "failed":
+        return {
+            "status": "failed",
+            "message": f"Análise falhou: {latest.error_message or 'erro desconhecido'}",
+            "keywords": [],
+            "total_keywords": 0,
+        }
+
+    # Status ready — buscar keywords
+    keywords = keyword_repo.get_keywords(
+        analysis_id=latest.id,
+        sort_by=sort_by,
+        limit=limit,
+        offset=offset,
+    )
+
+    return {
+        "status": "ready",
+        "analysis_id": str(latest.id),
+        "total_keywords": latest.total_keywords,
+        "completed_at": latest.completed_at.isoformat() if latest.completed_at else None,
+        "keywords": [
+            {
+                "id": str(k.id),
+                "keyword": k.keyword,
+                "category": k.category,
+                "relevance_score": k.relevance_score,
+                "rank": k.rank,
+            }
+            for k in keywords
+        ],
+    }
+
+
+@router.post("/{audience_id}/keywords/refresh", status_code=202)
+def refresh_audience_keywords(
+    audience_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Força reprocessamento da análise de keywords.
+    Útil quando o usuário quer dados atualizados.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    communities = audience_repo.get_communities(audience_id)
+    if not communities:
+        raise HTTPException(
+            status_code=400,
+            detail="Audiência não possui comunidades para análise",
+        )
+
+    keyword_repo = AudienceKeywordRepository(db)
+
+    # Verificar se já há uma análise em processamento
+    latest = keyword_repo.find_latest_by_audience(audience_id)
+    if latest and latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Já existe uma análise em andamento.",
+        }
+
+    # Criar nova análise (ignora fingerprint — força reprocessamento)
+    community_names = [c.subreddit_name for c in communities]
+    fingerprint = AudienceKeywordRepository.generate_fingerprint(community_names)
+    analysis = keyword_repo.create_analysis(audience_id, fingerprint)
+
+    trigger = TriggerKeywordAnalysisUseCase(db)
+    trigger._run_in_background(audience_id, analysis.id)
+
+    return {
+        "status": "processing",
+        "message": "Análise de keywords iniciada. Consulte novamente em alguns minutos.",
+        "analysis_id": str(analysis.id),
+    }

--- a/docs/issue-32-audience-search-keywords.md
+++ b/docs/issue-32-audience-search-keywords.md
@@ -1,0 +1,205 @@
+# Issue #32 — Geração Automática de Keywords de Busca por Audiência
+
+## Motivação
+
+Na tela de detalhes de uma audiência, as tags de busca exibidas (ex: "Search Tips", "health issues", "choice", "I hate", "Looking for") eram **mockadas no frontend** e não refletiam o contexto real das comunidades da audiência. O usuário não tinha como descobrir termos de busca relevantes para explorar o conteúdo das suas comunidades.
+
+### Cenário do usuário
+
+O usuário criou uma audiência "Marketing Custom" com comunidades como r/socialmediamarketing, r/digitalmarketing, r/marketing e r/marketingdigitalbr. Ele quer saber: "quais termos de busca vão me ajudar a encontrar discussões relevantes?" — por exemplo, "best tools for", "struggling with", "how do you", "budget concerns" etc.
+
+---
+
+## Solução Adotada
+
+### Abordagem: Pipeline de keywords em background, mesmo padrão da Issue #29
+
+Ao invés de gerar keywords sob demanda, o pipeline é disparado automaticamente quando as comunidades da audiência mudam. Assim, quando o frontend precisa das tags, os dados já estão prontos.
+
+```
+POST/PUT/ADD/REMOVE comunidades
+    → TriggerKeywordAnalysisUseCase
+        → Calcula fingerprint (SHA256 das comunidades ordenadas)
+        → Já existe análise com mesmo fingerprint? → Skip
+        → Cria análise (status: "processing")
+        → threading.Thread(daemon=True)
+            → ExtractKeywordsUseCase
+                → Coleta descrições das comunidades (Reddit API)
+                → Busca tópicos já extraídos (se existirem)
+                → LangGraph: extract_keywords (1 nó)
+                → Salva keywords no banco → status: "ready"
+
+GET /audiences/{id}/keywords
+    → Busca análise mais recente
+    → "ready"      → retorna keywords categorizadas
+    → "processing" → retorna {status: "processing"}
+    → "failed"     → retorna erro
+```
+
+### Decisões arquiteturais
+
+1. **Módulo isolado `audience_keywords`:** Segue o padrão DDD do projeto — domain, application, infra separados. Não mistura com o módulo `audience_topics`.
+
+2. **Enriquecimento com tópicos:** O agente recebe os tópicos já extraídos (se existirem) para gerar keywords mais contextuais. Se os tópicos ainda não estiverem prontos, gera com base apenas nas comunidades.
+
+3. **Categorização de keywords:** Cada keyword tem uma categoria (`pain_point`, `question`, `recommendation`, `trend`, `general`) e um score de relevância (1-10). Isso permite ao frontend filtrar e exibir por tipo.
+
+4. **LangGraph com 1 nó:** Diferente da extração de tópicos (2 nós), keywords precisam de apenas 1 chamada ao LLM. O prompt é focado e inclui contexto das comunidades + tópicos trending.
+
+5. **Fingerprint compartilhado:** Mesmo mecanismo SHA256 das comunidades ordenadas, evitando reprocessamento quando a composição não muda.
+
+---
+
+## Arquivos Criados
+
+### `app/modules/audience_keywords/domain/entities/audience_keyword.py`
+- Entidade `AudienceKeywordAnalysis` — tabela `audience_keyword_analyses` (id, audience_id, status, communities_fingerprint, total_keywords, error_message, timestamps)
+- Entidade `AudienceKeyword` — tabela `audience_keywords` (id, analysis_id, keyword, category, relevance_score, rank)
+
+### `alembic/versions/b9c0d1e2f3a4_add_audience_keywords.py`
+- Migration criando as duas tabelas com FKs CASCADE para `audiences` e `audience_keyword_analyses`
+
+### `app/modules/audience_keywords/infra/repositories/audience_keyword_repository.py`
+- `generate_fingerprint()` — SHA256 das comunidades ordenadas
+- `find_latest_ready()`, `find_by_fingerprint()` — queries para cache/invalidação
+- `create_analysis()`, `mark_ready()`, `mark_failed()` — ciclo de vida da análise
+- `save_keywords()` — salva keywords em batch
+- `get_keywords()` — listagem com ordenação (rank, relevance, keyword, category)
+- `delete_old_analyses()` — limpeza, mantém as 2 mais recentes
+
+### `app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/`
+- `state.py` — `KeywordExtractionState` com `ExtractedKeyword`
+- `prompts/keyword_extraction_prompts.py` — `extract_keywords_prompt()` com contexto de comunidades e tópicos
+- `keyword_extraction_agent.py` — Agente LangGraph com 1 nó: `extract_keywords`
+
+### `app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/extract_keywords_use_case.py`
+- Orquestrador: coleta descrições via Reddit API → busca tópicos existentes → roda agente → salva keywords → marca como ready
+
+### `app/modules/audience_keywords/application/use_cases/trigger_keyword_analysis_use_case.py`
+- Verifica fingerprint, cria análise, dispara `ExtractKeywordsUseCase` em `threading.Thread(daemon=True)` com `SessionLocal()` própria
+
+### `app/routes/audience_keywords.py`
+- `GET /audiences/{id}/keywords` — lista keywords com status e ordenação
+- `POST /audiences/{id}/keywords/refresh` — força reprocessamento
+
+---
+
+## Arquivos Modificados
+
+### `app/modules/audiences/application/use_cases/manage_audience_use_case.py`
+- Hooks em 4 use cases: `CreateAudienceUseCase`, `UpdateAudienceUseCase`, `AddCommunityToAudienceUseCase`, `RemoveCommunityFromAudienceUseCase`
+- Cada um chama `TriggerKeywordAnalysisUseCase.execute()` após mutação de comunidades (junto com o trigger de tópicos existente)
+
+### `app/main.py`
+- Registro do `audience_keywords_router`
+
+### `app/routes/__init__.py`
+- Export do `audience_keywords_router`
+
+### `alembic/env.py`
+- Import da entidade `audience_keyword` para autogenerate
+
+---
+
+## Como Testar
+
+### Teste 1 — Criar audiência (dispara análise de keywords em background)
+
+```http
+POST /audiences
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+    "name": "Marketing Custom",
+    "description": "Comunidades de marketing",
+    "subreddit_names": ["socialmediamarketing", "digitalmarketing", "marketing"]
+}
+```
+
+**Esperado:** Audiência criada. Nos logs, `Triggering keyword analysis for audience ...`.
+
+### Teste 2 — Consultar keywords (em processamento)
+
+```http
+GET /audiences/{audience_id}/keywords
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "processing", keywords: [], total_keywords: 0}`
+
+### Teste 3 — Consultar keywords (após ~30 segundos)
+
+```http
+GET /audiences/{audience_id}/keywords
+Authorization: Bearer <token>
+```
+
+**Esperado:**
+```json
+{
+    "status": "ready",
+    "total_keywords": 20,
+    "keywords": [
+        {
+            "keyword": "best tools for",
+            "category": "recommendation",
+            "relevance_score": 9,
+            "rank": 1
+        },
+        ...
+    ]
+}
+```
+
+### Teste 4 — Ordenar por relevância
+
+```http
+GET /audiences/{audience_id}/keywords?sort_by=relevance
+Authorization: Bearer <token>
+```
+
+**Esperado:** Keywords ordenadas por `relevance_score` decrescente.
+
+### Teste 5 — Forçar reprocessamento
+
+```http
+POST /audiences/{audience_id}/keywords/refresh
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "processing", message: "Análise de keywords iniciada..."}`. Status 202.
+
+### Teste 6 — Fingerprint evita reprocessamento
+
+```http
+PUT /audiences/{audience_id}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+    "name": "Novo nome"
+}
+```
+
+**Esperado:** Nome atualizado. Análise de keywords NÃO é disparada (comunidades não mudaram).
+
+---
+
+## Relação com Outras Issues
+
+| Issue | Relação |
+|-------|---------|
+| #29 — Audience Topic Analysis | Mesmo padrão arquitetural (trigger + background + fingerprint + LangGraph). Keywords reutilizam tópicos extraídos para contexto |
+| #25 — Audience Community Sync | Sync dispara análise de keywords quando `subreddit_names` muda |
+| #17 — Audience User Ownership | Reutiliza `_check_ownership` nas rotas de keywords |
+
+---
+
+## Melhorias Futuras (Fora do Escopo)
+
+- **Keywords personalizadas:** Permitir que o usuário adicione/remova keywords manualmente
+- **Keywords por tópico:** Gerar keywords específicas para cada tópico extraído
+- **Trending keywords:** Detectar keywords que estão ganhando tração ao longo do tempo
+- **Autocomplete:** Usar keywords como sugestões de autocomplete na busca do frontend
+- **Keywords multilíngue:** Gerar keywords no idioma predominante das comunidades


### PR DESCRIPTION
## Summary

- Add background keyword extraction pipeline for audiences using LangGraph agent
- LLM analyzes community context (names, descriptions, trending topics) to generate relevant search keywords
- Keywords are categorized by type (`pain_point`, `question`, `recommendation`, `trend`, `general`) with relevance scoring (1-10)
- Follows the same architectural pattern as Issue #29 (Topic Analysis): trigger on write → fingerprint cache → background thread → LangGraph agent

## New Endpoints

- `GET /audiences/{id}/keywords` — List extracted search keywords with sorting (rank, relevance, keyword, category)
- `POST /audiences/{id}/keywords/refresh` — Force keyword re-analysis

## Architecture

```
POST/PUT/ADD/REMOVE communities
    → TriggerKeywordAnalysisUseCase
        → SHA256 fingerprint check → skip if unchanged
        → Create analysis (status: "processing")
        → threading.Thread(daemon=True)
            → ExtractKeywordsUseCase
                → Collect community descriptions (Reddit API)
                → Fetch existing topics (if available)
                → LangGraph: extract_keywords (1 node)
                → Save keywords → status: "ready"
```

## Files Created (9)

- `app/modules/audience_keywords/domain/entities/audience_keyword.py` — Entities
- `app/modules/audience_keywords/infra/repositories/audience_keyword_repository.py` — Repository
- `app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/` — LangGraph agent (state, prompts, agent)
- `app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/extract_keywords_use_case.py` — Orchestrator
- `app/modules/audience_keywords/application/use_cases/trigger_keyword_analysis_use_case.py` — Trigger
- `app/routes/audience_keywords.py` — API routes
- `alembic/versions/b9c0d1e2f3a4_add_audience_keywords.py` — Migration

## Files Modified (4)

- `app/modules/audiences/application/use_cases/manage_audience_use_case.py` — Trigger keyword analysis on community changes
- `app/main.py` — Register keywords router
- `app/routes/__init__.py` — Export keywords router
- `alembic/env.py` — Import new entity

## Test plan

- [ ] Create audience with communities → verify keyword analysis triggered in logs
- [ ] `GET /audiences/{id}/keywords` while processing → returns `{status: "processing"}`
- [ ] `GET /audiences/{id}/keywords` after completion → returns categorized keywords
- [ ] `PUT /audiences/{id}` with only name change → keyword analysis NOT triggered (fingerprint unchanged)
- [ ] `POST /audiences/{id}/keywords/refresh` → forces re-analysis
- [ ] Add/remove community → keyword analysis re-triggered

Closes #32