### PR TITLE
feat: multi-language support for LLM analysis responses

### DIFF
--- a/alembic/versions/a0b1c2d3e4f5_add_preferred_language_to_users.py
+++ b/alembic/versions/a0b1c2d3e4f5_add_preferred_language_to_users.py
@@ -1,0 +1,28 @@
+"""add preferred_language to users
+
+Revision ID: a0b1c2d3e4f5
+Revises: 9e2a609b8ef4
+Create Date: 2026-02-22
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a0b1c2d3e4f5"
+down_revision: Union[str, None] = "9e2a609b8ef4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("preferred_language", sa.String(10), nullable=False, server_default="en"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "preferred_language")

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/keyword_extraction_agent.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/keyword_extraction_agent.py
@@ -37,6 +37,7 @@ def extract_keywords(state: KeywordExtractionState) -> dict:
         community_names=state["community_names"],
         community_descriptions=state.get("community_descriptions", []),
         topics_summary=state.get("topics_summary"),
+        language=state.get("language", "en"),
     )
 
     response = llm.invoke(prompt)

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/prompts/keyword_extraction_prompts.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/prompts/keyword_extraction_prompts.py
@@ -1,9 +1,13 @@
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
 def extract_keywords_prompt(
     audience_name: str,
     audience_description: str | None,
     community_names: list[str],
     community_descriptions: list[str],
     topics_summary: str | None,
+    language: str = "en",
 ) -> str:
     communities_str = ", ".join(f"r/{name}" for name in community_names)
     desc_line = f"\nAudience description: {audience_description}" if audience_description else ""
@@ -21,7 +25,7 @@ def extract_keywords_prompt(
     if topics_summary:
         topics_block = f"\n\nTrending topics already identified in this audience:\n{topics_summary}"
 
-    return f"""You are an expert Reddit analyst specializing in audience research and keyword discovery.
+    prompt = f"""You are an expert Reddit analyst specializing in audience research and keyword discovery.
 
 Audience: "{audience_name}"{desc_line}
 Communities: {communities_str}{descriptions_block}{topics_block}
@@ -63,3 +67,5 @@ IMPORTANT:
 - Include a mix of short phrases (2-3 words) and longer search queries (4-6 words)
 - Focus on terms that reveal user intent (buying, learning, solving, comparing)
 - Do NOT include any other text, headers, or numbering. Just the pipe-delimited lines."""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/state.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/state.py
@@ -14,6 +14,7 @@ class KeywordExtractionState(TypedDict):
     community_names: list[str]
     community_descriptions: list[str]
     topics_summary: str | None
+    language: str
 
     # Populated by nodes
     extracted_keywords: list[ExtractedKeyword]

--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/extract_keywords_use_case.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/extract_keywords_use_case.py
@@ -37,13 +37,14 @@ class ExtractKeywordsUseCase:
         self.topic_repo = AudienceTopicRepository(db)
         self.reddit_provider = GenericRedditProvider()
 
-    def execute(self, audience_id: UUID, analysis_id: UUID) -> bool:
+    def execute(self, audience_id: UUID, analysis_id: UUID, language: str = "en") -> bool:
         """
         Executa a extração completa de keywords.
 
         Args:
             audience_id: ID da audiência
             analysis_id: ID da análise já criada (status: processing)
+            language: Idioma preferido do usuário
 
         Returns:
             True se concluiu com sucesso
@@ -81,6 +82,7 @@ class ExtractKeywordsUseCase:
                 "community_names": community_names,
                 "community_descriptions": community_descriptions,
                 "topics_summary": topics_summary,
+                "language": language,
                 "extracted_keywords": [],
             })
 

--- a/app/modules/audience_keywords/application/use_cases/trigger_keyword_analysis_use_case.py
+++ b/app/modules/audience_keywords/application/use_cases/trigger_keyword_analysis_use_case.py
@@ -27,7 +27,7 @@ class TriggerKeywordAnalysisUseCase:
         self.audience_repo = AudienceRepository(db)
         self.keyword_repo = AudienceKeywordRepository(db)
 
-    def execute(self, audience_id: UUID) -> None:
+    def execute(self, audience_id: UUID, language: str = "en") -> None:
         """
         Verifica e dispara análise se necessário.
         Não bloqueia — retorna imediatamente.
@@ -61,9 +61,9 @@ class TriggerKeywordAnalysisUseCase:
         )
 
         # Disparar em background
-        self._run_in_background(audience_id, analysis.id)
+        self._run_in_background(audience_id, analysis.id, language)
 
-    def _run_in_background(self, audience_id: UUID, analysis_id: UUID) -> None:
+    def _run_in_background(self, audience_id: UUID, analysis_id: UUID, language: str = "en") -> None:
         """Dispara extração de keywords em background thread."""
         from app.modules.shared.infra.database.database import SessionLocal
 
@@ -75,7 +75,7 @@ class TriggerKeywordAnalysisUseCase:
                 )
 
                 use_case = ExtractKeywordsUseCase(db)
