### PR TITLE
feat: add user profile fields (bio, locale, phone_number)

### DIFF
--- a/alembic/versions/a3bb06f1821e_add_bio_locale_phone_number_to_users.py
+++ b/alembic/versions/a3bb06f1821e_add_bio_locale_phone_number_to_users.py
@@ -1,0 +1,32 @@
+"""add bio locale phone_number to users
+
+Revision ID: a3bb06f1821e
+Revises: a0b1c2d3e4f5
+Create Date: 2026-02-22 23:25:28.932363
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3bb06f1821e'
+down_revision: Union[str, Sequence[str], None] = 'a0b1c2d3e4f5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('users', sa.Column('bio', sa.Text(), nullable=True))
+    op.add_column('users', sa.Column('locale', sa.String(length=100), nullable=True))
+    op.add_column('users', sa.Column('phone_number', sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'phone_number')
+    op.drop_column('users', 'locale')
+    op.drop_column('users', 'bio')

--- a/app/modules/identity/application/dtos.py
+++ b/app/modules/identity/application/dtos.py
@@ -1,6 +1,7 @@
 """DTOs for identity module."""
 
 from dataclasses import dataclass
+from typing import Optional
 from uuid import UUID
 
 
@@ -30,6 +31,18 @@ class UserDTO:
     full_name: str
     is_active: bool
     is_superuser: bool
+    bio: Optional[str] = None
+    locale: Optional[str] = None
+    phone_number: Optional[str] = None
+
+
+@dataclass
+class UpdateProfileInput:
+    """Input para atualização de perfil."""
+
+    bio: Optional[str] = None
+    locale: Optional[str] = None
+    phone_number: Optional[str] = None
 
 
 @dataclass

--- a/app/modules/identity/application/use_cases/update_profile_use_case.py
+++ b/app/modules/identity/application/use_cases/update_profile_use_case.py
@@ -1,0 +1,33 @@
+"""Update profile use case."""
+
+from sqlalchemy.orm import Session
+
+from app.modules.identity.application.dtos import UpdateProfileInput, UserDTO
+from app.modules.identity.domain.entities.user import User
+from app.modules.identity.infra.repositories.user_repository import UserRepository
+
+
+class UpdateProfileUseCase:
+    """Atualiza o perfil do usuário."""
+
+    def __init__(self, db: Session):
+        self.repository = UserRepository(db)
+
+    def execute(self, user: User, input_data: UpdateProfileInput) -> UserDTO:
+        updated_user = self.repository.update_profile(
+            user,
+            bio=input_data.bio,
+            locale=input_data.locale,
+            phone_number=input_data.phone_number,
+        )
+
+        return UserDTO(
+            id=updated_user.id,
+            email=updated_user.email,
+            full_name=updated_user.full_name,
+            is_active=updated_user.is_active,
+            is_superuser=updated_user.is_superuser,
+            bio=updated_user.bio,
+            locale=updated_user.locale,
+            phone_number=updated_user.phone_number,
+        )

--- a/app/modules/identity/domain/entities/user.py
+++ b/app/modules/identity/domain/entities/user.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, Column, DateTime, String
+from sqlalchemy import Boolean, Column, DateTime, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.modules.shared.infra.database.orm.metadata import Base
@@ -21,6 +21,9 @@ class User(Base):
     is_active = Column(Boolean, default=True, nullable=False)
     is_superuser = Column(Boolean, default=False, nullable=False)
     preferred_language = Column(String(10), default="en", nullable=False, server_default="en")
+    bio = Column(Text, nullable=True)
+    locale = Column(String(100), nullable=True)
+    phone_number = Column(String(20), nullable=True)
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/app/modules/identity/infra/repositories/user_repository.py
+++ b/app/modules/identity/infra/repositories/user_repository.py
@@ -33,3 +33,11 @@ class UserRepository:
             .filter(User.email == email.lower().strip())
             .first()
         )
+
+    def update_profile(self, user: User, **fields) -> User:
+        for key, value in fields.items():
+            if value is not None:
+                setattr(user, key, value)
+        self.db.commit()
+        self.db.refresh(user)
+        return user

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,17 +1,22 @@
 """Routes for authentication."""
 
 from fastapi import APIRouter, Depends, HTTPException
+from typing import Optional
+
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.modules.identity.application.dtos import RegisterInput, LoginInput
+from app.modules.identity.application.dtos import RegisterInput, LoginInput, UpdateProfileInput
 from app.modules.identity.application.use_cases.login_use_case import LoginUseCase
 from app.modules.identity.application.use_cases.refresh_token_use_case import (
     RefreshTokenUseCase,
 )
 from app.modules.identity.application.use_cases.register_use_case import (
     RegisterUseCase,
+)
+from app.modules.identity.application.use_cases.update_profile_use_case import (
+    UpdateProfileUseCase,
 )
 from app.modules.identity.dependencies import get_current_user
 from app.modules.identity.domain.entities.user import User
@@ -86,7 +91,35 @@ def me(current_user: User = Depends(get_current_user)):
         "is_active": current_user.is_active,
         "is_superuser": current_user.is_superuser,
         "preferred_language": current_user.preferred_language,
+        "bio": current_user.bio,
+        "locale": current_user.locale,
+        "phone_number": current_user.phone_number,
     }
+
+
+class UpdateProfileRequest(BaseModel):
+    bio: Optional[str] = None
+    locale: Optional[str] = None
+    phone_number: Optional[str] = None
+
+
+@router.patch("/me/profile")
+def update_profile(
+    request: UpdateProfileRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Atualiza o perfil do usuário (bio, locale, phone_number)."""
+    use_case = UpdateProfileUseCase(db)
+    updated = use_case.execute(
+        current_user,
+        UpdateProfileInput(
+            bio=request.bio,
+            locale=request.locale,
+            phone_number=request.phone_number,
+        ),
+    )
+    return vars(updated)
 
 
 class UpdateLanguageRequest(BaseModel):


### PR DESCRIPTION
## Summary

- Add three optional profile columns to the `users` table: `bio` (Text), `locale` (String 100), `phone_number` (String 20)
- New endpoint `PATCH /auth/me/profile` for partial profile updates
- `GET /auth/me` now returns the new fields
- Alembic migration with upgrade/downgrade support

## Arquivos

| Arquivo | Alteração |
|---------|-----------|
| `app/modules/identity/domain/entities/user.py` | Novas colunas `bio`, `locale`, `phone_number` |
| `app/modules/identity/application/dtos.py` | `UserDTO` + novo `UpdateProfileInput` |
| `app/modules/identity/application/use_cases/update_profile_use_case.py` | Novo use case |
| `app/modules/identity/infra/repositories/user_repository.py` | Novo método `update_profile()` |
| `app/routes/auth.py` | Novo endpoint + `GET /me` atualizado |
| `alembic/versions/a3bb06f1821e_...` | Migration |

## Test plan

- [ ] `GET /auth/me` retorna `bio`, `locale`, `phone_number` (null inicialmente)
- [ ] `PATCH /auth/me/profile` com todos os campos atualiza corretamente
- [ ] `PATCH /auth/me/profile` com campo parcial atualiza apenas o enviado
- [ ] `make migrate-down` e `make migrate` funcionam sem erro

Closes #57