### PR TITLE
feat: Ask — Q&A com IA sobre tópicos da audiência

### DIFF
--- a/alembic/versions/d6e7f8a9b0c1_add_topic_ask_logs.py
+++ b/alembic/versions/d6e7f8a9b0c1_add_topic_ask_logs.py
@@ -1,0 +1,55 @@
+"""add topic_ask_logs table
+
+Revision ID: d6e7f8a9b0c1
+Revises: c5d6e7f8a9b0
+Create Date: 2026-02-24
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "d6e7f8a9b0c1"
+down_revision: Union[str, None] = "c5d6e7f8a9b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "topic_ask_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "topic_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audience_topics.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "audience_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audiences.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("question", sa.Text, nullable=False),
+        sa.Column("answer", sa.Text, nullable=True),
+        sa.Column("context_quality", sa.String(20), nullable=False, default="limited"),
+        sa.Column("cached", sa.Boolean, nullable=False, default=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("topic_ask_logs")

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.routes import (
     topic_deep_dive_router,
     topic_patterns_router,
     topic_sentiment_router,
+    topic_ask_router,
     topic_snapshots_router,
     topics_router,
 )
@@ -82,6 +83,7 @@ app.include_router(topic_deep_dive_router)
 app.include_router(topic_behavioral_patterns_router)
 app.include_router(topic_snapshots_router)
 app.include_router(notifications_router)
+app.include_router(topic_ask_router)
 
 
 @app.get("/")

--- a/app/modules/shared/application/services/llm_cache_service.py
+++ b/app/modules/shared/application/services/llm_cache_service.py
@@ -15,6 +15,7 @@ class TaskType(str, Enum):
     THEME_SUMMARY = "theme_summary"
     COMMUNITY_CATEGORIZATION = "community_categorization"
     AUDIENCE_EXPANSION = "audience_expansion"
+    TOPIC_QA = "topic_qa"
 
 
 # TTL em horas para cada tipo de task
@@ -24,6 +25,7 @@ TTL_CONFIG = {
     TaskType.THEME_SUMMARY: 24,               # 24 horas
     TaskType.COMMUNITY_CATEGORIZATION: 720,   # 30 dias
     TaskType.AUDIENCE_EXPANSION: 24,          # 24 horas
+    TaskType.TOPIC_QA: 48,                    # 48 horas
 }
 
 

--- a/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/ask_agent.py
+++ b/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/ask_agent.py
@@ -1,0 +1,114 @@
+import json
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.topic_ask.application.use_cases.ask_topic_use_case.agent.prompts.ask_prompts import (
+    topic_qa_prompt,
+)
+from app.modules.topic_ask.application.use_cases.ask_topic_use_case.agent.state import (
+    TopicAskState,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_llm() -> ChatOpenAI:
+    return ChatOpenAI(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        max_completion_tokens=16384,
+    )
+
+
+def build_context(state: TopicAskState) -> dict:
+    """Validates context availability and determines quality."""
+    deep_dive_context = state.get("deep_dive_context")
+
+    if deep_dive_context:
+        logger.info(
+            "Ask Q&A: rich context available for topic '%s'",
+            state.get("topic_name"),
+        )
+        return {"context_quality": "rich"}
+
+    logger.info(
+        "Ask Q&A: limited context for topic '%s' (no deep dive)",
+        state.get("topic_name"),
+    )
+    return {"context_quality": "limited"}
+
+
+def answer_question(state: TopicAskState) -> dict:
+    """LLM answers the user question based on available context."""
+    deep_dive_context = state.get("deep_dive_context")
+    context_quality = state.get("context_quality", "limited")
+
+    if deep_dive_context:
+        context_text = deep_dive_context
+    else:
+        context_text = (
+            f"Topic: {state['topic_name']}\n"
+            f"Description: {state.get('topic_description', 'N/A')}\n"
+            f"Communities: {', '.join(f'r/{c}' for c in state.get('community_names', []))}"
+        )
+
+    llm = _get_llm()
+    prompt = topic_qa_prompt(
+        topic_name=state["topic_name"],
+        topic_description=state.get("topic_description", ""),
+        audience_name=state["audience_name"],
+        community_names=state.get("community_names", []),
+        context_text=context_text,
+        question=state["question"],
+        context_quality=context_quality,
+        language=state.get("language", "en"),
+    )
+
+    logger.info(
+        "Ask Q&A: sending prompt to LLM (length: %d chars, model: %s)",
+        len(prompt),
+        os.getenv("MODEL_NAME", "gpt-4o-mini"),
+    )
+
+    response = llm.invoke(prompt)
+
+    logger.info(
+        "Ask Q&A: LLM response type=%s, content_length=%d, content_preview='%s'",
+        type(response).__name__,
+        len(response.content) if response.content else 0,
+        (response.content[:200] if response.content else "<EMPTY>"),
+    )
+
+    answer = response.content.strip() if response.content else ""
+
+    if not answer:
+        logger.warning(
+            "Ask Q&A: LLM returned empty answer for topic '%s'. "
+            "Full response: %s",
+            state["topic_name"],
+            repr(response),
+        )
+
+    logger.info(
+        "Ask Q&A: answered question for topic '%s' (quality: %s, length: %d chars)",
+        state["topic_name"],
+        context_quality,
+        len(answer),
+    )
+    return {"answer": answer}
+
+
+def create_ask_agent():
+    """Create the LangGraph agent for topic Q&A."""
+    workflow = StateGraph(TopicAskState)
+
+    workflow.add_node("build_context", build_context)
+    workflow.add_node("answer_question", answer_question)
+
+    workflow.add_edge(START, "build_context")
+    workflow.add_edge("build_context", "answer_question")
+    workflow.add_edge("answer_question", END)
+
+    return workflow.compile()

--- a/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/prompts/ask_prompts.py
+++ b/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/prompts/ask_prompts.py
@@ -1,0 +1,51 @@
+from app.modules.shared.application.helpers.language_directive import (
+    get_language_directive,
+)
+
+
+def topic_qa_prompt(
+    topic_name: str,
+    topic_description: str,
+    audience_name: str,
+    community_names: list[str],
+    context_text: str,
+    question: str,
+    context_quality: str,
+    language: str = "en",
+) -> str:
+    communities_str = ", ".join(f"r/{name}" for name in community_names)
+
+    quality_note = ""
+    if context_quality == "limited":
+        quality_note = (
+            "\n\nNOTE: You only have basic topic metadata (no deep dive analysis available). "
+            "Be transparent about this limitation. Answer what you can based on the topic name, "
+            "description, and community context, but clearly state when you don't have enough "
+            "data to give a detailed answer. Suggest the user run a Deep Dive analysis for richer results."
+        )
+
+    prompt = f"""You are an expert analyst specialized in online community research.
+
+Audience: "{audience_name}"
+Communities: {communities_str}
+Topic: "{topic_name}"
+Topic description: {topic_description}
+
+CONTEXT DATA:
+{context_text}
+
+---
+
+USER QUESTION:
+"{question}"
+{quality_note}
+
+INSTRUCTIONS:
+- Answer EXCLUSIVELY based on the context data provided above
+- Cite concrete data: tools mentioned, sentiments, patterns, specific examples from posts
+- If the information is not in the context, explicitly say there is not enough data
+- Be direct and actionable
+- Use a maximum of 4 paragraphs
+- Do NOT invent data or make assumptions beyond what the context shows"""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/state.py
+++ b/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/state.py
@@ -1,0 +1,17 @@
+from typing import TypedDict
+
+
+class TopicAskState(TypedDict):
+    topic_name: str
+    topic_description: str
+    audience_name: str
+    community_names: list[str]
+    language: str
+    question: str
+
+    # Deep dive context (if available)
+    deep_dive_context: str | None
+
+    # Populated by nodes
+    context_quality: str  # "rich" or "limited"
+    answer: str | None

--- a/app/modules/topic_ask/application/use_cases/ask_topic_use_case/ask_topic_use_case.py
+++ b/app/modules/topic_ask/application/use_cases/ask_topic_use_case/ask_topic_use_case.py
@@ -1,0 +1,220 @@
+import json
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.shared.application.services.llm_cache_service import (
+    LLMCacheService,
+    TaskType,
+)
+from app.modules.topic_ask.application.use_cases.ask_topic_use_case.agent.ask_agent import (
+    create_ask_agent,
+)
+from app.modules.topic_ask.infra.repositories.topic_ask_repository import (
+    TopicAskRepository,
+)
+from app.modules.topic_deep_dive.infra.repositories.topic_deep_dive_repository import (
+    TopicDeepDiveRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AskTopicUseCase:
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.deep_dive_repo = TopicDeepDiveRepository(db)
+        self.ask_repo = TopicAskRepository(db)
+        self.cache_service = LLMCacheService(db)
+
+    def execute(
+        self,
+        topic_id: UUID,
+        audience_id: UUID,
+        user_id: UUID,
+        question: str,
+        language: str = "en",
+    ) -> dict:
+        """
+        Responde uma pergunta sobre um tópico usando dados do Deep Dive como contexto.
+
+        Returns:
+            dict com answer, context_quality, cached, topic_name, sources_used, suggestion
+        """
+        topic = self.topic_repo.get_topic_by_id(topic_id)
+        if not topic:
+            return {"error": "Topic not found"}
+
+        audience = self.audience_repo.find_by_id(audience_id)
+        if not audience:
+            return {"error": "Audience not found"}
+
+        communities = self.audience_repo.get_communities(audience_id)
+        community_names = [c.subreddit_name for c in communities]
+
+        # Check cache
+        cache_key = f"{topic_id}:{question.strip().lower()}"
+        cached_result = self.cache_service.get(cache_key, TaskType.TOPIC_QA)
+        if cached_result:
+            logger.info("Ask Q&A: cache hit for topic '%s'", topic.name)
+            self._safe_create_log(
+                topic_id=topic_id,
+                audience_id=audience_id,
+                user_id=user_id,
+                question=question,
+                answer=cached_result.get("answer"),
+                context_quality=cached_result.get("context_quality", "limited"),
+                cached=True,
+            )
+            return {**cached_result, "cached": True}
+
+        # Build deep dive context
+        deep_dive_context = None
+        context_quality = "limited"
+        sources_used = ["topic_metadata"]
+
+        latest_analysis = self.deep_dive_repo.find_latest_by_topic(topic_id)
+        if latest_analysis and latest_analysis.status == "ready":
+            deep_dive = self.deep_dive_repo.get_deep_dive(latest_analysis.id)
+            if deep_dive:
+                deep_dive_context = self._build_deep_dive_context(deep_dive)
+                context_quality = "rich"
+                sources_used = ["deep_dive"]
+
+        # Run agent
+        agent = create_ask_agent()
+        result = agent.invoke({
+            "topic_name": topic.name,
+            "topic_description": topic.description or "",
+            "audience_name": audience.name,
+            "community_names": community_names,
+            "language": language,
+            "question": question,
+            "deep_dive_context": deep_dive_context,
+            "context_quality": context_quality,
+            "answer": None,
+        })
+
+        answer = result.get("answer")
+        final_context_quality = result.get("context_quality", context_quality)
+
+        suggestion = None
+        if final_context_quality == "limited":
+            suggestion = (
+                "Execute o Deep Dive neste tópico para obter respostas "
+                "mais detalhadas e baseadas em dados reais."
+            )
+
+        response = {
+            "answer": answer,
+            "context_quality": final_context_quality,
+            "sources_used": sources_used,
+            "cached": False,
+            "topic_name": topic.name,
+            "suggestion": suggestion,
+        }
+
+        # Persist log first, then cache (log failure must not block the response)
+        self._safe_create_log(
+            topic_id=topic_id,
+            audience_id=audience_id,
+            user_id=user_id,
+            question=question,
+            answer=answer,
+            context_quality=final_context_quality,
+            cached=False,
+        )
+
+        # Cache the result (only after log succeeds or is safely skipped)
+        self.cache_service.set(cache_key, TaskType.TOPIC_QA, response)
+
+        logger.info(
+            "Ask Q&A: answered for topic '%s' (quality: %s)",
+            topic.name,
+            final_context_quality,
+        )
+
+        return response
+
+    def _safe_create_log(self, **kwargs) -> None:
+        """Persists the ask log without blocking the response on failure."""
+        try:
+            self.ask_repo.create_log(**kwargs)
+        except Exception:
+            logger.debug("Failed to persist ask log, skipping")
+            try:
+                self.db.rollback()
+            except Exception:
+                pass
+
+    def _build_deep_dive_context(self, deep_dive) -> str:
+        """Builds a text context from the deep dive data stored in the database."""
+        sections = []
+
+        if deep_dive.summary:
+            sections.append(f"SUMMARY:\n{deep_dive.summary}")
+
+        if deep_dive.subtopics:
+            lines = ["SUBTOPICS IDENTIFIED:"]
+            for st in deep_dive.subtopics:
+                name = st.get("name", "")
+                desc = st.get("description", "")
+                count = st.get("post_count", 0)
+                lines.append(f"- {name} ({count} posts): {desc}")
+            sections.append("\n".join(lines))
+
+        if deep_dive.common_questions:
+            lines = ["FREQUENTLY ASKED QUESTIONS:"]
+            for q in deep_dive.common_questions:
+                question = q.get("question", "")
+                freq = q.get("frequency", "")
+                ctx = q.get("example_context", "")
+                lines.append(f"- [{freq}] \"{question}\"")
+                if ctx:
+                    lines.append(f"  Context: \"{ctx}\"")
+            sections.append("\n".join(lines))
+
+        if deep_dive.mentioned_products:
+            lines = ["MENTIONED TOOLS/PRODUCTS:"]
+            for p in deep_dive.mentioned_products:
+                name = p.get("name", "")
+                cat = p.get("category", "")
+                sentiment = p.get("sentiment", "")
+                mentions = p.get("mention_count", 0)
+                context = p.get("context", "")
+                lines.append(
+                    f"- {name} ({cat}, sentiment: {sentiment}, {mentions} mentions): {context}"
+                )
+            sections.append("\n".join(lines))
+
+        if deep_dive.representative_posts:
+            lines = ["REPRESENTATIVE POSTS:"]
+            for p in deep_dive.representative_posts:
+                title = p.get("title", "")
+                sub = p.get("subreddit", "")
+                score = p.get("score", 0)
+                excerpt = p.get("excerpt", "")
+                lines.append(f"- [r/{sub}, score:{score}] \"{title}\"")
+                if excerpt:
+                    lines.append(f"  Excerpt: \"{excerpt}\"")
+            sections.append("\n".join(lines))
+
+        if deep_dive.actionable_insights:
+            lines = ["ACTIONABLE INSIGHTS:"]
+            for i in deep_dive.actionable_insights:
+                insight = i.get("insight", "")
+                itype = i.get("type", "")
+                confidence = i.get("confidence", "")
+                lines.append(f"- [{itype}, {confidence} confidence] {insight}")
+            sections.append("\n".join(lines))
+
+        return "\n\n".join(sections)

--- a/app/modules/topic_ask/domain/entities/topic_ask_log.py
+++ b/app/modules/topic_ask/domain/entities/topic_ask_log.py
@@ -1,0 +1,45 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text, Boolean
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class TopicAskLog(Base):
+    """
+    Log de perguntas e respostas do Q&A de tópicos.
+    Persiste histórico para analytics futuros.
+    """
+
+    __tablename__ = "topic_ask_logs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    topic_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audience_topics.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    question = Column(Text, nullable=False)
+    answer = Column(Text, nullable=True)
+    context_quality = Column(
+        String(20), nullable=False, default="limited"
+    )  # rich, limited
+    cached = Column(Boolean, nullable=False, default=False)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )

--- a/app/modules/topic_ask/infra/repositories/topic_ask_repository.py
+++ b/app/modules/topic_ask/infra/repositories/topic_ask_repository.py
@@ -1,0 +1,47 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.topic_ask.domain.entities.topic_ask_log import TopicAskLog
+
+
+class TopicAskRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_log(
+        self,
+        topic_id: UUID,
+        audience_id: UUID,
+        user_id: UUID,
+        question: str,
+        answer: str | None,
+        context_quality: str,
+        cached: bool = False,
+    ) -> TopicAskLog:
+        """Persiste uma pergunta/resposta no histórico."""
+        log = TopicAskLog(
+            topic_id=topic_id,
+            audience_id=audience_id,
+            user_id=user_id,
+            question=question,
+            answer=answer,
+            context_quality=context_quality,
+            cached=cached,
+        )
+        self.db.add(log)
+        self.db.commit()
+        self.db.refresh(log)
+        return log
+
+    def get_recent_by_topic(
+        self, topic_id: UUID, limit: int = 10
+    ) -> list[TopicAskLog]:
+        """Busca perguntas recentes de um tópico."""
+        return (
+            self.db.query(TopicAskLog)
+            .filter(TopicAskLog.topic_id == topic_id)
+            .order_by(TopicAskLog.created_at.desc())
+            .limit(limit)
+            .all()
+        )

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -14,6 +14,7 @@ from app.routes.topic_sentiment import router as topic_sentiment_router
 from app.routes.topic_behavioral_patterns import router as topic_behavioral_patterns_router
 from app.routes.topic_snapshots import router as topic_snapshots_router
 from app.routes.notifications import router as notifications_router
+from app.routes.topic_ask import router as topic_ask_router
 
 __all__ = [
     "auth_router",
@@ -30,4 +31,5 @@ __all__ = [
     "topic_behavioral_patterns_router",
     "topic_snapshots_router",
     "notifications_router",
+    "topic_ask_router",
 ]

--- a/app/routes/topic_ask.py
+++ b/app/routes/topic_ask.py
@@ -1,0 +1,77 @@
+"""Routes for topic Q&A (Ask)."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+from app.modules.topic_ask.application.use_cases.ask_topic_use_case.ask_topic_use_case import (
+    AskTopicUseCase,
+)
+
+router = APIRouter(prefix="/audiences", tags=["Topic Ask"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
+TOPIC_NOT_FOUND = "Topic not found"
+
+
+class AskRequest(BaseModel):
+    question: str = Field(..., min_length=3, max_length=500)
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuário é dono da audiência ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+@router.post("/{audience_id}/topics/{topic_id}/ask")
+def ask_topic(
+    audience_id: UUID,
+    topic_id: UUID,
+    body: AskRequest,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Faz uma pergunta sobre um tópico e recebe uma resposta baseada em IA.
+
+    Usa os dados do Deep Dive (se disponível) como contexto para responder.
+    Respostas são cacheadas por 48 horas.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    topic_repo = AudienceTopicRepository(db)
+    topic = topic_repo.get_topic_by_id(topic_id)
+    if not topic:
+        raise HTTPException(status_code=404, detail=TOPIC_NOT_FOUND)
+
+    use_case = AskTopicUseCase(db)
+    result = use_case.execute(
+        topic_id=topic_id,
+        audience_id=audience_id,
+        user_id=current_user.id,
+        question=body.question,
+        language=current_user.preferred_language,
+    )
+
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+
+    return result


### PR DESCRIPTION
## Summary

- Novo endpoint `POST /audiences/{id}/topics/{id}/ask` para perguntas livres sobre tópicos
- Usa dados do Deep Dive já persistidos como contexto para o LLM (sem requests ao Reddit)
- Resposta síncrona (~3-5s), cache LLM com TTL 48h, histórico de perguntas persistido
- Agente LangGraph com 2 nós: `build_context` → `answer_question`

## Detalhes técnicos

- Novo módulo `app/modules/topic_ask/` (entidade, repositório, use case, agente, prompts)
- Nova rota `app/routes/topic_ask.py` com validação Pydantic (`AskRequest`)
- `TaskType.TOPIC_QA` adicionado ao `LLMCacheService` com TTL 48h
- Migration `d6e7f8a9b0c1` para tabela `topic_ask_logs`
- `_safe_create_log()` com try/except para que falha no log não bloqueie a resposta
- `max_completion_tokens=16384` para suportar reasoning models (gpt-5-nano)

## Contexto de qualidade

| Cenário | `context_quality` | Dados usados |
|---------|-------------------|--------------|
| Deep Dive disponível | `rich` | summary, subtopics, FAQs, products, posts, insights |
| Sem Deep Dive | `limited` | nome e descrição do tópico + sugestão para rodar Deep Dive |

## Test plan

- [x] Endpoint funcional com resposta baseada no Deep Dive
- [x] Cache LLM funcionando (mesma pergunta = resposta cacheada)
- [x] Histórico persistido na tabela `topic_ask_logs`
- [x] Autenticação e ownership validados
- [ ] Testar cenário sem Deep Dive (context_quality: limited)
- [ ] Testar validação de pergunta curta (min 3 chars)

Closes #63