-                use_case.execute(audience_id, analysis_id)
+                use_case.execute(audience_id, analysis_id, language=language)
             except Exception:
                 logger.exception(
                     "Background keyword extraction failed for audience %s", audience_id

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/prompts/topic_extraction_prompts.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/prompts/topic_extraction_prompts.py
@@ -1,14 +1,18 @@
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
 def extract_topics_prompt(
     audience_name: str,
     audience_description: str | None,
     community_names: list[str],
     posts_text: str,
     total_posts: int,
+    language: str = "en",
 ) -> str:
     communities_str = ", ".join(f"r/{name}" for name in community_names)
     desc_line = f"\nAudience description: {audience_description}" if audience_description else ""
 
-    return f"""You are an expert Reddit analyst specializing in trend detection and topic extraction.
+    prompt = f"""You are an expert Reddit analyst specializing in trend detection and topic extraction.
 
 Audience: "{audience_name}"{desc_line}
 Communities: {communities_str}
@@ -45,12 +49,15 @@ Health issues|Physical or mental conditions affecting pets that require attentio
 
 Do NOT include any other text, headers, or numbering. Just the pipe-delimited lines."""
 
+    return prompt + get_language_directive(language)
+
 
 def estimate_growth_prompt(
     topics_text: str,
     audience_name: str,
+    language: str = "en",
 ) -> str:
-    return f"""You are an expert in Reddit trend analysis.
+    prompt = f"""You are an expert in Reddit trend analysis.
 
 Audience: "{audience_name}"
 
@@ -82,3 +89,5 @@ Health issues|400
 Training tips|150
 
 Do NOT include any other text. Just the pipe-delimited lines."""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/state.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/state.py
@@ -28,6 +28,7 @@ class TopicExtractionState(TypedDict):
     community_names: list[str]
     posts: list[PostData]
     total_posts: int
+    language: str
 
     # Populated by nodes
     extracted_topics: list[ExtractedTopic]

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/topic_extraction_agent.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/topic_extraction_agent.py
@@ -70,6 +70,7 @@ def extract_topics(state: TopicExtractionState) -> dict:
         community_names=state["community_names"],
         posts_text=posts_text,
         total_posts=state["total_posts"],
+        language=state.get("language", "en"),
     )
 
     response = llm.invoke(prompt)
@@ -156,7 +157,7 @@ def estimate_growth(state: TopicExtractionState) -> dict:
     topics_text = "\n".join(topics_lines)
 
     llm = _get_llm()
-    prompt = estimate_growth_prompt(topics_text, state["audience_name"])
+    prompt = estimate_growth_prompt(topics_text, state["audience_name"], language=state.get("language", "en"))
     response = llm.invoke(prompt)
 
     # Parse growth results

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/extract_topics_use_case.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/extract_topics_use_case.py
@@ -36,13 +36,14 @@ class ExtractTopicsUseCase:
         self.topic_repo = AudienceTopicRepository(db)
         self.reddit_provider = GenericRedditProvider()
 
-    def execute(self, audience_id: UUID, analysis_id: UUID) -> bool:
+    def execute(self, audience_id: UUID, analysis_id: UUID, language: str = "en") -> bool:
         """
         Executa a extração completa de tópicos.
 
         Args:
             audience_id: ID da audiência
             analysis_id: ID da análise já criada (status: processing)
+            language: Idioma preferido do usuário
 
         Returns:
             True se concluiu com sucesso
@@ -104,6 +105,7 @@ class ExtractTopicsUseCase:
                 "community_names": community_names,
                 "posts": posts,
                 "total_posts": len(posts),
+                "language": language,
                 "extracted_topics": [],
             })
 

--- a/app/modules/audience_topics/application/use_cases/trigger_topic_analysis_use_case.py
+++ b/app/modules/audience_topics/application/use_cases/trigger_topic_analysis_use_case.py
@@ -27,7 +27,7 @@ class TriggerTopicAnalysisUseCase:
         self.audience_repo = AudienceRepository(db)
         self.topic_repo = AudienceTopicRepository(db)
 
-    def execute(self, audience_id: UUID) -> None:
+    def execute(self, audience_id: UUID, language: str = "en") -> None:
         """
         Verifica e dispara análise se necessário.
         Não bloqueia — retorna imediatamente.
@@ -61,9 +61,9 @@ class TriggerTopicAnalysisUseCase:
         )
 
         # Disparar em background
-        self._run_in_background(audience_id, analysis.id)
+        self._run_in_background(audience_id, analysis.id, language)
 
-    def _run_in_background(self, audience_id: UUID, analysis_id: UUID) -> None:
+    def _run_in_background(self, audience_id: UUID, analysis_id: UUID, language: str = "en") -> None:
         """Dispara extração de tópicos em background thread."""
         from app.modules.shared.infra.database.database import SessionLocal
 
