### PR TITLE
feat: topic deep dive analysis (Browse All)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -38,6 +38,7 @@ from app.modules.similar_communities.domain.entities import user_feedback  # noq
 from app.modules.audience_templates.domain.entities import audience_template  # noqa: E402
 from app.modules.audience_topics.domain.entities import audience_topic  # noqa: E402
 from app.modules.audience_keywords.domain.entities import audience_keyword  # noqa: E402
+from app.modules.topic_deep_dive.domain.entities import topic_deep_dive  # noqa: E402
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/d0e1f2a3b4c5_add_topic_deep_dive.py
+++ b/alembic/versions/d0e1f2a3b4c5_add_topic_deep_dive.py
@@ -1,0 +1,70 @@
+"""add topic_deep_dive_analyses and topic_deep_dives tables
+
+Revision ID: d0e1f2a3b4c5
+Revises: c0d1e2f3a4b5
+Create Date: 2026-02-22
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSON
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c5"
+down_revision: Union[str, None] = "c0d1e2f3a4b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "topic_deep_dive_analyses",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "topic_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audience_topics.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "audience_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audiences.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("status", sa.String(20), nullable=False, default="processing", index=True),
+        sa.Column("topic_fingerprint", sa.String(64), nullable=False, index=True),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "topic_deep_dives",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "analysis_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("topic_deep_dive_analyses.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("summary", sa.Text, nullable=True),
+        sa.Column("subtopics", JSON, nullable=True),
+        sa.Column("common_questions", JSON, nullable=True),
+        sa.Column("sentiment", JSON, nullable=True),
+        sa.Column("mentioned_products", JSON, nullable=True),
+        sa.Column("representative_posts", JSON, nullable=True),
+        sa.Column("actionable_insights", JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("topic_deep_dives")
+    op.drop_table("topic_deep_dive_analyses")

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.routes import (
     audiences_router,
     communities_router,
     similar_communities_router,
+    topic_deep_dive_router,
     topics_router,
 )
 
@@ -70,6 +71,7 @@ app.include_router(audience_topics_router)
 app.include_router(audience_keywords_router)
 app.include_router(similar_communities_router)
 app.include_router(communities_router)
+app.include_router(topic_deep_dive_router)
 
 
 @app.get("/")

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/deep_dive_agent.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/deep_dive_agent.py
@@ -1,0 +1,195 @@
+import json
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.topic_deep_dive.application.use_cases.extract_deep_dive_use_case.agent.prompts.deep_dive_prompts import (
+    deep_dive_analysis_prompt,
+    select_representative_posts_prompt,
+)
+from app.modules.topic_deep_dive.application.use_cases.extract_deep_dive_use_case.agent.state import (
+    DeepDiveState,
+    PostWithComments,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_POSTS_CHARS = 100_000  # Higher limit since we include comments
+MAX_COMMENT_LENGTH = 500
+
+
+def _get_llm() -> ChatOpenAI:
+    return ChatOpenAI(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        temperature=0,
+    )
+
+
+def _build_posts_with_comments_text(
+    posts: list[PostWithComments],
+    max_chars: int = MAX_POSTS_CHARS,
+) -> str:
+    """Builds a text block from posts with their comments."""
+    lines = []
+    total_chars = 0
+
+    for post in posts:
+        subreddit = post.get("subreddit", "")
+        title = post.get("title", "").strip()
+        selftext = post.get("selftext", "").strip()
+        score = post.get("score", 0)
+        num_comments = post.get("num_comments", 0)
+
+        # Truncate long selftext
+        if len(selftext) > 600:
+            selftext = selftext[:600] + "..."
+
+        line = f"[r/{subreddit}] (score: {score}, comments: {num_comments}) {title}"
+        if selftext:
+            line += f"\n  {selftext}"
+
+        # Add top comments
+        comments = post.get("comments", [])
+        if comments:
+            line += "\n  --- Comments ---"
+            for comment in comments[:5]:  # Top 5 comments per post
+                body = comment.get("body", "").strip()
+                if len(body) > MAX_COMMENT_LENGTH:
+                    body = body[:MAX_COMMENT_LENGTH] + "..."
+                c_score = comment.get("score", 0)
+                author = comment.get("author", "anonymous")
+                line += f"\n  [{author}, score:{c_score}] {body}"
+
+        if total_chars + len(line) > max_chars:
+            break
+
+        lines.append(line)
+        total_chars += len(line)
+
+    return "\n\n".join(lines)
+
+
+def _build_posts_summary_text(posts: list[PostWithComments]) -> str:
+    """Builds a summary text of posts for representative selection."""
+    lines = []
+    for post in posts:
+        subreddit = post.get("subreddit", "")
+        title = post.get("title", "").strip()
+        score = post.get("score", 0)
+        num_comments = post.get("num_comments", 0)
+        permalink = post.get("permalink", "")
+        selftext = post.get("selftext", "").strip()
+
+        if len(selftext) > 200:
+            selftext = selftext[:200] + "..."
+
+        line = f"[r/{subreddit}] score:{score} comments:{num_comments} permalink:{permalink}\n  {title}"
+        if selftext:
+            line += f"\n  {selftext}"
+        lines.append(line)
+
+    return "\n\n".join(lines)
+
+
+# ── Node 1: Analyze deep dive ──────────────────────────────────────────────
+
+
+def analyze_deep_dive(state: DeepDiveState) -> dict:
+    """LLM performs deep analysis of the topic from posts and comments."""
+    posts = state.get("relevant_posts", [])
+    if not posts:
+        return {"deep_dive_result": None}
+
+    posts_text = _build_posts_with_comments_text(posts)
+    total_comments = sum(len(p.get("comments", [])) for p in posts)
+
+    llm = _get_llm()
+    prompt = deep_dive_analysis_prompt(
+        topic_name=state["topic_name"],
+        topic_description=state.get("topic_description", ""),
+        audience_name=state["audience_name"],
+        community_names=state["community_names"],
+        posts_with_comments_text=posts_text,
+        total_posts=len(posts),
+        total_comments=total_comments,
+    )
+
+    response = llm.invoke(prompt)
+    content = response.content.strip()
+
+    # Clean markdown code blocks if present
+    if content.startswith("```"):
+        content = content.split("\n", 1)[1] if "\n" in content else content[3:]
+    if content.endswith("```"):
+        content = content[:-3].strip()
+
+    try:
+        result = json.loads(content)
+    except json.JSONDecodeError:
+        logger.error("Failed to parse deep dive JSON response: %s", content[:500])
+        return {"deep_dive_result": None}
+
+    logger.info("Deep dive analysis complete for topic '%s'", state["topic_name"])
+    return {"deep_dive_result": result}
+
+
+# ── Node 2: Extract representative posts ──────────────────────────────────
+
+
+def extract_representative_posts(state: DeepDiveState) -> dict:
+    """LLM selects representative posts for this topic."""
+    result = state.get("deep_dive_result")
+    posts = state.get("relevant_posts", [])
+
+    if not result or not posts:
+        return {}
+
+    posts_text = _build_posts_summary_text(posts)
+    llm = _get_llm()
+
+    prompt = select_representative_posts_prompt(
+        topic_name=state["topic_name"],
+        posts_text=posts_text,
+    )
+
+    response = llm.invoke(prompt)
+    content = response.content.strip()
+
+    # Clean markdown code blocks if present
+    if content.startswith("```"):
+        content = content.split("\n", 1)[1] if "\n" in content else content[3:]
+    if content.endswith("```"):
+        content = content[:-3].strip()
+
+    try:
+        representative = json.loads(content)
+        if isinstance(representative, list):
+            result["representative_posts"] = representative
+    except json.JSONDecodeError:
+        logger.error("Failed to parse representative posts JSON: %s", content[:500])
+
+    logger.info(
+        "Selected %d representative posts for topic '%s'",
+        len(result.get("representative_posts", [])),
+        state["topic_name"],
+    )
+    return {"deep_dive_result": result}
+
+
+# ── Graph assembly ──────────────────────────────────────────────────────────
+
+
+def create_deep_dive_agent():
+    """Create the LangGraph agent for topic deep dive analysis."""
+    workflow = StateGraph(DeepDiveState)
+
+    workflow.add_node("analyze_deep_dive", analyze_deep_dive)
+    workflow.add_node("extract_representative_posts", extract_representative_posts)
+
+    workflow.add_edge(START, "analyze_deep_dive")
+    workflow.add_edge("analyze_deep_dive", "extract_representative_posts")
+    workflow.add_edge("extract_representative_posts", END)
+
+    return workflow.compile()

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/prompts/deep_dive_prompts.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/prompts/deep_dive_prompts.py
@@ -1,0 +1,105 @@
+def deep_dive_analysis_prompt(
+    topic_name: str,
+    topic_description: str,
+    audience_name: str,
+    community_names: list[str],
+    posts_with_comments_text: str,
+    total_posts: int,
+    total_comments: int,
+) -> str:
+    communities_str = ", ".join(f"r/{name}" for name in community_names)
+
+    return f"""You are an expert Reddit analyst performing a deep dive analysis on a specific topic.
+
+Audience: "{audience_name}"
+Communities: {communities_str}
+Topic: "{topic_name}"
+Topic description: {topic_description}
+Total posts analyzed: {total_posts}
+Total comments analyzed: {total_comments}
+
+Below are posts and their top comments related to this topic:
+
+{posts_with_comments_text}
+
+---
+
+TASK: Perform a comprehensive deep dive analysis of this topic. You must produce a structured analysis in JSON format with the following sections:
+
+1. **summary**: Write 2-3 paragraphs summarizing what this topic is about, why it matters to this audience, and what the key takeaways are. Be specific — reference actual discussions and patterns you see in the data.
+
+2. **subtopics**: Identify 3-10 distinct facets/subtopics within this theme. Each subtopic should have:
+   - "name": 2-4 word name
+   - "description": One sentence explaining this subtopic
+   - "post_count": Estimated number of posts related to this subtopic
+
+3. **common_questions**: Identify 3-8 frequently asked questions within this topic. Each should have:
+   - "question": The actual question (as people phrase it)
+   - "frequency": "high", "medium", or "low"
+   - "example_context": A brief excerpt from a real post/comment showing this question
+
+4. **sentiment**: Analyze the overall sentiment around this topic:
+   - "overall": "positive", "negative", "neutral", or "mixed"
+   - "positive_ratio": float 0-1
+   - "negative_ratio": float 0-1
+   - "neutral_ratio": float 0-1
+   - "highlights": Array of 3-6 notable sentiment examples, each with:
+     - "text": The quote or paraphrased text
+     - "sentiment": "positive", "negative", or "neutral"
+     - "source": The subreddit it came from (e.g., "r/SocialMediaMarketing")
+
+5. **mentioned_products**: List tools, services, brands, or products mentioned in discussions. Each should have:
+   - "name": Product/tool name
+   - "category": "tool", "service", "brand", "platform", or "resource"
+   - "sentiment": "positive", "negative", "neutral", or "mixed"
+   - "mention_count": Estimated number of mentions
+   - "context": Brief context of how/why it's mentioned
+
+   If no products are mentioned, return an empty array.
+
+6. **actionable_insights**: Extract 3-6 actionable insights from the analysis. Each should have:
+   - "insight": Clear, actionable statement
+   - "type": "opportunity" (unmet need), "gap" (missing content/solution), "trend" (emerging pattern), or "warning" (risk/issue)
+   - "confidence": "high", "medium", or "low"
+
+IMPORTANT:
+- Base ALL analysis on the actual posts and comments provided. Do NOT invent data.
+- If there isn't enough data for a section, provide fewer items rather than fabricating.
+- Be specific — reference actual content patterns, not generic observations.
+- Sentiment ratios must sum to 1.0.
+
+Respond ONLY with valid JSON. No markdown code blocks, no explanations outside the JSON.
+
+Example structure:
+{{"summary": "...", "subtopics": [...], "common_questions": [...], "sentiment": {{...}}, "mentioned_products": [...], "actionable_insights": [...]}}"""
+
+
+def select_representative_posts_prompt(
+    topic_name: str,
+    posts_text: str,
+) -> str:
+    return f"""You are selecting the most representative posts for the topic "{topic_name}".
+
+Below are posts related to this topic:
+
+{posts_text}
+
+---
+
+TASK: Select 5-10 posts that best represent this topic. Choose posts that:
+- Cover different aspects/subtopics
+- Have high engagement (score, comments)
+- Provide clear examples of the topic in action
+- Represent diverse perspectives
+
+For each selected post, provide:
+- "title": The post title
+- "subreddit": The subreddit name (without r/)
+- "score": The post score
+- "permalink": The post permalink
+- "excerpt": A 1-2 sentence excerpt that captures why this post is representative
+
+Respond ONLY with a valid JSON array. No markdown code blocks.
+
+Example:
+[{{"title": "...", "subreddit": "...", "score": 123, "permalink": "/r/sub/comments/...", "excerpt": "..."}}]"""

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/state.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/state.py
@@ -1,0 +1,41 @@
+from typing import TypedDict
+
+
+class PostWithComments(TypedDict):
+    id: str
+    subreddit: str
+    title: str
+    selftext: str
+    score: int
+    num_comments: int
+    created_utc: float
+    permalink: str | None
+    comments: list[dict]  # [{"body": "...", "score": N, "author": "..."}]
+
+
+class DeepDiveResult(TypedDict):
+    summary: str
+    subtopics: list[dict]
+    # [{"name": "...", "description": "...", "post_count": N}]
+    common_questions: list[dict]
+    # [{"question": "...", "frequency": "high|medium|low", "example_context": "..."}]
+    sentiment: dict
+    # {"overall": "...", "positive_ratio": float, "negative_ratio": float,
+    #  "neutral_ratio": float, "highlights": [...]}
+    mentioned_products: list[dict]
+    # [{"name": "...", "category": "...", "sentiment": "...", "mention_count": N, "context": "..."}]
+    representative_posts: list[dict]
+    # [{"title": "...", "subreddit": "...", "score": N, "permalink": "...", "excerpt": "..."}]
+    actionable_insights: list[dict]
+    # [{"insight": "...", "type": "opportunity|gap|trend|warning", "confidence": "high|medium|low"}]
+
+
+class DeepDiveState(TypedDict):
+    topic_name: str
+    topic_description: str
+    audience_name: str
+    community_names: list[str]
+
+    # Populated by nodes
+    relevant_posts: list[PostWithComments]
+    deep_dive_result: DeepDiveResult | None

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/extract_deep_dive_use_case.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/extract_deep_dive_use_case.py
@@ -1,0 +1,248 @@
+"""Use case that orchestrates deep dive analysis for a topic."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.topic_deep_dive.application.use_cases.extract_deep_dive_use_case.agent.deep_dive_agent import (
+    create_deep_dive_agent,
+)
+from app.modules.topic_deep_dive.application.use_cases.extract_deep_dive_use_case.agent.state import (
+    PostWithComments,
+)
+from app.modules.topic_deep_dive.infra.repositories.topic_deep_dive_repository import (
+    TopicDeepDiveRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.topics.infra.providers.reddit_provider.generic_reddit_provider import (
+    GenericRedditProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+# Number of top posts to fetch comments for
+TOP_POSTS_FOR_COMMENTS = 10
+COMMENTS_PER_POST = 20
+
+
+class ExtractDeepDiveUseCase:
+    """
+    Coleta posts + comentários relacionados a um tópico e roda deep dive via LangGraph.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.deep_dive_repo = TopicDeepDiveRepository(db)
+        self.reddit_provider = GenericRedditProvider()
+
+    def execute(self, topic_id: UUID, audience_id: UUID, analysis_id: UUID) -> bool:
+        """
+        Executa a análise de deep dive completa.
+
+        Args:
+            topic_id: ID do tópico
+            audience_id: ID da audiência
+            analysis_id: ID da análise já criada (status: processing)
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        try:
+            # 1. Buscar dados do tópico e audiência
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                self.deep_dive_repo.mark_failed(analysis_id, "Audience not found")
+                return False
+
+            topic = self.topic_repo.get_topic_by_id(topic_id)
+            if not topic:
+                self.deep_dive_repo.mark_failed(analysis_id, "Topic not found")
+                return False
+
+            communities = self.audience_repo.get_communities(audience_id)
+            community_names = [c.subreddit_name for c in communities]
+
+            if not community_names:
+                self.deep_dive_repo.mark_failed(analysis_id, "No communities in audience")
+                return False
+
+            # 2. Coletar posts das comunidades do tópico
+            topic_communities = topic.communities or []
+            topic_community_names = [
+                c["name"].removeprefix("r/") for c in topic_communities if c.get("name")
+            ]
+
+            # Se o tópico não tem comunidades específicas, usar todas da audiência
+            if not topic_community_names:
+                topic_community_names = community_names
+
+            logger.info(
+                "Collecting posts for deep dive on topic '%s' from %d communities",
+                topic.name,
+                len(topic_community_names),
+            )
+
+            post_results = self.reddit_provider.collect_posts_for_communities(
+                topic_community_names, posts_per_sort=25
+            )
+
+            # 3. Filtrar posts relevantes ao tópico e deduplicar
+            seen_ids = set()
+            all_posts = []
+            for result in post_results:
+                for post in result.posts:
+                    if post.id in seen_ids:
+                        continue
+                    seen_ids.add(post.id)
+                    all_posts.append(post)
+
+            # Filtrar por relevância ao tópico (título ou texto contém keywords do tópico)
+            topic_keywords = self._extract_topic_keywords(topic.name, topic.description)
+            relevant_posts = self._filter_relevant_posts(all_posts, topic_keywords)
+
+            if not relevant_posts:
+                # Se nenhum post é diretamente relevante, usar todos (o LLM filtra)
+                relevant_posts = all_posts
+
+            # Ordenar por score (mais engajados primeiro)
+            relevant_posts.sort(key=lambda p: p.score, reverse=True)
+
+            logger.info(
+                "Found %d relevant posts out of %d total for topic '%s'",
+                len(relevant_posts),
+                len(all_posts),
+                topic.name,
+            )
+
+            # 4. Buscar comentários dos top posts
+            posts_with_comments: list[PostWithComments] = []
+            for i, post in enumerate(relevant_posts):
+                comments = []
+                if i < TOP_POSTS_FOR_COMMENTS:
+                    raw_comments = self.reddit_provider.get_post_comments(
+                        post.subreddit, post.id, limit=COMMENTS_PER_POST
+                    )
+                    comments = [
+                        {
+                            "body": c.body,
+                            "score": c.score,
+                            "author": c.author,
+                        }
+                        for c in raw_comments
+                    ]
+
+                posts_with_comments.append(
+                    PostWithComments(
+                        id=post.id,
+                        subreddit=post.subreddit,
+                        title=post.title,
+                        selftext=post.selftext,
+                        score=post.score,
+                        num_comments=post.num_comments,
+                        created_utc=post.created_utc,
+                        permalink=post.permalink,
+                        comments=comments,
+                    )
+                )
+
+            if not posts_with_comments:
+                self.deep_dive_repo.mark_failed(analysis_id, "No posts collected")
+                return False
+
+            total_comments = sum(len(p["comments"]) for p in posts_with_comments)
+            logger.info(
+                "Collected %d posts with %d comments, running deep dive agent",
+                len(posts_with_comments),
+                total_comments,
+            )
+
+            # 5. Rodar agente de deep dive
+            agent = create_deep_dive_agent()
+            result = agent.invoke({
+                "topic_name": topic.name,
+                "topic_description": topic.description or "",
+                "audience_name": audience.name,
+                "community_names": community_names,
+                "relevant_posts": posts_with_comments,
+                "deep_dive_result": None,
+            })
+
+            deep_dive_result = result.get("deep_dive_result")
+
+            if not deep_dive_result:
+                self.deep_dive_repo.mark_failed(analysis_id, "Deep dive analysis returned no results")
+                return False
+
+            # 6. Salvar resultado no banco
+            self.deep_dive_repo.save_deep_dive(analysis_id, deep_dive_result)
+
+            # 7. Marcar como pronto
+            self.deep_dive_repo.mark_ready(analysis_id)
+
+            # 8. Limpar análises antigas
+            self.deep_dive_repo.delete_old_analyses(topic_id, keep_latest=2)
+
+            logger.info(
+                "Deep dive complete for topic '%s': %d subtopics, %d insights",
+                topic.name,
+                len(deep_dive_result.get("subtopics", [])),
+                len(deep_dive_result.get("actionable_insights", [])),
+            )
+            return True
+
+        except Exception as e:
+            logger.exception("Deep dive failed for topic %s", topic_id)
+            try:
+                self.deep_dive_repo.mark_failed(analysis_id, str(e))
+            except Exception:
+                pass
+            return False
+
+    def _extract_topic_keywords(self, name: str, description: str | None) -> list[str]:
+        """Extrai keywords do nome e descrição do tópico para filtragem."""
+        text = name.lower()
+        if description:
+            text += " " + description.lower()
+
+        # Remove palavras muito genéricas
+        stop_words = {
+            "the", "a", "an", "is", "are", "was", "were", "be", "been",
+            "being", "have", "has", "had", "do", "does", "did", "will",
+            "would", "could", "should", "may", "might", "can", "shall",
+            "to", "of", "in", "for", "on", "with", "at", "by", "from",
+            "as", "into", "through", "during", "before", "after", "and",
+            "but", "or", "nor", "not", "so", "yet", "both", "either",
+            "neither", "each", "every", "all", "any", "few", "more",
+            "most", "other", "some", "such", "no", "only", "own", "same",
+            "than", "too", "very", "just", "about", "this", "that",
+            "these", "those", "it", "its", "they", "them", "their",
+            "related", "discussions", "topics", "issues", "content",
+        }
+
+        words = text.split()
+        keywords = [w.strip(".,!?;:'\"()[]{}") for w in words if len(w) > 2]
+        keywords = [w for w in keywords if w and w not in stop_words]
+
+        return list(set(keywords))
+
+    def _filter_relevant_posts(self, posts: list, keywords: list[str]) -> list:
+        """Filtra posts que contêm keywords do tópico."""
+        if not keywords:
+            return posts
+
+        relevant = []
+        for post in posts:
+            text = (post.title + " " + post.selftext).lower()
+            if any(kw in text for kw in keywords):
+                relevant.append(post)
+
+        return relevant

--- a/app/modules/topic_deep_dive/application/use_cases/trigger_deep_dive_use_case.py
+++ b/app/modules/topic_deep_dive/application/use_cases/trigger_deep_dive_use_case.py
@@ -1,0 +1,115 @@
+"""Triggers deep dive analysis in background when user requests it."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.topic_deep_dive.infra.repositories.topic_deep_dive_repository import (
+    TopicDeepDiveRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerDeepDiveUseCase:
+    """
+    Verifica se o deep dive precisa ser processado
+    e dispara em background thread se necessário.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.deep_dive_repo = TopicDeepDiveRepository(db)
+
+    def execute(self, topic_id: UUID, audience_id: UUID, force: bool = False) -> dict:
+        """
+        Verifica e dispara deep dive se necessário.
+
+        Args:
+            topic_id: ID do tópico
+            audience_id: ID da audiência
+            force: Se True, ignora fingerprint e força reprocessamento
+
+        Returns:
+            dict com status e informações
+        """
+        # Verificar se o tópico existe
+        topic = self.topic_repo.get_topic_by_id(topic_id)
+        if not topic:
+            return {"status": "error", "message": "Topic not found"}
+
+        # Verificar se já há análise em processamento
+        latest = self.deep_dive_repo.find_latest_by_topic(topic_id)
+        if latest and latest.status == "processing" and not force:
+            return {
+                "status": "processing",
+                "message": "Já existe uma análise em andamento.",
+                "analysis_id": str(latest.id),
+            }
+
+        # Gerar fingerprint
+        communities = self.audience_repo.get_communities(audience_id)
+        community_names = [c.subreddit_name for c in communities]
+        fingerprint = TopicDeepDiveRepository.generate_fingerprint(topic_id, community_names)
+
+        # Se não forçar, verificar se já existe análise com mesmo fingerprint
+        if not force:
+            existing = self.deep_dive_repo.find_by_fingerprint(topic_id, fingerprint)
+            if existing:
+                return {
+                    "status": existing.status,
+                    "message": f"Análise existente (status={existing.status}).",
+                    "analysis_id": str(existing.id),
+                }
+
+        # Criar registro de análise com status "processing"
+        analysis = self.deep_dive_repo.create_analysis(topic_id, audience_id, fingerprint)
+        logger.info(
+            "Triggering deep dive for topic %s (analysis %s)",
+            topic_id,
+            analysis.id,
+        )
+
+        # Disparar em background
+        self._run_in_background(topic_id, audience_id, analysis.id)
+
+        return {
+            "status": "processing",
+            "message": "Análise de deep dive iniciada. Consulte novamente em alguns minutos.",
+            "analysis_id": str(analysis.id),
+        }
+
+    def _run_in_background(
+        self, topic_id: UUID, audience_id: UUID, analysis_id: UUID
+    ) -> None:
+        """Dispara extração de deep dive em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.topic_deep_dive.application.use_cases.extract_deep_dive_use_case.extract_deep_dive_use_case import (
+                    ExtractDeepDiveUseCase,
+                )
+
+                use_case = ExtractDeepDiveUseCase(db)
+                use_case.execute(topic_id, audience_id, analysis_id)
+            except Exception:
+                logger.exception(
+                    "Background deep dive failed for topic %s", topic_id
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/topic_deep_dive/domain/entities/topic_deep_dive.py
+++ b/app/modules/topic_deep_dive/domain/entities/topic_deep_dive.py
@@ -1,0 +1,96 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class TopicDeepDiveAnalysis(Base):
+    """
+    Registro de uma análise de deep dive de um tópico.
+    Criado sob demanda quando o usuário clica em "Browse All".
+    """
+
+    __tablename__ = "topic_deep_dive_analyses"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    topic_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audience_topics.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(
+        String(20), nullable=False, default="processing", index=True
+    )  # processing, ready, failed
+    topic_fingerprint = Column(String(64), nullable=False, index=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    deep_dive = relationship(
+        "TopicDeepDive",
+        back_populates="analysis",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+
+
+class TopicDeepDive(Base):
+    """
+    Resultado do deep dive de um tópico.
+    Contém análise profunda: subtópicos, FAQs, sentimento, produtos, insights.
+    """
+
+    __tablename__ = "topic_deep_dives"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("topic_deep_dive_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    summary = Column(Text, nullable=True)
+    subtopics = Column(JSON, nullable=True)
+    # [{"name": "...", "description": "...", "post_count": N}]
+    common_questions = Column(JSON, nullable=True)
+    # [{"question": "...", "frequency": "high|medium|low", "example_context": "..."}]
+    sentiment = Column(JSON, nullable=True)
+    # {"overall": "positive|negative|neutral|mixed", "positive_ratio": 0.6,
+    #  "negative_ratio": 0.2, "neutral_ratio": 0.2,
+    #  "highlights": [{"text": "...", "sentiment": "positive", "source": "r/sub"}]}
+    mentioned_products = Column(JSON, nullable=True)
+    # [{"name": "...", "category": "tool|service|brand", "sentiment": "positive",
+    #   "mention_count": N, "context": "..."}]
+    representative_posts = Column(JSON, nullable=True)
+    # [{"title": "...", "subreddit": "...", "score": N, "permalink": "...", "excerpt": "..."}]
+    actionable_insights = Column(JSON, nullable=True)
+    # [{"insight": "...", "type": "opportunity|gap|trend|warning", "confidence": "high|medium|low"}]
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    analysis = relationship("TopicDeepDiveAnalysis", back_populates="deep_dive")

--- a/app/modules/topic_deep_dive/infra/repositories/topic_deep_dive_repository.py
+++ b/app/modules/topic_deep_dive/infra/repositories/topic_deep_dive_repository.py
@@ -1,0 +1,148 @@
+import hashlib
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.topic_deep_dive.domain.entities.topic_deep_dive import (
+    TopicDeepDive,
+    TopicDeepDiveAnalysis,
+)
+
+
+class TopicDeepDiveRepository:
+    """Repositório para operações com análises de deep dive de tópicos."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def generate_fingerprint(topic_id: UUID, community_names: list[str]) -> str:
+        """Gera fingerprint SHA256 do tópico + comunidades."""
+        sorted_names = sorted(n.lower() for n in community_names)
+        content = f"{topic_id}:" + ":".join(sorted_names)
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def find_latest_by_topic(self, topic_id: UUID) -> TopicDeepDiveAnalysis | None:
+        """Busca a análise mais recente de deep dive (qualquer status)."""
+        return (
+            self.db.query(TopicDeepDiveAnalysis)
+            .filter(TopicDeepDiveAnalysis.topic_id == topic_id)
+            .order_by(TopicDeepDiveAnalysis.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, topic_id: UUID, fingerprint: str
+    ) -> TopicDeepDiveAnalysis | None:
+        """Busca análise por fingerprint (mesma composição)."""
+        return (
+            self.db.query(TopicDeepDiveAnalysis)
+            .filter(
+                TopicDeepDiveAnalysis.topic_id == topic_id,
+                TopicDeepDiveAnalysis.topic_fingerprint == fingerprint,
+                TopicDeepDiveAnalysis.status.in_(["ready", "processing"]),
+            )
+            .order_by(TopicDeepDiveAnalysis.created_at.desc())
+            .first()
+        )
+
+    def create_analysis(
+        self, topic_id: UUID, audience_id: UUID, fingerprint: str
+    ) -> TopicDeepDiveAnalysis:
+        """Cria um novo registro de análise com status 'processing'."""
+        analysis = TopicDeepDiveAnalysis(
+            topic_id=topic_id,
+            audience_id=audience_id,
+            topic_fingerprint=fingerprint,
+            status="processing",
+        )
+        self.db.add(analysis)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_ready(self, analysis_id: UUID) -> TopicDeepDiveAnalysis | None:
+        """Marca análise como pronta."""
+        analysis = (
+            self.db.query(TopicDeepDiveAnalysis)
+            .filter(TopicDeepDiveAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "ready"
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_failed(
+        self, analysis_id: UUID, error_message: str
+    ) -> TopicDeepDiveAnalysis | None:
+        """Marca análise como falha."""
+        analysis = (
+            self.db.query(TopicDeepDiveAnalysis)
+            .filter(TopicDeepDiveAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "failed"
+        analysis.error_message = error_message
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def save_deep_dive(self, analysis_id: UUID, data: dict) -> TopicDeepDive:
+        """Salva resultado do deep dive."""
+        deep_dive = TopicDeepDive(
+            analysis_id=analysis_id,
+            summary=data.get("summary"),
+            subtopics=data.get("subtopics"),
+            common_questions=data.get("common_questions"),
+            sentiment=data.get("sentiment"),
+            mentioned_products=data.get("mentioned_products"),
+            representative_posts=data.get("representative_posts"),
+            actionable_insights=data.get("actionable_insights"),
+        )
+        self.db.add(deep_dive)
+        self.db.commit()
+        self.db.refresh(deep_dive)
+        return deep_dive
+
+    def get_deep_dive(self, analysis_id: UUID) -> TopicDeepDive | None:
+        """Busca o deep dive de uma análise."""
+        return (
+            self.db.query(TopicDeepDive)
+            .filter(TopicDeepDive.analysis_id == analysis_id)
+            .first()
+        )
+
+    def delete_old_analyses(self, topic_id: UUID, keep_latest: int = 2) -> int:
+        """Remove análises antigas, mantendo as N mais recentes."""
+        latest_ids = (
+            self.db.query(TopicDeepDiveAnalysis.id)
+            .filter(TopicDeepDiveAnalysis.topic_id == topic_id)
+            .order_by(TopicDeepDiveAnalysis.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(TopicDeepDiveAnalysis)
+            .filter(
+                TopicDeepDiveAnalysis.topic_id == topic_id,
+                TopicDeepDiveAnalysis.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -8,6 +8,7 @@ from app.routes.audience_topics import router as audience_topics_router
 from app.routes.audience_keywords import router as audience_keywords_router
 from app.routes.similar_communities import router as similar_communities_router
 from app.routes.communities import router as communities_router
+from app.routes.topic_deep_dive import router as topic_deep_dive_router
 
 __all__ = [
     "auth_router",
@@ -18,4 +19,5 @@ __all__ = [
     "audience_keywords_router",
     "similar_communities_router",
     "communities_router",
+    "topic_deep_dive_router",
 ]

--- a/app/routes/topic_deep_dive.py
+++ b/app/routes/topic_deep_dive.py
@@ -1,0 +1,157 @@
+"""Routes for topic deep dive analysis (Browse All)."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.modules.topic_deep_dive.application.use_cases.trigger_deep_dive_use_case import (
+    TriggerDeepDiveUseCase,
+)
+from app.modules.topic_deep_dive.infra.repositories.topic_deep_dive_repository import (
+    TopicDeepDiveRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+
+router = APIRouter(prefix="/audiences", tags=["Topic Deep Dive"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
+TOPIC_NOT_FOUND = "Topic not found"
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuário é dono da audiência ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+@router.get("/{audience_id}/topics/{topic_id}/deep-dive")
+def get_topic_deep_dive(
+    audience_id: UUID,
+    topic_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Retorna a análise de deep dive de um tópico.
+
+    Se não existe análise, retorna status 'no_analysis'.
+    Se está em processamento, retorna status 'processing'.
+    Se está pronta, retorna os dados completos.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    # Verificar se o tópico existe
+    topic_repo = AudienceTopicRepository(db)
+    topic = topic_repo.get_topic_by_id(topic_id)
+    if not topic:
+        raise HTTPException(status_code=404, detail=TOPIC_NOT_FOUND)
+
+    deep_dive_repo = TopicDeepDiveRepository(db)
+    latest = deep_dive_repo.find_latest_by_topic(topic_id)
+
+    if not latest:
+        return {
+            "status": "no_analysis",
+            "message": "Nenhuma análise de deep dive encontrada. Clique em 'Browse All' para iniciar.",
+            "topic_id": str(topic_id),
+            "topic_name": topic.name,
+        }
+
+    if latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Análise de deep dive em andamento. Tente novamente em alguns minutos.",
+            "analysis_id": str(latest.id),
+            "topic_id": str(topic_id),
+            "topic_name": topic.name,
+        }
+
+    if latest.status == "failed":
+        return {
+            "status": "failed",
+            "message": f"Análise falhou: {latest.error_message or 'erro desconhecido'}",
+            "analysis_id": str(latest.id),
+            "topic_id": str(topic_id),
+            "topic_name": topic.name,
+        }
+
+    # Status ready — buscar deep dive
+    deep_dive = deep_dive_repo.get_deep_dive(latest.id)
+    if not deep_dive:
+        return {
+            "status": "failed",
+            "message": "Análise marcada como pronta mas sem dados.",
+            "analysis_id": str(latest.id),
+            "topic_id": str(topic_id),
+            "topic_name": topic.name,
+        }
+
+    return {
+        "status": "ready",
+        "analysis_id": str(latest.id),
+        "topic_id": str(topic_id),
+        "topic_name": topic.name,
+        "completed_at": latest.completed_at.isoformat() if latest.completed_at else None,
+        "summary": deep_dive.summary,
+        "subtopics": deep_dive.subtopics,
+        "common_questions": deep_dive.common_questions,
+        "sentiment": deep_dive.sentiment,
+        "mentioned_products": deep_dive.mentioned_products,
+        "representative_posts": deep_dive.representative_posts,
+        "actionable_insights": deep_dive.actionable_insights,
+    }
+
+
+@router.post("/{audience_id}/topics/{topic_id}/deep-dive/refresh", status_code=202)
+def refresh_topic_deep_dive(
+    audience_id: UUID,
+    topic_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Força reprocessamento da análise de deep dive.
+    Útil quando o usuário quer dados atualizados.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    # Verificar se o tópico existe
+    topic_repo = AudienceTopicRepository(db)
+    topic = topic_repo.get_topic_by_id(topic_id)
+    if not topic:
+        raise HTTPException(status_code=404, detail=TOPIC_NOT_FOUND)
+
+    # Verificar se já há uma análise em processamento
+    deep_dive_repo = TopicDeepDiveRepository(db)
+    latest = deep_dive_repo.find_latest_by_topic(topic_id)
+    if latest and latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Já existe uma análise em andamento.",
+            "analysis_id": str(latest.id),
+        }
+
+    trigger = TriggerDeepDiveUseCase(db)
+    result = trigger.execute(topic_id, audience_id, force=True)
+
+    return result

--- a/docs/issue-38-topic-deep-dive.md
+++ b/docs/issue-38-topic-deep-dive.md
@@ -1,0 +1,218 @@
+# Issue #38 — Topic Deep Dive (Browse All)
+
+## Motivacao
+
+O sistema ja possuia extracao de topicos por audiencia (Issue #29), que identifica temas recorrentes nos posts das comunidades com nome, descricao, frequencia e crescimento estimado. Porem, essa analise era **superficial** — equivalente a ler manchetes sem ler as materias. O usuario sabia *quais* temas existiam, mas nao entendia *o que* estava sendo discutido dentro deles.
+
+### Cenario do usuario
+
+O usuario tem uma audiencia "Marketing" com comunidades como r/digital_marketing e r/DigitalMarketing. Na aba Topics, ele ve o topico "AI in Marketing" com +100% de crescimento. Ao clicar em **Browse All**, ele quer entender: quais sao as facetas desse tema? Quais perguntas as pessoas fazem? Qual o sentimento geral? Quais ferramentas sao mencionadas? O que posso fazer com essa informacao?
+
+---
+
+## Solucao Adotada
+
+### Abordagem: Analise sob demanda com background thread
+
+Diferente dos topicos (que sao extraidos automaticamente quando as comunidades mudam), o deep dive e disparado **sob demanda** — apenas quando o usuario clica em "Browse All". Isso evita custo desnecessario de LLM, ja que nem todo topico sera explorado.
+
+```
+POST /audiences/{id}/topics/{topic_id}/deep-dive/refresh
+    → TriggerDeepDiveUseCase
+        → Gera fingerprint (SHA256 do topic_id + comunidades)
+        → Ja existe analise com mesmo fingerprint? → Retorna status
+        → Cria analise (status: "processing")
+        → threading.Thread(daemon=True)
+            → ExtractDeepDiveUseCase
+                → Coleta posts das comunidades do topico (Reddit API)
+                → Filtra posts relevantes por keywords do topico
+                → Busca top comentarios dos 10 posts mais relevantes
+                → LangGraph: analyze_deep_dive → extract_representative_posts
+                → Salva resultado no banco → status: "ready"
+
+GET /audiences/{id}/topics/{topic_id}/deep-dive
+    → Busca analise mais recente
+    → "ready"      → retorna dados completos
+    → "processing" → retorna {status: "processing"}
+    → "failed"     → retorna erro
+    → nenhuma      → retorna {status: "no_analysis"}
+```
+
+### Decisoes arquiteturais
+
+1. **Sob demanda vs. automatico:** O deep dive so roda quando o usuario solicita. Com 200 topicos possiveis, rodar automaticamente seria caro (200 x 2 chamadas LLM + 200 x 10 requests de comentarios ao Reddit).
+
+2. **Coleta de comentarios:** Alem dos posts, o deep dive busca os top 20 comentarios dos 10 posts mais engajados. Os comentarios sao onde as pessoas revelam dores reais, recomendam produtos e discordam — informacoes que nao aparecem nos titulos.
+
+3. **Filtragem por relevancia:** Posts sao filtrados por keywords extraidas do nome e descricao do topico antes de enviar ao LLM. Isso reduz ruido e melhora a qualidade da analise.
+
+4. **LangGraph com 2 nos:** No 1 faz a analise profunda (summary, subtopics, FAQs, sentiment, products, insights). No 2 seleciona posts representativos. Separados para manter cada prompt focado.
+
+5. **JSON estruturado:** O LLM retorna JSON puro, parseado e persistido em colunas JSON no PostgreSQL. Isso permite ao frontend consumir cada secao independentemente.
+
+6. **Prefixo r/ nas comunidades:** Os nomes das comunidades armazenados nos topicos incluem "r/" (ex: "r/digital_marketing"). O use case faz `removeprefix("r/")` antes de chamar a Reddit API.
+
+---
+
+## Arquivos Criados
+
+### `app/modules/topic_deep_dive/domain/entities/topic_deep_dive.py`
+- Entidade `TopicDeepDiveAnalysis` — tabela `topic_deep_dive_analyses` (id, topic_id, audience_id, status, topic_fingerprint, error_message, timestamps)
+- Entidade `TopicDeepDive` — tabela `topic_deep_dives` (id, analysis_id, summary, subtopics JSON, common_questions JSON, sentiment JSON, mentioned_products JSON, representative_posts JSON, actionable_insights JSON)
+
+### `alembic/versions/d0e1f2a3b4c5_add_topic_deep_dive.py`
+- Migration criando as duas tabelas com FKs CASCADE para `audience_topics` e `audiences`
+
+### `app/modules/topic_deep_dive/infra/repositories/topic_deep_dive_repository.py`
+- `generate_fingerprint()` — SHA256 do topic_id + comunidades ordenadas
+- `find_latest_by_topic()`, `find_by_fingerprint()` — queries para cache/invalidacao
+- `create_analysis()`, `mark_ready()`, `mark_failed()` — ciclo de vida da analise
+- `save_deep_dive()` — salva resultado do deep dive
+- `get_deep_dive()` — busca resultado por analysis_id
+- `delete_old_analyses()` — limpeza, mantem as 2 mais recentes
+
+### `app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/`
+- `state.py` — `DeepDiveState` com `PostWithComments` e `DeepDiveResult`
+- `prompts/deep_dive_prompts.py` — `deep_dive_analysis_prompt()` e `select_representative_posts_prompt()`
+- `deep_dive_agent.py` — Agente LangGraph com 2 nos: `analyze_deep_dive` → `extract_representative_posts`
+
+### `app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/extract_deep_dive_use_case.py`
+- Orquestrador: coleta posts → filtra por relevancia → busca comentarios → roda agente → salva → marca ready
+- `_extract_topic_keywords()` — extrai keywords do nome e descricao do topico
+- `_filter_relevant_posts()` — filtra posts que contem keywords
+
+### `app/modules/topic_deep_dive/application/use_cases/trigger_deep_dive_use_case.py`
+- Verifica fingerprint, cria analise, dispara `ExtractDeepDiveUseCase` em `threading.Thread(daemon=True)` com `SessionLocal()` propria
+
+### `app/routes/topic_deep_dive.py`
+- `GET /audiences/{id}/topics/{topic_id}/deep-dive` — consulta deep dive
+- `POST /audiences/{id}/topics/{topic_id}/deep-dive/refresh` — dispara analise (202)
+
+### `topic-deep-dive.rest`
+- Arquivo REST Client com todos os endpoints documentados, exemplos de resposta e cenarios de erro
+
+---
+
+## Arquivos Modificados
+
+### `app/main.py`
+- Registro do `topic_deep_dive_router`
+
+### `app/routes/__init__.py`
+- Import e export do `topic_deep_dive_router`
+
+### `alembic/env.py`
+- Import da entidade `topic_deep_dive` para autogenerate
+
+---
+
+## Estrutura de Dados Retornada
+
+Quando `status = "ready"`, o endpoint retorna:
+
+```json
+{
+  "status": "ready",
+  "analysis_id": "uuid",
+  "topic_id": "uuid",
+  "topic_name": "AI in Marketing",
+  "completed_at": "2026-02-22T13:26:54Z",
+  "summary": "The topic of AI in Marketing has gained significant traction...",
+  "subtopics": [
+    {"name": "AI Tools and Automation", "description": "Exploration of...", "post_count": 12},
+    {"name": "Job Security Concerns", "description": "Discussions around...", "post_count": 8}
+  ],
+  "common_questions": [
+    {"question": "Is AI taking our jobs?", "frequency": "high", "example_context": "..."},
+    {"question": "What AI tools should I learn?", "frequency": "medium", "example_context": "..."}
+  ],
+  "sentiment": {
+    "overall": "mixed",
+    "positive_ratio": 0.45,
+    "negative_ratio": 0.25,
+    "neutral_ratio": 0.30,
+    "highlights": [
+      {"text": "AI changes how we work, not why the work exists.", "sentiment": "positive", "source": "r/digital_marketing"}
+    ]
+  },
+  "mentioned_products": [
+    {"name": "Blobr AI", "category": "tool", "sentiment": "positive", "mention_count": 3, "context": "..."}
+  ],
+  "representative_posts": [
+    {"title": "AI is NOT taking our jobs.", "subreddit": "digital_marketing", "score": 94, "permalink": "...", "excerpt": "..."}
+  ],
+  "actionable_insights": [
+    {"insight": "Marketers should embrace AI tools...", "type": "opportunity", "confidence": "high"},
+    {"insight": "There is a growing need for educational resources...", "type": "gap", "confidence": "medium"}
+  ]
+}
+```
+
+---
+
+## Como Testar
+
+### Teste 1 — Consultar deep dive (nenhuma analise existe)
+
+```http
+GET /audiences/{audience_id}/topics/{topic_id}/deep-dive
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "no_analysis", message: "Nenhuma análise de deep dive encontrada..."}`
+
+### Teste 2 — Disparar deep dive
+
+```http
+POST /audiences/{audience_id}/topics/{topic_id}/deep-dive/refresh
+Authorization: Bearer <token>
+```
+
+**Esperado:** Status 202. `{status: "processing", message: "Análise de deep dive iniciada...", analysis_id: "uuid"}`
+
+### Teste 3 — Consultar durante processamento
+
+```http
+GET /audiences/{audience_id}/topics/{topic_id}/deep-dive
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "processing", message: "Análise em andamento..."}`
+
+### Teste 4 — Consultar apos ~2-3 minutos
+
+```http
+GET /audiences/{audience_id}/topics/{topic_id}/deep-dive
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "ready", summary: "...", subtopics: [...], ...}` com todos os campos preenchidos.
+
+### Teste 5 — Topico inexistente
+
+```http
+GET /audiences/{audience_id}/topics/00000000-0000-0000-0000-000000000000/deep-dive
+Authorization: Bearer <token>
+```
+
+**Esperado:** Status 404. `{detail: "Topic not found"}`
+
+---
+
+## Relacao com Outras Issues
+
+| Issue | Relacao |
+|-------|---------|
+| #29 — Audience Topic Analysis | Base: deep dive analisa um topico extraido pela Issue #29 |
+| #32 — Search Keywords | Mesmo padrao de modulo DDD + LangGraph + background thread |
+| #17 — Audience User Ownership | Reutiliza `_check_ownership` nas rotas |
+
+---
+
+## Melhorias Futuras (Fora do Escopo)
+
+- **Cache de posts:** Armazenar posts coletados para evitar re-coleta ao rodar deep dive em multiplos topicos
+- **Modelo mais poderoso:** Usar gpt-4o ao inves de gpt-4o-mini para analises mais sofisticadas
+- **Historico de deep dives:** Comparar deep dives ao longo do tempo para detectar evolucao
+- **Deep dive automatico:** Disparar automaticamente para os top 5 topicos por crescimento
+- **Export:** Permitir exportar o deep dive como PDF ou markdown

--- a/topic-deep-dive.rest
+++ b/topic-deep-dive.rest
@@ -1,0 +1,144 @@
+###############################################################################
+# Topic Deep Dive (Browse All)
+#
+# Análise profunda de um tópico específico da audiência.
+# Quando o usuário clica em "Browse All" na UI, dispara uma análise
+# que retorna: summary, subtopics, FAQs, sentiment, products, insights.
+#
+# FLUXO:
+#   1. GET  /deep-dive          → primeira vez retorna "no_analysis"
+#   2. POST /deep-dive/refresh  → dispara análise em background (202)
+#   3. GET  /deep-dive          → durante processamento retorna "processing"
+#   4. GET  /deep-dive          → após ~2-3min retorna "ready" com dados
+#
+# NOTA: A análise é sob demanda (não automática). Só roda quando o
+#       usuário solicita via POST refresh.
+###############################################################################
+
+@base_url = http://localhost:8000
+@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiNWYzOTZhOC1iYmU2LTRkOWItOGI5OS1jMGE1ZTc3ZjgwNzEiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcxNzA1MTA4fQ.fdFgKKP9QH2Aan5ZDvXagzii8YTOLYo-bFO6RYb6cN8
+
+# IDs de exemplo — substitua pelos seus
+@audience_id = e9458348-6cad-4ba6-bf3e-87674d035613
+@topic_id = 13129258-589b-4c3a-b7ab-aaf8f7d46346
+
+###############################################################################
+# 1. CONSULTAR DEEP DIVE DE UM TÓPICO
+###############################################################################
+
+### Consultar deep dive (primeira vez → status: "no_analysis")
+# Retorna o estado atual da análise de deep dive do tópico.
+#
+# Respostas possíveis:
+#   - "no_analysis": Nenhuma análise existe. Use POST /refresh para iniciar.
+#   - "processing":  Análise em andamento. Aguarde 2-3 minutos.
+#   - "ready":       Análise pronta. Retorna dados completos (ver abaixo).
+#   - "failed":      Análise falhou. Verifique error_message.
+#
+# Quando status = "ready", os campos retornados são:
+#   - summary:              Resumo executivo (2-3 parágrafos)
+#   - subtopics:            [{name, description, post_count}]
+#   - common_questions:     [{question, frequency, example_context}]
+#   - sentiment:            {overall, positive_ratio, negative_ratio, neutral_ratio, highlights[]}
+#   - mentioned_products:   [{name, category, sentiment, mention_count, context}]
+#   - representative_posts: [{title, subreddit, score, permalink, excerpt}]
+#   - actionable_insights:  [{insight, type, confidence}]
+#
+GET {{base_url}}/audiences/{{audience_id}}/topics/{{topic_id}}/deep-dive
+content-type: application/json
+Authorization: Bearer {{token}}
+
+###############################################################################
+# 2. DISPARAR ANÁLISE DE DEEP DIVE
+###############################################################################
+
+### Disparar deep dive (status: 202 Accepted)
+# Cria uma nova análise e a processa em background.
+# Se já existe uma análise em processamento, retorna o status sem criar outra.
+#
+# O processamento envolve:
+#   1. Coleta de posts das comunidades do tópico (~50 posts)
+#   2. Filtragem por relevância ao tópico (keywords matching)
+#   3. Coleta de comentários dos top 10 posts (20 comments cada)
+#   4. Análise profunda via LLM (summary, subtopics, FAQs, sentiment, products)
+#   5. Seleção de posts representativos via LLM
+#
+# Tempo estimado: ~2-3 minutos (depende do rate limiting do Reddit)
+#
+# Resposta:
+#   {status: "processing", message: "...", analysis_id: "uuid"}
+#
+POST {{base_url}}/audiences/{{audience_id}}/topics/{{topic_id}}/deep-dive/refresh
+content-type: application/json
+Authorization: Bearer {{token}}
+
+###############################################################################
+# 3. CONSULTAR DEEP DIVE APÓS PROCESSAMENTO
+###############################################################################
+
+### Consultar deep dive (após ~2-3min → status: "ready")
+# Mesma chamada do passo 1. Quando a análise termina, retorna os dados.
+#
+# Exemplo de resposta (resumido):
+# {
+#   "status": "ready",
+#   "topic_name": "AI in Marketing",
+#   "summary": "The topic of AI in Marketing has gained significant...",
+#   "subtopics": [
+#     {"name": "AI Tools and Automation", "description": "...", "post_count": 12},
+#     {"name": "Job Security Concerns", "description": "...", "post_count": 8}
+#   ],
+#   "common_questions": [
+#     {"question": "Is AI taking our jobs?", "frequency": "high", "example_context": "..."}
+#   ],
+#   "sentiment": {
+#     "overall": "mixed",
+#     "positive_ratio": 0.45,
+#     "negative_ratio": 0.25,
+#     "neutral_ratio": 0.30,
+#     "highlights": [{"text": "AI changes how we work...", "sentiment": "positive", "source": "r/..."}]
+#   },
+#   "mentioned_products": [
+#     {"name": "ChatGPT", "category": "tool", "sentiment": "positive", "mention_count": 5, "context": "..."}
+#   ],
+#   "representative_posts": [
+#     {"title": "How AI Is Reshaping...", "subreddit": "digital_marketing", "score": 94, "permalink": "...", "excerpt": "..."}
+#   ],
+#   "actionable_insights": [
+#     {"insight": "Marketers should embrace AI tools...", "type": "opportunity", "confidence": "high"}
+#   ]
+# }
+#
+GET {{base_url}}/audiences/{{audience_id}}/topics/{{topic_id}}/deep-dive
+content-type: application/json
+Authorization: Bearer {{token}}
+
+###############################################################################
+# 4. TESTAR COM OUTROS TÓPICOS
+###############################################################################
+
+### Listar tópicos disponíveis (para pegar topic_id)
+# Use este endpoint para descobrir os topic_ids disponíveis.
+# Pegue o "id" de qualquer tópico e substitua em @topic_id acima.
+#
+GET {{base_url}}/audiences/{{audience_id}}/topics?limit=10&offset=0
+content-type: application/json
+Authorization: Bearer {{token}}
+
+###############################################################################
+# 5. CENÁRIOS DE ERRO
+###############################################################################
+
+### Tópico inexistente (→ 404)
+GET {{base_url}}/audiences/{{audience_id}}/topics/00000000-0000-0000-0000-000000000000/deep-dive
+content-type: application/json
+Authorization: Bearer {{token}}
+
+### Audiência inexistente (→ 404)
+GET {{base_url}}/audiences/00000000-0000-0000-0000-000000000000/topics/{{topic_id}}/deep-dive
+content-type: application/json
+Authorization: Bearer {{token}}
+
+### Sem autenticação (→ 401)
+GET {{base_url}}/audiences/{{audience_id}}/topics/{{topic_id}}/deep-dive
+content-type: application/json


### PR DESCRIPTION
## Summary
- Add on-demand deep dive analysis for individual audience topics (Browse All button)
- New LangGraph agent collects posts + comments from Reddit and produces structured analysis: summary, subtopics, FAQs, sentiment, mentioned products, representative posts, and actionable insights
- New module `topic_deep_dive` following existing DDD pattern with background thread processing

## Endpoints
- `GET /audiences/{id}/topics/{topic_id}/deep-dive` — query analysis status/results
- `POST /audiences/{id}/topics/{topic_id}/deep-dive/refresh` — trigger analysis (202)

## Test plan
- [ ] `GET /deep-dive` returns `no_analysis` when no analysis exists
- [ ] `POST /deep-dive/refresh` returns `202` and triggers background analysis
- [ ] `GET /deep-dive` returns `processing` while analysis runs
- [ ] `GET /deep-dive` returns `ready` with full data after ~2-3 minutes
- [ ] 404 for non-existent topic/audience
- [ ] 401 without auth token
- [ ] 403 for non-owner user (unless superuser)