@@ -75,7 +75,7 @@ class TriggerTopicAnalysisUseCase:
                 )
 
                 use_case = ExtractTopicsUseCase(db)
-                use_case.execute(audience_id, analysis_id)
+                use_case.execute(audience_id, analysis_id, language=language)
             except Exception:
                 logger.exception(
                     "Background topic extraction failed for audience %s", audience_id

--- a/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/audience_expansion_agent.py
+++ b/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/audience_expansion_agent.py
@@ -33,7 +33,7 @@ def analyze_audience_theme(state: AudienceExpansionState) -> dict:
         return {"audience_theme": "General"}
 
     llm = _get_llm()
-    prompt = analyze_audience_theme_prompt(communities)
+    prompt = analyze_audience_theme_prompt(communities, language=state.get("language", "en"))
     response = llm.invoke(prompt)
 
     theme = "General"
@@ -90,7 +90,7 @@ def rank_and_explain(state: AudienceExpansionState) -> dict:
         return {"suggestions": []}
 
     llm = _get_llm()
-    prompt = rank_and_explain_prompt(state["audience_theme"], real_candidates)
+    prompt = rank_and_explain_prompt(state["audience_theme"], real_candidates, language=state.get("language", "en"))
     response = llm.invoke(prompt)
 
     # Build a lookup map from candidates

--- a/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/prompts/audience_expansion_prompts.py
+++ b/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/prompts/audience_expansion_prompts.py
@@ -1,10 +1,13 @@
-def analyze_audience_theme_prompt(communities: list[dict]) -> str:
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
+def analyze_audience_theme_prompt(communities: list[dict], language: str = "en") -> str:
     community_list = "\n".join(
         f"- r/{c['name']}: {c.get('title', 'N/A')} — {c.get('description', 'N/A')}"
         for c in communities
     )
 
-    return f"""You are an expert in Reddit communities and audience analysis.
+    prompt = f"""You are an expert in Reddit communities and audience analysis.
 
 Analyze this audience composed of the following communities:
 {community_list}
@@ -17,9 +20,11 @@ Respond in this exact format (no extra text):
 THEME: <one sentence describing the audience theme>
 TERMS: <5 search terms separated by comma>"""
 
+    return prompt + get_language_directive(language)
+
 
 def rank_and_explain_prompt(
-    audience_theme: str, candidates: list[dict]
+    audience_theme: str, candidates: list[dict], language: str = "en",
 ) -> str:
     candidate_list = "\n".join(
         f"- r/{c['name']} ({c.get('subscribers', 'N/A')} subscribers): "
@@ -27,7 +32,7 @@ def rank_and_explain_prompt(
         for c in candidates
     )
 
-    return f"""You are an expert in Reddit communities.
+    prompt = f"""You are an expert in Reddit communities.
 
 Audience theme: {audience_theme}
 
@@ -41,3 +46,5 @@ Respond with one line per community in this exact format (no extra text):
 r/<name>|<score>|<reason>
 
 Order from most to least relevant. Only include communities with score >= 0.3."""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/state.py
+++ b/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/state.py
@@ -36,6 +36,7 @@ class AudienceExpansionState(TypedDict):
     excluded_names: list[str]
     user_id: str
     limit: int
+    language: str
 
     # Populated by nodes
     audience_theme: str

--- a/app/modules/audiences/application/use_cases/expand_audience_use_case/expand_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/expand_audience_use_case/expand_audience_use_case.py
@@ -64,6 +64,7 @@ class ExpandAudienceUseCase:
         audience_id: UUID,
         user_id: str,
         limit: int = 10,
+        language: str = "en",
     ) -> AudienceExpansionResult:
         audience = self.audience_repo.find_by_id(audience_id)
         if not audience:
@@ -148,6 +149,7 @@ class ExpandAudienceUseCase:
             "excluded_names": excluded_names,
             "user_id": user_id,
             "limit": limit,
+            "language": language,
             "audience_theme": "",
             "candidates": candidates,
             "suggestions": [],

--- a/app/modules/identity/domain/entities/user.py
+++ b/app/modules/identity/domain/entities/user.py
@@ -20,6 +20,7 @@ class User(Base):
     full_name = Column(String(255), nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
     is_superuser = Column(Boolean, default=False, nullable=False)
+    preferred_language = Column(String(10), default="en", nullable=False, server_default="en")
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/app/modules/shared/application/helpers/language_directive.py
+++ b/app/modules/shared/application/helpers/language_directive.py
@@ -1,0 +1,36 @@
+"""Helper para injetar diretiva de idioma nos prompts dos agentes LLM."""
+
+SUPPORTED_LANGUAGES = {
+    "en": "English",
+    "pt-BR": "Brazilian Portuguese",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "zh": "Chinese",
+}
+
+
+def get_language_directive(language_code: str) -> str:
+    """Retorna bloco de instrução de idioma para concatenar ao final dos prompts.
+
+    Se o idioma for inglês, retorna string vazia (comportamento padrão).
+    """
+    if language_code == "en":
+        return ""
+
+    language_name = SUPPORTED_LANGUAGES.get(language_code, language_code)
+
+    return (
+        f"\n\nLANGUAGE INSTRUCTION: Write ALL text content "
+        f"(summaries, descriptions, insights, questions, analysis, "
+        f"recommendations, evidence excerpts, context) in {language_name}. "
+        f"Keep all JSON keys, field names, and enum values "
+        f"(like 'high', 'medium', 'low', 'positive', 'negative', 'neutral', "
+        f"'opportunity', 'gap', 'trend', 'warning', 'satisfied', 'mixed', "
+        f"'dissatisfied', 'common', 'moderate', 'rare', 'early', 'growing', "
+        f"'established', 'tool', 'service', 'brand', 'platform', 'resource') "
+        f"in English exactly as specified in the format above."
+    )

--- a/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/behavioral_pattern_agent.py
+++ b/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/behavioral_pattern_agent.py
@@ -21,7 +21,7 @@ MAX_COMMENT_LENGTH = 600
 
 def _get_llm() -> ChatOpenAI:
     return ChatOpenAI(
-        model=os.getenv("BEHAVIORAL_PATTERN_MODEL_NAME", "gpt-4"),
+        model=os.getenv("BEHAVIORAL_PATTERN_MODEL_NAME", "gpt-4o"),
         temperature=0,
     )
 
@@ -89,6 +89,7 @@ def detect_behavioral_patterns(state: BehavioralPatternState) -> dict:
         posts_with_comments_text=posts_text,
         total_posts=len(posts),
         total_comments=total_comments,
+        language=state.get("language", "en"),
     )
 
     response = llm.invoke(prompt)

--- a/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/prompts/behavioral_pattern_prompts.py
+++ b/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/prompts/behavioral_pattern_prompts.py
@@ -1,3 +1,6 @@
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
 def behavioral_pattern_detection_prompt(
     topic_name: str,
     topic_description: str,
@@ -6,10 +9,11 @@ def behavioral_pattern_detection_prompt(
     posts_with_comments_text: str,
     total_posts: int,
     total_comments: int,
+    language: str = "en",
 ) -> str:
     communities_str = ", ".join(f"r/{name}" for name in community_names)
 
-    return f"""You are an expert behavioral analyst specializing in detecting behavioral patterns from online community discussions.
+    prompt = f"""You are an expert behavioral analyst specializing in detecting behavioral patterns from online community discussions.
 
 Audience: "{audience_name}"
 Communities: {communities_str}
@@ -85,3 +89,5 @@ Respond ONLY with valid JSON. No markdown code blocks, no explanations outside t
 
 Example structure:
 {{"summary": "...", "tool_patterns": [...], "workaround_patterns": [...], "friction_patterns": [...], "shift_patterns": [...], "demand_signals": [...]}}"""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/state.py
+++ b/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/state.py
@@ -32,6 +32,7 @@ class BehavioralPatternState(TypedDict):
     topic_description: str
     audience_name: str
     community_names: list[str]
+    language: str
 
     # Populated by nodes
     relevant_posts: list[PostWithComments]

--- a/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/detect_behavioral_patterns_use_case.py
+++ b/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/detect_behavioral_patterns_use_case.py
@@ -43,7 +43,7 @@ class DetectBehavioralPatternsUseCase:
         self.pattern_repo = TopicBehavioralPatternRepository(db)
         self.reddit_provider = GenericRedditProvider()
 
-    def execute(self, topic_id: UUID, audience_id: UUID, analysis_id: UUID) -> bool:
+    def execute(self, topic_id: UUID, audience_id: UUID, analysis_id: UUID, language: str = "en") -> bool:
         """
         Executa a detecção de padrões comportamentais completa.
 
@@ -51,6 +51,7 @@ class DetectBehavioralPatternsUseCase:
             topic_id: ID do tópico
             audience_id: ID da audiência
             analysis_id: ID da análise já criada (status: processing)
+            language: Idioma preferido do usuário
 
         Returns:
             True se concluiu com sucesso
@@ -167,6 +168,7 @@ class DetectBehavioralPatternsUseCase:
                 "topic_description": topic.description or "",
                 "audience_name": audience.name,
                 "community_names": community_names,
+                "language": language,
                 "relevant_posts": posts_with_comments,
                 "pattern_result": None,
             })

--- a/app/modules/topic_behavioral_patterns/application/use_cases/trigger_behavioral_pattern_use_case.py
+++ b/app/modules/topic_behavioral_patterns/application/use_cases/trigger_behavioral_pattern_use_case.py
@@ -31,7 +31,7 @@ class TriggerBehavioralPatternUseCase:
         self.topic_repo = AudienceTopicRepository(db)
         self.pattern_repo = TopicBehavioralPatternRepository(db)
 
-    def execute(self, topic_id: UUID, audience_id: UUID, force: bool = False) -> dict:
+    def execute(self, topic_id: UUID, audience_id: UUID, force: bool = False, language: str = "en") -> dict:
         """
         Verifica e dispara análise de padrões comportamentais se necessário.
 
@@ -77,7 +77,7 @@ class TriggerBehavioralPatternUseCase:
             analysis.id,
         )
 
-        self._run_in_background(topic_id, audience_id, analysis.id)
+        self._run_in_background(topic_id, audience_id, analysis.id, language)
 
         return {
             "status": "processing",
@@ -86,7 +86,7 @@ class TriggerBehavioralPatternUseCase:
         }
 
     def _run_in_background(
-        self, topic_id: UUID, audience_id: UUID, analysis_id: UUID
+        self, topic_id: UUID, audience_id: UUID, analysis_id: UUID, language: str = "en",
     ) -> None:
         """Dispara detecção de padrões comportamentais em background thread."""
         from app.modules.shared.infra.database.database import SessionLocal
@@ -99,7 +99,7 @@ class TriggerBehavioralPatternUseCase:
                 )
 
                 use_case = DetectBehavioralPatternsUseCase(db)
-                use_case.execute(topic_id, audience_id, analysis_id)
+                use_case.execute(topic_id, audience_id, analysis_id, language=language)
             except Exception:
                 logger.exception(
                     "Background behavioral pattern analysis failed for topic %s", topic_id

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/deep_dive_agent.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/deep_dive_agent.py
@@ -114,6 +114,7 @@ def analyze_deep_dive(state: DeepDiveState) -> dict:
         posts_with_comments_text=posts_text,
         total_posts=len(posts),
         total_comments=total_comments,
+        language=state.get("language", "en"),
     )
 
     response = llm.invoke(prompt)
@@ -152,6 +153,7 @@ def extract_representative_posts(state: DeepDiveState) -> dict:
     prompt = select_representative_posts_prompt(
         topic_name=state["topic_name"],
         posts_text=posts_text,
+        language=state.get("language", "en"),
     )
 
     response = llm.invoke(prompt)

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/prompts/deep_dive_prompts.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/prompts/deep_dive_prompts.py
@@ -1,3 +1,6 @@
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
 def deep_dive_analysis_prompt(
     topic_name: str,
     topic_description: str,
@@ -6,10 +9,11 @@ def deep_dive_analysis_prompt(
     posts_with_comments_text: str,
     total_posts: int,
     total_comments: int,
+    language: str = "en",
 ) -> str:
     communities_str = ", ".join(f"r/{name}" for name in community_names)
 
-    return f"""You are an expert Reddit analyst performing a deep dive analysis on a specific topic.
+    prompt = f"""You are an expert Reddit analyst performing a deep dive analysis on a specific topic.
 
 Audience: "{audience_name}"
 Communities: {communities_str}
@@ -73,12 +77,15 @@ Respond ONLY with valid JSON. No markdown code blocks, no explanations outside t
 Example structure:
 {{"summary": "...", "subtopics": [...], "common_questions": [...], "sentiment": {{...}}, "mentioned_products": [...], "actionable_insights": [...]}}"""
 
+    return prompt + get_language_directive(language)
+
 
 def select_representative_posts_prompt(
     topic_name: str,
     posts_text: str,
+    language: str = "en",
 ) -> str:
-    return f"""You are selecting the most representative posts for the topic "{topic_name}".
+    prompt = f"""You are selecting the most representative posts for the topic "{topic_name}".
 
 Below are posts related to this topic:
 
@@ -103,3 +110,5 @@ Respond ONLY with a valid JSON array. No markdown code blocks.
 
 Example:
 [{{"title": "...", "subreddit": "...", "score": 123, "permalink": "/r/sub/comments/...", "excerpt": "..."}}]"""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/state.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/state.py
@@ -35,6 +35,7 @@ class DeepDiveState(TypedDict):
     topic_description: str
     audience_name: str
     community_names: list[str]
+    language: str
 
     # Populated by nodes
     relevant_posts: list[PostWithComments]

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/extract_deep_dive_use_case.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/extract_deep_dive_use_case.py
@@ -44,7 +44,7 @@ class ExtractDeepDiveUseCase:
         self.deep_dive_repo = TopicDeepDiveRepository(db)
         self.reddit_provider = GenericRedditProvider()
 
-    def execute(self, topic_id: UUID, audience_id: UUID, analysis_id: UUID) -> bool:
+    def execute(self, topic_id: UUID, audience_id: UUID, analysis_id: UUID, language: str = "en") -> bool:
         """
         Executa a análise de deep dive completa.
 
@@ -52,6 +52,7 @@ class ExtractDeepDiveUseCase:
             topic_id: ID do tópico
             audience_id: ID da audiência
             analysis_id: ID da análise já criada (status: processing)
+            language: Idioma preferido do usuário
 
         Returns:
             True se concluiu com sucesso
@@ -172,6 +173,7 @@ class ExtractDeepDiveUseCase:
                 "topic_description": topic.description or "",
                 "audience_name": audience.name,
                 "community_names": community_names,
+                "language": language,
                 "relevant_posts": posts_with_comments,
                 "deep_dive_result": None,
             })

--- a/app/modules/topic_deep_dive/application/use_cases/trigger_deep_dive_use_case.py
+++ b/app/modules/topic_deep_dive/application/use_cases/trigger_deep_dive_use_case.py
@@ -31,7 +31,7 @@ class TriggerDeepDiveUseCase:
         self.topic_repo = AudienceTopicRepository(db)
         self.deep_dive_repo = TopicDeepDiveRepository(db)
 
-    def execute(self, topic_id: UUID, audience_id: UUID, force: bool = False) -> dict:
+    def execute(self, topic_id: UUID, audience_id: UUID, force: bool = False, language: str = "en") -> dict:
         """
         Verifica e dispara deep dive se necessário.
 
@@ -81,7 +81,7 @@ class TriggerDeepDiveUseCase:
         )
 
         # Disparar em background
-        self._run_in_background(topic_id, audience_id, analysis.id)
+        self._run_in_background(topic_id, audience_id, analysis.id, language)
 
         return {
             "status": "processing",
@@ -90,7 +90,7 @@ class TriggerDeepDiveUseCase:
         }
 
     def _run_in_background(
-        self, topic_id: UUID, audience_id: UUID, analysis_id: UUID
+        self, topic_id: UUID, audience_id: UUID, analysis_id: UUID, language: str = "en",
     ) -> None:
         """Dispara extração de deep dive em background thread."""
         from app.modules.shared.infra.database.database import SessionLocal
@@ -103,7 +103,7 @@ class TriggerDeepDiveUseCase:
                 )
 
                 use_case = ExtractDeepDiveUseCase(db)
-                use_case.execute(topic_id, audience_id, analysis_id)
+                use_case.execute(topic_id, audience_id, analysis_id, language=language)
             except Exception:
                 logger.exception(
                     "Background deep dive failed for topic %s", topic_id

--- a/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/pattern_detection_agent.py
+++ b/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/pattern_detection_agent.py
@@ -130,6 +130,7 @@ def detect_patterns(state: PatternDetectionState) -> dict:
         total_topics=len(topics),
         total_posts=len(posts),
         total_comments=total_comments,
+        language=state.get("language", "en"),
     )
 
     response = llm.invoke(prompt)

--- a/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/prompts/pattern_detection_prompts.py
+++ b/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/prompts/pattern_detection_prompts.py
@@ -1,3 +1,6 @@
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
 def pattern_detection_prompt(
     audience_name: str,
     community_names: list[str],
@@ -6,10 +9,11 @@ def pattern_detection_prompt(
     total_topics: int,
     total_posts: int,
     total_comments: int,
+    language: str = "en",
 ) -> str:
     communities_str = ", ".join(f"r/{name}" for name in community_names)
 
-    return f"""You are an expert Reddit analyst specializing in cross-topic pattern detection.
+    prompt = f"""You are an expert Reddit analyst specializing in cross-topic pattern detection.
 
 Audience: "{audience_name}"
 Communities: {communities_str}
@@ -73,3 +77,5 @@ Respond ONLY with valid JSON. No markdown code blocks, no explanations outside t
 
 Example structure:
 {{"summary": "...", "co_occurrences": [...], "unanswered_questions": [...], "emerging_opinions": [...], "cross_community_gaps": [...], "content_opportunities": [...]}}"""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/state.py
+++ b/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/state.py
@@ -39,6 +39,7 @@ class PatternDetectionState(TypedDict):
     audience_name: str
     community_names: list[str]
     topics: list[TopicSummary]
+    language: str
 
     # Populated by nodes
     posts_with_comments: list[PostWithComments]

--- a/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/detect_patterns_use_case.py
+++ b/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/detect_patterns_use_case.py
@@ -45,7 +45,7 @@ class DetectPatternsUseCase:
         self.pattern_repo = TopicPatternRepository(db)
         self.reddit_provider = GenericRedditProvider()
 
-    def execute(self, audience_id: UUID, analysis_id: UUID) -> bool:
+    def execute(self, audience_id: UUID, analysis_id: UUID, language: str = "en") -> bool:
         """
         Executa a deteccao de padroes completa.
 
@@ -177,6 +177,7 @@ class DetectPatternsUseCase:
                 "audience_name": audience.name,
                 "community_names": community_names,
                 "topics": topics,
+                "language": language,
                 "posts_with_comments": posts_with_comments,
                 "pattern_result": None,
             })

--- a/app/modules/topic_patterns/application/use_cases/trigger_pattern_analysis_use_case.py
+++ b/app/modules/topic_patterns/application/use_cases/trigger_pattern_analysis_use_case.py
@@ -27,7 +27,7 @@ class TriggerPatternAnalysisUseCase:
         self.audience_repo = AudienceRepository(db)
         self.pattern_repo = TopicPatternRepository(db)
 
-    def execute(self, audience_id: UUID, force: bool = False) -> dict:
+    def execute(self, audience_id: UUID, force: bool = False, language: str = "en") -> dict:
         """
         Verifica e dispara deteccao de padroes se necessario.
 
@@ -73,7 +73,7 @@ class TriggerPatternAnalysisUseCase:
         )
 
         # Disparar em background
-        self._run_in_background(audience_id, analysis.id)
+        self._run_in_background(audience_id, analysis.id, language)
 
         return {
             "status": "processing",
@@ -82,7 +82,7 @@ class TriggerPatternAnalysisUseCase:
         }
 
     def _run_in_background(
-        self, audience_id: UUID, analysis_id: UUID
+        self, audience_id: UUID, analysis_id: UUID, language: str = "en",
     ) -> None:
         """Dispara deteccao de padroes em background thread."""
         from app.modules.shared.infra.database.database import SessionLocal
@@ -95,7 +95,7 @@ class TriggerPatternAnalysisUseCase:
                 )
 
                 use_case = DetectPatternsUseCase(db)
-                use_case.execute(audience_id, analysis_id)
+                use_case.execute(audience_id, analysis_id, language=language)
             except Exception:
                 logger.exception(
                     "Background pattern detection failed for audience %s",

--- a/app/modules/topics/application/use_cases/get_community_details_use_case/agent/communit_detail_analiser_agent.py
+++ b/app/modules/topics/application/use_cases/get_community_details_use_case/agent/communit_detail_analiser_agent.py
@@ -20,7 +20,7 @@ def analyze_community(state: CommunityAnalyzerState) -> dict:
         temperature=0,
     )
 
-    prompt = analyze_community_node_prompt(state["title"], state["public_description"])
+    prompt = analyze_community_node_prompt(state["title"], state["public_description"], language=state.get("language", "en"))
 
     response = llm.invoke(prompt)
 
@@ -45,7 +45,7 @@ def create_community_analyzer_agent():
 
 
 def analyze_community_for_related_terms(
-    title: str, public_description: str
+    title: str, public_description: str, language: str = "en",
 ) -> list[str]:
     """
     Executa o agente e retorna os termos derivados
@@ -53,6 +53,7 @@ def analyze_community_for_related_terms(
     Args:
         title: Título da comunidade
         public_description: Descrição pública da comunidade
+        language: Idioma preferido do usuário
 
     Returns:
         Lista de termos derivados para buscar comunidades relacionadas
@@ -63,6 +64,7 @@ def analyze_community_for_related_terms(
         {
             "title": title,
             "public_description": public_description,
+            "language": language,
             "derived_terms": [],
         }
     )

--- a/app/modules/topics/application/use_cases/get_community_details_use_case/agent/prompts/analizy_community_prompt.py
+++ b/app/modules/topics/application/use_cases/get_community_details_use_case/agent/prompts/analizy_community_prompt.py
@@ -1,9 +1,12 @@
-def analyze_community_node_prompt(title: str, public_description: str) -> str:
+from app.modules.shared.application.helpers.language_directive import get_language_directive
+
+
+def analyze_community_node_prompt(title: str, public_description: str, language: str = "en") -> str:
     """
     Prompt para analisar a comunidade
     """
 
-    return f"""You are an expert in Reddit communities.
+    prompt = f"""You are an expert in Reddit communities.
 
 Analyze this community:
 - Title: {title}
@@ -14,3 +17,5 @@ The terms should be specific and different from the original title.
 
 Respond ONLY with the 10 terms separated by comma, without explanations.
 Example: programming, software, coding, developer, tech, computer science, algorithms, web development, backend, frontend"""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/topics/application/use_cases/get_community_details_use_case/agent/state.py
+++ b/app/modules/topics/application/use_cases/get_community_details_use_case/agent/state.py
@@ -7,4 +7,5 @@ class CommunityAnalyzerState(TypedDict):
 
     title: str  # Título da comunidade
     public_description: str  # Descrição pública
+    language: str  # Idioma preferido do usuário
     derived_terms: list[str]  # Termos derivados gerados pelo LLM

--- a/app/routes/audience_keywords.py
+++ b/app/routes/audience_keywords.py
@@ -149,7 +149,7 @@ def refresh_audience_keywords(
     analysis = keyword_repo.create_analysis(audience_id, fingerprint)
 
     trigger = TriggerKeywordAnalysisUseCase(db)
-    trigger._run_in_background(audience_id, analysis.id)
+    trigger._run_in_background(audience_id, analysis.id, language=current_user.preferred_language)
 
     return {
         "status": "processing",

--- a/app/routes/audience_topics.py
+++ b/app/routes/audience_topics.py
@@ -190,7 +190,7 @@ def refresh_audience_topics(
     analysis = topic_repo.create_analysis(audience_id, fingerprint)
 
     trigger = TriggerTopicAnalysisUseCase(db)
-    trigger._run_in_background(audience_id, analysis.id)
+    trigger._run_in_background(audience_id, analysis.id, language=current_user.preferred_language)
 
     return {
         "status": "processing",

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -15,6 +15,7 @@ from app.modules.identity.application.use_cases.register_use_case import (
 )
 from app.modules.identity.dependencies import get_current_user
 from app.modules.identity.domain.entities.user import User
+from app.modules.shared.application.helpers.language_directive import SUPPORTED_LANGUAGES
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
@@ -84,4 +85,26 @@ def me(current_user: User = Depends(get_current_user)):
         "full_name": current_user.full_name,
         "is_active": current_user.is_active,
         "is_superuser": current_user.is_superuser,
+        "preferred_language": current_user.preferred_language,
     }
+
+
+class UpdateLanguageRequest(BaseModel):
+    preferred_language: str
+
+
+@router.patch("/me/language")
+def update_language(
+    request: UpdateLanguageRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Atualiza o idioma preferido do usuário."""
+    if request.preferred_language not in SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Idioma não suportado. Opções: {', '.join(SUPPORTED_LANGUAGES.keys())}",
+        )
+    current_user.preferred_language = request.preferred_language
+    db.commit()
+    return {"preferred_language": current_user.preferred_language}

--- a/app/routes/similar_communities.py
+++ b/app/routes/similar_communities.py
@@ -115,6 +115,7 @@ def get_audience_suggestions(
         audience_id=audience_id,
         user_id=str(current_user.id),
         limit=limit,
+        language=current_user.preferred_language,
     )
 
     if not result.audience_name:

--- a/app/routes/topic_behavioral_patterns.py
+++ b/app/routes/topic_behavioral_patterns.py
@@ -149,6 +149,6 @@ def refresh_topic_behavioral_patterns(
         }
 
     trigger = TriggerBehavioralPatternUseCase(db)
-    result = trigger.execute(topic_id, audience_id, force=True)
+    result = trigger.execute(topic_id, audience_id, force=True, language=current_user.preferred_language)
 
     return result

--- a/app/routes/topic_deep_dive.py
+++ b/app/routes/topic_deep_dive.py
@@ -152,6 +152,6 @@ def refresh_topic_deep_dive(
         }
 
     trigger = TriggerDeepDiveUseCase(db)
-    result = trigger.execute(topic_id, audience_id, force=True)
+    result = trigger.execute(topic_id, audience_id, force=True, language=current_user.preferred_language)
 
     return result

--- a/app/routes/topic_patterns.py
+++ b/app/routes/topic_patterns.py
@@ -128,6 +128,6 @@ def refresh_topic_patterns(
         }
 
     trigger = TriggerPatternAnalysisUseCase(db)
-    result = trigger.execute(audience_id, force=True)
+    result = trigger.execute(audience_id, force=True, language=current_user.preferred_language)
 
     return result


### PR DESCRIPTION
## Summary

- Adiciona campo `preferred_language` ao modelo User com migration Alembic, permitindo que cada usuário defina seu idioma preferido (en, pt-BR, es, fr, de, it, ja, ko, zh)
- Injeta diretiva de idioma diretamente nos prompts dos 7 agentes LLM (deep dive, behavioral patterns, cross-topic patterns, keywords, topics, audience expansion, community analysis), mantendo JSON keys e enums em inglês para estabilidade de parsing
- Propaga `language` por toda a cadeia: Rota → Trigger Use Case → Extract Use Case → Agent State → Prompt → LLM

## Arquivos modificados (43 files)

**Novos:**
- `app/modules/shared/application/helpers/language_directive.py` — helper que gera o bloco de instrução de idioma
- `alembic/versions/a0b1c2d3e4f5_add_preferred_language_to_users.py` — migration

**Modificados:**
- 7 arquivos de prompt — parâmetro `language` + concatenação da diretiva
- 7 arquivos de state — campo `language: str`
- 7 arquivos de agent — propagação do state para o prompt
- 6 arquivos de use case (extract) — `language` passado no `agent.invoke()`
- 5 arquivos de use case (trigger) — `language` recebido e repassado na thread
- 6 arquivos de rota — `current_user.preferred_language` passado para os use cases
- `app/routes/auth.py` — endpoint `PATCH /me/language` + `preferred_language` no GET /me
- `app/modules/identity/domain/entities/user.py` — coluna `preferred_language`

## Backward compatibility

- Default `"en"` em todas as camadas
- `get_language_directive("en")` retorna string vazia = comportamento atual inalterado
- Migration usa `server_default="en"` para registros existentes

## Test plan

- [ ] Criar usuário com `preferred_language = "pt-BR"` via `PATCH /me/language`
- [ ] Disparar qualquer análise (ex: deep dive refresh)
- [ ] Confirmar que JSON retornado tem keys em inglês e valores de texto em português
- [ ] Testar com `preferred_language = "en"` e confirmar comportamento inalterado
- [ ] Testar idioma inválido no PATCH retorna 422

Closes #54