### PR TITLE
feat: add topic chat with conversation history

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -44,6 +44,8 @@ from app.modules.topic_sentiment.domain.entities import topic_sentiment  # noqa:
 from app.modules.topic_behavioral_patterns.domain.entities import topic_behavioral_pattern  # noqa: E402
 from app.modules.topic_snapshots.domain.entities import topic_snapshot  # noqa: E402
 from app.modules.notifications.domain.entities import notification  # noqa: E402
+from app.modules.topic_chat.domain.entities import topic_conversation  # noqa: E402
+from app.modules.topic_chat.domain.entities import topic_conversation_message  # noqa: E402
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/e7f8a9b0c1d2_add_topic_chat_tables.py
+++ b/alembic/versions/e7f8a9b0c1d2_add_topic_chat_tables.py
@@ -1,0 +1,72 @@
+"""add topic_conversations and topic_conversation_messages tables
+
+Revision ID: e7f8a9b0c1d2
+Revises: d6e7f8a9b0c1
+Create Date: 2026-02-24
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, None] = "d6e7f8a9b0c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "topic_conversations",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "topic_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audience_topics.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "audience_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("audiences.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("title", sa.String(255), nullable=True),
+        sa.Column("context_quality", sa.String(20), nullable=False, default="limited"),
+        sa.Column("is_active", sa.Boolean, nullable=False, default=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "topic_conversation_messages",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "conversation_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("topic_conversations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("role", sa.String(20), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("context_quality", sa.String(20), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("topic_conversation_messages")
+    op.drop_table("topic_conversations")

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.routes import (
     topic_patterns_router,
     topic_sentiment_router,
     topic_ask_router,
+    topic_chat_router,
     topic_snapshots_router,
     topics_router,
 )
@@ -84,6 +85,7 @@ app.include_router(topic_behavioral_patterns_router)
 app.include_router(topic_snapshots_router)
 app.include_router(notifications_router)
 app.include_router(topic_ask_router)
+app.include_router(topic_chat_router)
 
 
 @app.get("/")

--- a/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/chat_agent.py
+++ b/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/chat_agent.py
@@ -1,0 +1,118 @@
+import logging
+import os
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.topic_chat.application.use_cases.send_message_use_case.agent.prompts.chat_prompts import (
+    topic_chat_system_prompt,
+)
+from app.modules.topic_chat.application.use_cases.send_message_use_case.agent.state import (
+    TopicChatState,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_llm() -> ChatOpenAI:
+    return ChatOpenAI(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        max_completion_tokens=16384,
+    )
+
+
+def build_context(state: TopicChatState) -> dict:
+    """Validates context availability and determines quality."""
+    deep_dive_context = state.get("deep_dive_context")
+
+    if deep_dive_context:
+        logger.info(
+            "Topic Chat: rich context available for topic '%s'",
+            state.get("topic_name"),
+        )
+        return {"context_quality": "rich"}
+
+    logger.info(
+        "Topic Chat: limited context for topic '%s' (no deep dive)",
+        state.get("topic_name"),
+    )
+    return {"context_quality": "limited"}
+
+
+def answer_with_history(state: TopicChatState) -> dict:
+    """LLM answers considering the full conversation history."""
+    deep_dive_context = state.get("deep_dive_context")
+    context_quality = state.get("context_quality", "limited")
+
+    if deep_dive_context:
+        context_text = deep_dive_context
+    else:
+        context_text = (
+            f"Topic: {state['topic_name']}\n"
+            f"Description: {state.get('topic_description', 'N/A')}\n"
+            f"Communities: {', '.join(f'r/{c}' for c in state.get('community_names', []))}"
+        )
+
+    system_prompt = topic_chat_system_prompt(
+        topic_name=state["topic_name"],
+        topic_description=state.get("topic_description", ""),
+        audience_name=state["audience_name"],
+        community_names=state.get("community_names", []),
+        context_text=context_text,
+        context_quality=context_quality,
+        language=state.get("language", "en"),
+    )
+
+    # Build message list: system + conversation history
+    langchain_messages = [SystemMessage(content=system_prompt)]
+
+    for msg in state.get("messages", []):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if role == "user":
+            langchain_messages.append(HumanMessage(content=content))
+        elif role == "assistant":
+            langchain_messages.append(AIMessage(content=content))
+
+    llm = _get_llm()
+
+    logger.info(
+        "Topic Chat: sending %d messages to LLM (model: %s)",
+        len(langchain_messages),
+        os.getenv("MODEL_NAME", "gpt-4o-mini"),
+    )
+
+    response = llm.invoke(langchain_messages)
+
+    answer = response.content.strip() if response.content else ""
+
+    if not answer:
+        logger.warning(
+            "Topic Chat: LLM returned empty answer for topic '%s'. "
+            "Full response: %s",
+            state["topic_name"],
+            repr(response),
+        )
+
+    logger.info(
+        "Topic Chat: answered for topic '%s' (quality: %s, length: %d chars)",
+        state["topic_name"],
+        context_quality,
+        len(answer),
+    )
+    return {"answer": answer}
+
+
+def create_chat_agent():
+    """Create the LangGraph agent for topic chat with conversation history."""
+    workflow = StateGraph(TopicChatState)
+
+    workflow.add_node("build_context", build_context)
+    workflow.add_node("answer_with_history", answer_with_history)
+
+    workflow.add_edge(START, "build_context")
+    workflow.add_edge("build_context", "answer_with_history")
+    workflow.add_edge("answer_with_history", END)
+
+    return workflow.compile()

--- a/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/prompts/chat_prompts.py
+++ b/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/prompts/chat_prompts.py
@@ -1,0 +1,48 @@
+from app.modules.shared.application.helpers.language_directive import (
+    get_language_directive,
+)
+
+
+def topic_chat_system_prompt(
+    topic_name: str,
+    topic_description: str,
+    audience_name: str,
+    community_names: list[str],
+    context_text: str,
+    context_quality: str,
+    language: str = "en",
+) -> str:
+    communities_str = ", ".join(f"r/{name}" for name in community_names)
+
+    quality_note = ""
+    if context_quality == "limited":
+        quality_note = (
+            "\n\nNOTE: You only have basic topic metadata (no deep dive analysis available). "
+            "Be transparent about this limitation. Answer what you can based on the topic name, "
+            "description, and community context, but clearly state when you don't have enough "
+            "data to give a detailed answer. Suggest the user run a Deep Dive analysis for richer results."
+        )
+
+    prompt = f"""You are an expert analyst specialized in online community research.
+You are having a conversation with a user about a specific topic.
+
+Audience: "{audience_name}"
+Communities: {communities_str}
+Topic: "{topic_name}"
+Topic description: {topic_description}
+
+CONTEXT DATA:
+{context_text}
+{quality_note}
+
+INSTRUCTIONS:
+- Answer EXCLUSIVELY based on the context data provided above
+- Cite concrete data: tools mentioned, sentiments, patterns, specific examples from posts
+- If the information is not in the context, explicitly say there is not enough data
+- Be direct and actionable
+- Use a maximum of 4 paragraphs per response
+- Do NOT invent data or make assumptions beyond what the context shows
+- Consider the conversation history to provide coherent follow-up answers
+- If the user refers to something from a previous message, use that context naturally"""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/state.py
+++ b/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/state.py
@@ -1,0 +1,19 @@
+from typing import TypedDict
+
+
+class TopicChatState(TypedDict):
+    topic_name: str
+    topic_description: str
+    audience_name: str
+    community_names: list[str]
+    language: str
+
+    # Deep dive context (if available)
+    deep_dive_context: str | None
+
+    # Conversation history: [{"role": "user"|"assistant", "content": "..."}]
+    messages: list[dict]
+
+    # Populated by nodes
+    context_quality: str  # "rich" or "limited"
+    answer: str | None

--- a/app/modules/topic_chat/application/use_cases/send_message_use_case/send_message_use_case.py
+++ b/app/modules/topic_chat/application/use_cases/send_message_use_case/send_message_use_case.py
@@ -1,0 +1,216 @@
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.topic_chat.application.use_cases.send_message_use_case.agent.chat_agent import (
+    create_chat_agent,
+)
+from app.modules.topic_chat.infra.repositories.topic_conversation_message_repository import (
+    TopicConversationMessageRepository,
+)
+from app.modules.topic_chat.infra.repositories.topic_conversation_repository import (
+    TopicConversationRepository,
+)
+from app.modules.topic_deep_dive.infra.repositories.topic_deep_dive_repository import (
+    TopicDeepDiveRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_HISTORY_MESSAGES = 40
+
+
+class SendMessageUseCase:
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.deep_dive_repo = TopicDeepDiveRepository(db)
+        self.conversation_repo = TopicConversationRepository(db)
+        self.message_repo = TopicConversationMessageRepository(db)
+
+    def execute(
+        self,
+        conversation_id: UUID,
+        question: str,
+        language: str = "en",
+    ) -> dict:
+        """
+        Envia uma mensagem na conversa e retorna a resposta da IA.
+
+        Returns:
+            dict com answer, context_quality, message_id, conversation_id
+        """
+        conversation = self.conversation_repo.find_by_id(conversation_id)
+        if not conversation:
+            return {"error": "Conversation not found"}
+
+        topic = self.topic_repo.get_topic_by_id(conversation.topic_id)
+        if not topic:
+            return {"error": "Topic not found"}
+
+        audience = self.audience_repo.find_by_id(conversation.audience_id)
+        if not audience:
+            return {"error": "Audience not found"}
+
+        communities = self.audience_repo.get_communities(conversation.audience_id)
+        community_names = [c.subreddit_name for c in communities]
+
+        # Persist user message
+        self.message_repo.create(
+            conversation_id=conversation_id,
+            role="user",
+            content=question,
+        )
+
+        # Load conversation history
+        history_records = self.message_repo.list_by_conversation(
+            conversation_id, limit=MAX_HISTORY_MESSAGES
+        )
+        messages = [
+            {"role": msg.role, "content": msg.content} for msg in history_records
+        ]
+
+        # Build deep dive context
+        deep_dive_context = None
+        context_quality = "limited"
+
+        latest_analysis = self.deep_dive_repo.find_latest_by_topic(
+            conversation.topic_id
+        )
+        if latest_analysis and latest_analysis.status == "ready":
+            deep_dive = self.deep_dive_repo.get_deep_dive(latest_analysis.id)
+            if deep_dive:
+                deep_dive_context = self._build_deep_dive_context(deep_dive)
+                context_quality = "rich"
+
+        # Run agent with conversation history
+        agent = create_chat_agent()
+        result = agent.invoke(
+            {
+                "topic_name": topic.name,
+                "topic_description": topic.description or "",
+                "audience_name": audience.name,
+                "community_names": community_names,
+                "language": language,
+                "deep_dive_context": deep_dive_context,
+                "context_quality": context_quality,
+                "messages": messages,
+                "answer": None,
+            }
+        )
+
+        answer = result.get("answer", "")
+        final_context_quality = result.get("context_quality", context_quality)
+
+        # Persist assistant message
+        assistant_msg = self.message_repo.create(
+            conversation_id=conversation_id,
+            role="assistant",
+            content=answer,
+            context_quality=final_context_quality,
+        )
+
+        # Update conversation metadata
+        self.conversation_repo.update_context_quality(
+            conversation_id, final_context_quality
+        )
+        self.conversation_repo.touch(conversation_id)
+
+        # Auto-generate title from first question
+        if not conversation.title:
+            title = question[:100].strip()
+            if len(question) > 100:
+                title += "..."
+            self.conversation_repo.update_title(conversation_id, title)
+
+        suggestion = None
+        if final_context_quality == "limited":
+            suggestion = (
+                "Execute o Deep Dive neste topico para obter respostas "
+                "mais detalhadas e baseadas em dados reais."
+            )
+
+        logger.info(
+            "Topic Chat: answered in conversation '%s' (quality: %s)",
+            conversation_id,
+            final_context_quality,
+        )
+
+        return {
+            "answer": answer,
+            "context_quality": final_context_quality,
+            "message_id": str(assistant_msg.id),
+            "conversation_id": str(conversation_id),
+            "suggestion": suggestion,
+        }
+
+    def _build_deep_dive_context(self, deep_dive) -> str:
+        """Builds a text context from the deep dive data stored in the database."""
+        sections = []
+
+        if deep_dive.summary:
+            sections.append(f"SUMMARY:\n{deep_dive.summary}")
+
+        if deep_dive.subtopics:
+            lines = ["SUBTOPICS IDENTIFIED:"]
+            for st in deep_dive.subtopics:
+                name = st.get("name", "")
+                desc = st.get("description", "")
+                count = st.get("post_count", 0)
+                lines.append(f"- {name} ({count} posts): {desc}")
+            sections.append("\n".join(lines))
+
+        if deep_dive.common_questions:
+            lines = ["FREQUENTLY ASKED QUESTIONS:"]
+            for q in deep_dive.common_questions:
+                question = q.get("question", "")
+                freq = q.get("frequency", "")
+                ctx = q.get("example_context", "")
+                lines.append(f'- [{freq}] "{question}"')
+                if ctx:
+                    lines.append(f'  Context: "{ctx}"')
+            sections.append("\n".join(lines))
+
+        if deep_dive.mentioned_products:
+            lines = ["MENTIONED TOOLS/PRODUCTS:"]
+            for p in deep_dive.mentioned_products:
+                name = p.get("name", "")
+                cat = p.get("category", "")
+                sentiment = p.get("sentiment", "")
+                mentions = p.get("mention_count", 0)
+                context = p.get("context", "")
+                lines.append(
+                    f"- {name} ({cat}, sentiment: {sentiment}, {mentions} mentions): {context}"
+                )
+            sections.append("\n".join(lines))
+
+        if deep_dive.representative_posts:
+            lines = ["REPRESENTATIVE POSTS:"]
+            for p in deep_dive.representative_posts:
+                title = p.get("title", "")
+                sub = p.get("subreddit", "")
+                score = p.get("score", 0)
+                excerpt = p.get("excerpt", "")
+                lines.append(f'- [r/{sub}, score:{score}] "{title}"')
+                if excerpt:
+                    lines.append(f'  Excerpt: "{excerpt}"')
+            sections.append("\n".join(lines))
+
+        if deep_dive.actionable_insights:
+            lines = ["ACTIONABLE INSIGHTS:"]
+            for i in deep_dive.actionable_insights:
+                insight = i.get("insight", "")
+                itype = i.get("type", "")
+                confidence = i.get("confidence", "")
+                lines.append(f"- [{itype}, {confidence} confidence] {insight}")
+            sections.append("\n".join(lines))
+
+        return "\n\n".join(sections)

--- a/app/modules/topic_chat/application/use_cases/start_conversation_use_case/start_conversation_use_case.py
+++ b/app/modules/topic_chat/application/use_cases/start_conversation_use_case/start_conversation_use_case.py
@@ -1,0 +1,84 @@
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.topic_chat.infra.repositories.topic_conversation_repository import (
+    TopicConversationRepository,
+)
+from app.modules.topic_deep_dive.infra.repositories.topic_deep_dive_repository import (
+    TopicDeepDiveRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StartConversationUseCase:
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.deep_dive_repo = TopicDeepDiveRepository(db)
+        self.conversation_repo = TopicConversationRepository(db)
+
+    def execute(
+        self,
+        topic_id: UUID,
+        audience_id: UUID,
+        user_id: UUID,
+    ) -> dict:
+        """
+        Cria uma nova conversa sobre um topico.
+
+        Returns:
+            dict com conversation_id, topic_name, context_quality
+        """
+        topic = self.topic_repo.get_topic_by_id(topic_id)
+        if not topic:
+            return {"error": "Topic not found"}
+
+        audience = self.audience_repo.find_by_id(audience_id)
+        if not audience:
+            return {"error": "Audience not found"}
+
+        # Determine context quality
+        context_quality = "limited"
+        latest_analysis = self.deep_dive_repo.find_latest_by_topic(topic_id)
+        if latest_analysis and latest_analysis.status == "ready":
+            deep_dive = self.deep_dive_repo.get_deep_dive(latest_analysis.id)
+            if deep_dive:
+                context_quality = "rich"
+
+        conversation = self.conversation_repo.create(
+            topic_id=topic_id,
+            audience_id=audience_id,
+            user_id=user_id,
+            context_quality=context_quality,
+        )
+
+        logger.info(
+            "Topic Chat: started conversation '%s' for topic '%s' (quality: %s)",
+            conversation.id,
+            topic.name,
+            context_quality,
+        )
+
+        suggestion = None
+        if context_quality == "limited":
+            suggestion = (
+                "Execute o Deep Dive neste topico para obter respostas "
+                "mais detalhadas e baseadas em dados reais."
+            )
+
+        return {
+            "conversation_id": str(conversation.id),
+            "topic_name": topic.name,
+            "context_quality": context_quality,
+            "suggestion": suggestion,
+        }

--- a/app/modules/topic_chat/domain/entities/topic_conversation.py
+++ b/app/modules/topic_chat/domain/entities/topic_conversation.py
@@ -1,0 +1,57 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class TopicConversation(Base):
+    """
+    Sessao de chat entre usuario e IA sobre um topico.
+    Cada conversa agrupa multiplas mensagens com historico.
+    """
+
+    __tablename__ = "topic_conversations"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    topic_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audience_topics.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title = Column(String(255), nullable=True)
+    context_quality = Column(
+        String(20), nullable=False, default="limited"
+    )  # rich, limited
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    messages = relationship(
+        "TopicConversationMessage",
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        order_by="TopicConversationMessage.created_at",
+    )

--- a/app/modules/topic_chat/domain/entities/topic_conversation_message.py
+++ b/app/modules/topic_chat/domain/entities/topic_conversation_message.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class TopicConversationMessage(Base):
+    """
+    Mensagem individual dentro de uma conversa de chat.
+    Pode ser do usuario (role=user) ou da IA (role=assistant).
+    """
+
+    __tablename__ = "topic_conversation_messages"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("topic_conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role = Column(String(20), nullable=False)  # user, assistant
+    content = Column(Text, nullable=False)
+    context_quality = Column(
+        String(20), nullable=True
+    )  # rich, limited (only for assistant messages)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    conversation = relationship(
+        "TopicConversation",
+        back_populates="messages",
+    )

--- a/app/modules/topic_chat/infra/repositories/topic_conversation_message_repository.py
+++ b/app/modules/topic_chat/infra/repositories/topic_conversation_message_repository.py
@@ -1,0 +1,51 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.topic_chat.domain.entities.topic_conversation_message import (
+    TopicConversationMessage,
+)
+
+
+class TopicConversationMessageRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        conversation_id: UUID,
+        role: str,
+        content: str,
+        context_quality: str | None = None,
+    ) -> TopicConversationMessage:
+        """Cria uma nova mensagem na conversa."""
+        message = TopicConversationMessage(
+            conversation_id=conversation_id,
+            role=role,
+            content=content,
+            context_quality=context_quality,
+        )
+        self.db.add(message)
+        self.db.commit()
+        self.db.refresh(message)
+        return message
+
+    def list_by_conversation(
+        self, conversation_id: UUID, limit: int = 50
+    ) -> list[TopicConversationMessage]:
+        """Lista mensagens de uma conversa em ordem cronologica."""
+        return (
+            self.db.query(TopicConversationMessage)
+            .filter(TopicConversationMessage.conversation_id == conversation_id)
+            .order_by(TopicConversationMessage.created_at.asc())
+            .limit(limit)
+            .all()
+        )
+
+    def count_by_conversation(self, conversation_id: UUID) -> int:
+        """Conta mensagens de uma conversa."""
+        return (
+            self.db.query(TopicConversationMessage)
+            .filter(TopicConversationMessage.conversation_id == conversation_id)
+            .count()
+        )

--- a/app/modules/topic_chat/infra/repositories/topic_conversation_repository.py
+++ b/app/modules/topic_chat/infra/repositories/topic_conversation_repository.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.topic_chat.domain.entities.topic_conversation import TopicConversation
+
+
+class TopicConversationRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        topic_id: UUID,
+        audience_id: UUID,
+        user_id: UUID,
+        title: str | None = None,
+        context_quality: str = "limited",
+    ) -> TopicConversation:
+        """Cria uma nova conversa."""
+        conversation = TopicConversation(
+            topic_id=topic_id,
+            audience_id=audience_id,
+            user_id=user_id,
+            title=title,
+            context_quality=context_quality,
+        )
+        self.db.add(conversation)
+        self.db.commit()
+        self.db.refresh(conversation)
+        return conversation
+
+    def find_by_id(self, conversation_id: UUID) -> TopicConversation | None:
+        """Busca conversa por ID."""
+        return (
+            self.db.query(TopicConversation)
+            .filter(TopicConversation.id == conversation_id)
+            .first()
+        )
+
+    def list_by_topic_and_user(
+        self, topic_id: UUID, user_id: UUID, limit: int = 20
+    ) -> list[TopicConversation]:
+        """Lista conversas de um usuario em um topico, mais recentes primeiro."""
+        return (
+            self.db.query(TopicConversation)
+            .filter(
+                TopicConversation.topic_id == topic_id,
+                TopicConversation.user_id == user_id,
+            )
+            .order_by(TopicConversation.updated_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def update_title(
+        self, conversation_id: UUID, title: str
+    ) -> TopicConversation | None:
+        """Atualiza o titulo da conversa."""
+        conversation = self.find_by_id(conversation_id)
+        if conversation:
+            conversation.title = title
+            conversation.updated_at = datetime.now(timezone.utc)
+            self.db.commit()
+            self.db.refresh(conversation)
+        return conversation
+
+    def update_context_quality(
+        self, conversation_id: UUID, context_quality: str
+    ) -> None:
+        """Atualiza a qualidade do contexto da conversa."""
+        conversation = self.find_by_id(conversation_id)
+        if conversation:
+            conversation.context_quality = context_quality
+            self.db.commit()
+
+    def touch(self, conversation_id: UUID) -> None:
+        """Atualiza o updated_at da conversa."""
+        conversation = self.find_by_id(conversation_id)
+        if conversation:
+            conversation.updated_at = datetime.now(timezone.utc)
+            self.db.commit()
+
+    def deactivate(self, conversation_id: UUID) -> TopicConversation | None:
+        """Desativa uma conversa (soft delete)."""
+        conversation = self.find_by_id(conversation_id)
+        if conversation:
+            conversation.is_active = False
+            conversation.updated_at = datetime.now(timezone.utc)
+            self.db.commit()
+            self.db.refresh(conversation)
+        return conversation

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -15,6 +15,7 @@ from app.routes.topic_behavioral_patterns import router as topic_behavioral_patt
 from app.routes.topic_snapshots import router as topic_snapshots_router
 from app.routes.notifications import router as notifications_router
 from app.routes.topic_ask import router as topic_ask_router
+from app.routes.topic_chat import router as topic_chat_router
 
 __all__ = [
     "auth_router",
@@ -32,4 +33,5 @@ __all__ = [
     "topic_snapshots_router",
     "notifications_router",
     "topic_ask_router",
+    "topic_chat_router",
 ]

--- a/app/routes/topic_chat.py
+++ b/app/routes/topic_chat.py
@@ -1,0 +1,255 @@
+"""Routes for topic chat (conversational Q&A with history)."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+from app.modules.topic_chat.application.use_cases.send_message_use_case.send_message_use_case import (
+    SendMessageUseCase,
+)
+from app.modules.topic_chat.application.use_cases.start_conversation_use_case.start_conversation_use_case import (
+    StartConversationUseCase,
+)
+from app.modules.topic_chat.infra.repositories.topic_conversation_message_repository import (
+    TopicConversationMessageRepository,
+)
+from app.modules.topic_chat.infra.repositories.topic_conversation_repository import (
+    TopicConversationRepository,
+)
+
+router = APIRouter(prefix="/audiences", tags=["Topic Chat"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
+TOPIC_NOT_FOUND = "Topic not found"
+CONVERSATION_NOT_FOUND = "Conversation not found"
+
+
+class SendMessageRequest(BaseModel):
+    question: str = Field(..., min_length=3, max_length=500)
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuario e dono da audiencia ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+def _check_conversation_ownership(conversation, current_user: User) -> None:
+    """Valida que o usuario e dono da conversa."""
+    if current_user.is_superuser:
+        return
+    if conversation.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+@router.post("/{audience_id}/topics/{topic_id}/chat")
+def start_conversation(
+    audience_id: UUID,
+    topic_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Inicia uma nova conversa sobre um topico.
+
+    Retorna o conversation_id para enviar mensagens.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    topic_repo = AudienceTopicRepository(db)
+    topic = topic_repo.get_topic_by_id(topic_id)
+    if not topic:
+        raise HTTPException(status_code=404, detail=TOPIC_NOT_FOUND)
+
+    use_case = StartConversationUseCase(db)
+    result = use_case.execute(
+        topic_id=topic_id,
+        audience_id=audience_id,
+        user_id=current_user.id,
+    )
+
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+
+    return result
+
+
+@router.post("/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages")
+def send_message(
+    audience_id: UUID,
+    topic_id: UUID,
+    conversation_id: UUID,
+    body: SendMessageRequest,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Envia uma mensagem na conversa e recebe a resposta da IA.
+
+    A IA considera todo o historico da conversa para responder.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    conversation_repo = TopicConversationRepository(db)
+    conversation = conversation_repo.find_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail=CONVERSATION_NOT_FOUND)
+
+    _check_conversation_ownership(conversation, current_user)
+
+    if not conversation.is_active:
+        raise HTTPException(status_code=400, detail="Conversation is archived")
+
+    use_case = SendMessageUseCase(db)
+    result = use_case.execute(
+        conversation_id=conversation_id,
+        question=body.question,
+        language=current_user.preferred_language,
+    )
+
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+
+    return result
+
+
+@router.get("/{audience_id}/topics/{topic_id}/chat")
+def list_conversations(
+    audience_id: UUID,
+    topic_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Lista conversas do usuario em um topico.
+
+    Retorna as conversas mais recentes primeiro.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    conversation_repo = TopicConversationRepository(db)
+    conversations = conversation_repo.list_by_topic_and_user(
+        topic_id=topic_id,
+        user_id=current_user.id,
+    )
+
+    return {
+        "conversations": [
+            {
+                "conversation_id": str(c.id),
+                "title": c.title,
+                "context_quality": c.context_quality,
+                "is_active": c.is_active,
+                "created_at": c.created_at.isoformat() if c.created_at else None,
+                "updated_at": c.updated_at.isoformat() if c.updated_at else None,
+            }
+            for c in conversations
+        ]
+    }
+
+
+@router.get("/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages")
+def list_messages(
+    audience_id: UUID,
+    topic_id: UUID,
+    conversation_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Lista mensagens de uma conversa.
+
+    Retorna mensagens em ordem cronologica.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    conversation_repo = TopicConversationRepository(db)
+    conversation = conversation_repo.find_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail=CONVERSATION_NOT_FOUND)
+
+    _check_conversation_ownership(conversation, current_user)
+
+    message_repo = TopicConversationMessageRepository(db)
+    messages = message_repo.list_by_conversation(conversation_id)
+
+    return {
+        "conversation_id": str(conversation_id),
+        "title": conversation.title,
+        "context_quality": conversation.context_quality,
+        "is_active": conversation.is_active,
+        "messages": [
+            {
+                "message_id": str(m.id),
+                "role": m.role,
+                "content": m.content,
+                "context_quality": m.context_quality,
+                "created_at": m.created_at.isoformat() if m.created_at else None,
+            }
+            for m in messages
+        ],
+    }
+
+
+@router.delete("/{audience_id}/topics/{topic_id}/chat/{conversation_id}")
+def archive_conversation(
+    audience_id: UUID,
+    topic_id: UUID,
+    conversation_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Arquiva uma conversa (soft delete).
+
+    A conversa nao sera mais listada como ativa, mas o historico e preservado.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    conversation_repo = TopicConversationRepository(db)
+    conversation = conversation_repo.find_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail=CONVERSATION_NOT_FOUND)
+
+    _check_conversation_ownership(conversation, current_user)
+
+    conversation_repo.deactivate(conversation_id)
+
+    return {"status": "archived", "conversation_id": str(conversation_id)}

--- a/docs/issue-65-topic-chat-conversations.md
+++ b/docs/issue-65-topic-chat-conversations.md
@@ -1,0 +1,297 @@
+# Issue #65 — Topic Chat — Conversa com IA por Topico com Historico
+
+## Motivacao
+
+O sistema ja possuia o Q&A de topicos (Issue #63) que permite perguntas livres sobre um topico. Porem, cada pergunta e **independente** — nao ha memoria de conversa. O usuario precisa repetir contexto a cada nova pergunta e nao consegue fazer follow-ups naturais como "e sobre isso?" ou "pode detalhar mais o ponto anterior?".
+
+### Cenario do usuario
+
+O usuario tem uma audiencia "Marketing" e ve o topico "AI in Marketing". Ele ja rodou o Deep Dive e usou o Ask Q&A. Agora quer ter uma **conversa continua**: primeiro pergunta "Quais sao as principais dores?", depois "E quais ferramentas estao sendo recomendadas para resolver essas dores?", e depois "Qual dessas ferramentas tem melhor sentimento?". Cada resposta da IA considera toda a conversa anterior, como um chat real.
+
+### Diferencial em relacao ao Ask Q&A
+
+| Modulo | Tipo | Estado | Historico |
+|--------|------|--------|-----------|
+| **Ask Q&A** (Issue #63) | Pergunta isolada | Stateless | Nao — cada pergunta e independente |
+| **Topic Chat** (Issue #65) | Conversa continua | Stateful | Sim — IA lembra de toda a conversa |
+
+---
+
+## Solucao Adotada
+
+### Abordagem: Chat sincrono com historico persistido
+
+Diferente do Ask Q&A que usa cache LLM (mesma pergunta = mesma resposta), o Topic Chat **nao usa cache** — cada resposta e unica considerando o historico acumulado. A resposta continua sincrona (~3-5 segundos) pois reutiliza dados do Deep Dive sem coletar dados do Reddit.
+
+```
+POST /audiences/{id}/topics/{topic_id}/chat
+    → StartConversationUseCase
+        → Verifica deep dive disponivel → Define context_quality
+        → Cria registro TopicConversation
+        → Retorna conversation_id
+
+POST /audiences/{id}/topics/{topic_id}/chat/{conv_id}/messages
+    → SendMessageUseCase
+        → Persiste mensagem do usuario
+        → Carrega historico da conversa (ultimas 40 mensagens)
+        → Busca deep dive context (se disponivel)
+        → LangGraph: build_context → answer_with_history
+            → SystemMessage (contexto + instrucoes)
+            → HumanMessage/AIMessage alternados (historico)
+        → Persiste resposta da IA
+        → Auto-gera titulo da conversa (primeira pergunta)
+        → Retorna resposta
+```
+
+### Decisoes arquiteturais
+
+1. **Modulo separado do Ask Q&A:** O Topic Chat tem entidades, repositorios e agent proprios. O Ask Q&A continua existindo para perguntas rapidas sem estado — os dois coexistem com propositos diferentes.
+
+2. **Historico como mensagens do LLM:** Em vez de concatenar o historico no prompt (como texto plano), o agent usa `SystemMessage` + `HumanMessage`/`AIMessage` — o formato nativo da API do LLM para conversas multi-turn. Isso permite que o modelo entenda melhor a estrutura da conversa.
+
+3. **Limite de 40 mensagens:** Para evitar estourar o contexto do LLM, o historico e limitado a 40 mensagens (20 turnos user/assistant). Mensagens mais antigas sao descartadas do prompt mas permanecem persistidas no banco.
+
+4. **Sem cache LLM:** Diferente do Ask Q&A (cache 48h), o chat nao cacheia respostas — cada resposta e unica dado o historico acumulado. O cache nao faz sentido em conversas multi-turn.
+
+5. **Titulo auto-gerado:** O titulo da conversa e gerado automaticamente a partir da primeira pergunta (primeiros 100 caracteres). Isso permite que o usuario identifique conversas na listagem sem esforco.
+
+6. **Soft delete (archive):** Conversas nao sao deletadas — sao desativadas (`is_active=False`). O historico e preservado para analytics futuros.
+
+7. **Deep Dive como fonte de contexto:** Mesmo padrao do Ask Q&A — serializa dados do deep dive em texto plano para o system prompt. Se nao houver deep dive, `context_quality = "limited"`.
+
+8. **`max_completion_tokens=16384`:** Mesmo padrao do Ask Q&A para suportar reasoning models.
+
+---
+
+## Arquivos Criados
+
+### `app/modules/topic_chat/domain/entities/topic_conversation.py`
+- Entidade `TopicConversation` — tabela `topic_conversations` (id, topic_id, audience_id, user_id, title, context_quality, is_active, created_at, updated_at)
+- FKs CASCADE para `audience_topics`, `audiences` e `users`
+- Relationship com `TopicConversationMessage` (cascade delete-orphan)
+
+### `app/modules/topic_chat/domain/entities/topic_conversation_message.py`
+- Entidade `TopicConversationMessage` — tabela `topic_conversation_messages` (id, conversation_id, role, content, context_quality, created_at)
+- FK CASCADE para `topic_conversations`
+- Relationship back_populates com `TopicConversation`
+
+### `alembic/versions/e7f8a9b0c1d2_add_topic_chat_tables.py`
+- Migration criando tabelas `topic_conversations` e `topic_conversation_messages` com todas as colunas, indices e FKs
+
+### `app/modules/topic_chat/infra/repositories/topic_conversation_repository.py`
+- `create()` — cria nova conversa
+- `find_by_id()` — busca conversa por ID
+- `list_by_topic_and_user()` — lista conversas de um usuario em um topico
+- `update_title()` — atualiza titulo
+- `update_context_quality()` — atualiza qualidade do contexto
+- `touch()` — atualiza updated_at
+- `deactivate()` — soft delete
+
+### `app/modules/topic_chat/infra/repositories/topic_conversation_message_repository.py`
+- `create()` — cria nova mensagem
+- `list_by_conversation()` — lista mensagens em ordem cronologica
+- `count_by_conversation()` — conta mensagens
+
+### `app/modules/topic_chat/application/use_cases/send_message_use_case/agent/`
+- `state.py` — `TopicChatState` (TypedDict) com: topic_name, topic_description, audience_name, community_names, language, deep_dive_context, context_quality, messages (historico), answer
+- `prompts/chat_prompts.py` — `topic_chat_system_prompt()` com instrucoes para conversa multi-turn, referencia a historico, maximo 4 paragrafos
+- `chat_agent.py` — Agente LangGraph com 2 nos: `build_context` → `answer_with_history`. Usa `SystemMessage` + `HumanMessage`/`AIMessage` para historico nativo do LLM
+
+### `app/modules/topic_chat/application/use_cases/send_message_use_case/send_message_use_case.py`
+- `execute()` — orquestra: persiste msg user → carrega historico → deep dive → agent → persiste msg assistant → auto-titulo → resposta
+- `_build_deep_dive_context()` — serializa dados do deep dive em texto plano (mesmo padrao do Ask Q&A)
+
+### `app/modules/topic_chat/application/use_cases/start_conversation_use_case/start_conversation_use_case.py`
+- `execute()` — valida topic/audience → determina context_quality → cria conversa → retorna conversation_id
+
+### `app/routes/topic_chat.py`
+- `POST /audiences/{audience_id}/topics/{topic_id}/chat` — criar conversa
+- `POST /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages` — enviar mensagem
+- `GET /audiences/{audience_id}/topics/{topic_id}/chat` — listar conversas
+- `GET /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages` — listar mensagens
+- `DELETE /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}` — arquivar conversa
+- Validacoes: ownership de audiencia + ownership de conversa
+- `SendMessageRequest` — Pydantic model com `question: str` (min 3, max 500 chars)
+
+---
+
+## Arquivos Modificados
+
+| Arquivo | Mudanca |
+|---------|---------|
+| `alembic/env.py` | Import das entidades `topic_conversation` e `topic_conversation_message` |
+| `app/routes/__init__.py` | Import e export do `topic_chat_router` |
+| `app/main.py` | Registro do `topic_chat_router` |
+
+---
+
+## Estrutura de Dados Retornada
+
+### Criar conversa
+
+```json
+{
+  "conversation_id": "uuid",
+  "topic_name": "AI in Marketing",
+  "context_quality": "rich",
+  "suggestion": null
+}
+```
+
+### Enviar mensagem
+
+```json
+{
+  "answer": "Segundo as discussoes nas comunidades...",
+  "context_quality": "rich",
+  "message_id": "uuid",
+  "conversation_id": "uuid",
+  "suggestion": null
+}
+```
+
+### Listar conversas
+
+```json
+{
+  "conversations": [
+    {
+      "conversation_id": "uuid",
+      "title": "Quais sao as principais dores das pessoas nesse topico?",
+      "context_quality": "rich",
+      "is_active": true,
+      "created_at": "2026-02-24T10:00:00+00:00",
+      "updated_at": "2026-02-24T10:05:00+00:00"
+    }
+  ]
+}
+```
+
+### Listar mensagens
+
+```json
+{
+  "conversation_id": "uuid",
+  "title": "Quais sao as principais dores...",
+  "context_quality": "rich",
+  "is_active": true,
+  "messages": [
+    {
+      "message_id": "uuid",
+      "role": "user",
+      "content": "Quais sao as principais dores das pessoas nesse topico?",
+      "context_quality": null,
+      "created_at": "2026-02-24T10:00:00+00:00"
+    },
+    {
+      "message_id": "uuid",
+      "role": "assistant",
+      "content": "Segundo as discussoes nas comunidades r/digital_marketing...",
+      "context_quality": "rich",
+      "created_at": "2026-02-24T10:00:04+00:00"
+    }
+  ]
+}
+```
+
+### Arquivar conversa
+
+```json
+{
+  "status": "archived",
+  "conversation_id": "uuid"
+}
+```
+
+---
+
+## Como Testar
+
+### Teste 1 — Criar conversa e enviar primeira mensagem
+
+```http
+POST /audiences/{audience_id}/topics/{topic_id}/chat
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{conversation_id: "uuid", context_quality: "rich"}`
+
+```http
+POST /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"question": "Quais sao as principais dores das pessoas nesse topico?"}
+```
+
+**Esperado:** `{answer: "...", context_quality: "rich", message_id: "uuid"}`
+
+### Teste 2 — Follow-up (IA lembra do contexto)
+
+```http
+POST /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"question": "E quais ferramentas estao sendo recomendadas para resolver essas dores?"}
+```
+
+**Esperado:** Resposta que referencia "dores" da mensagem anterior, mostrando que a IA tem contexto da conversa.
+
+### Teste 3 — Listar conversas
+
+```http
+GET /audiences/{audience_id}/topics/{topic_id}/chat
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{conversations: [{title: "Quais sao as principais dores...", ...}]}` — titulo auto-gerado.
+
+### Teste 4 — Listar mensagens
+
+```http
+GET /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}/messages
+Authorization: Bearer <token>
+```
+
+**Esperado:** Mensagens em ordem cronologica, alternando user/assistant.
+
+### Teste 5 — Arquivar conversa
+
+```http
+DELETE /audiences/{audience_id}/topics/{topic_id}/chat/{conversation_id}
+Authorization: Bearer <token>
+```
+
+**Esperado:** `{status: "archived"}`. Apos isso, enviar mensagem retorna 400 "Conversation is archived".
+
+### Teste 6 — Validacoes
+
+- Pergunta com menos de 3 chars → 422
+- Conversa inexistente → 404
+- Audiencia de outro usuario → 403
+- Sem autenticacao → 401
+
+---
+
+## Relacao com Outras Issues
+
+| Issue | Relacao |
+|-------|---------|
+| #63 — Topic Ask Q&A | Evolucao: Chat adiciona historico ao conceito de Q&A. Ask continua como pergunta isolada, Chat e conversa continua |
+| #38 — Topic Deep Dive | Fonte de contexto: dados do deep dive sao serializados em texto plano para o system prompt do chat |
+| #17 — Audience User Ownership | Reutiliza `_check_ownership` nas rotas |
+| #54 — Multi-Language | Reutiliza `get_language_directive()` para respostas no idioma do usuario |
+
+---
+
+## Melhorias Futuras
+
+- **SSE Streaming:** Retornar resposta token-a-token via Server-Sent Events para UX de chat real-time, aproveitando o padrao SSE ja existente no modulo de notificacoes
+- **Sugestoes de perguntas:** Baseado nos dados do deep dive, sugerir follow-ups relevantes ao usuario apos cada resposta
+- **Contexto expandido:** Incluir dados de sentiment analysis (Issue #59) e patterns (Issue #39) como contexto adicional para respostas mais ricas
+- **Titulo inteligente:** Gerar titulo da conversa automaticamente via LLM ao inves de truncar a primeira pergunta
+- **Limite de mensagens por conversa:** Definir um teto (ex: 50 mensagens) e sugerir nova conversa quando atingido
+- **Exportar conversa:** Permitir download do historico em markdown ou PDF
+- **Resumo de contexto:** Quando o historico ultrapassar o limite, gerar um resumo das mensagens antigas para manter contexto sem estourar tokens
+- **Rate limiting:** Limitar numero de mensagens por usuario/conversa por hora

--- a/docs/issue-65-topic-chat-conversations.md
+++ b/docs/issue-65-topic-chat-conversations.md
@@ -287,11 +287,16 @@ Authorization: Bearer <token>
 
 ## Melhorias Futuras
 
+> Todas as melhorias abaixo estao detalhadas e priorizadas no card de backlog: [Issue #67 — feat: melhorias e evolução do Topic Chat](https://github.com/robsonmvieira/oraculo-backend/issues/67).
+
+### Should Have
 - **SSE Streaming:** Retornar resposta token-a-token via Server-Sent Events para UX de chat real-time, aproveitando o padrao SSE ja existente no modulo de notificacoes
-- **Sugestoes de perguntas:** Baseado nos dados do deep dive, sugerir follow-ups relevantes ao usuario apos cada resposta
 - **Contexto expandido:** Incluir dados de sentiment analysis (Issue #59) e patterns (Issue #39) como contexto adicional para respostas mais ricas
+- **Resumo de contexto:** Quando o historico ultrapassar o limite de 40 mensagens, gerar um resumo das mensagens antigas via LLM para manter contexto sem estourar tokens
+
+### Nice to Have
+- **Sugestoes de perguntas:** Baseado nos dados do deep dive, sugerir 2-3 follow-ups relevantes ao usuario apos cada resposta
 - **Titulo inteligente:** Gerar titulo da conversa automaticamente via LLM ao inves de truncar a primeira pergunta
-- **Limite de mensagens por conversa:** Definir um teto (ex: 50 mensagens) e sugerir nova conversa quando atingido
-- **Exportar conversa:** Permitir download do historico em markdown ou PDF
-- **Resumo de contexto:** Quando o historico ultrapassar o limite, gerar um resumo das mensagens antigas para manter contexto sem estourar tokens
 - **Rate limiting:** Limitar numero de mensagens por usuario/conversa por hora
+- **Exportar conversa:** Permitir download do historico em markdown ou PDF
+- **Limite de mensagens por conversa:** Definir um teto (ex: 50 mensagens) e sugerir nova conversa quando atingido


### PR DESCRIPTION
## Summary
- Adds a new `topic_chat` module that enables persistent conversations between users and AI about specific topics
- Each new message considers the full conversation history for coherent multi-turn follow-up answers
- Uses LangGraph agent with `SystemMessage` + `HumanMessage`/`AIMessage` history pattern for multi-turn LLM calls
- Deep Dive data is used as context (same pattern as topic_ask)

## What was done
- **Entities:** `TopicConversation` (session) + `TopicConversationMessage` (individual messages with role user/assistant)
- **Migration:** Creates `topic_conversations` and `topic_conversation_messages` tables
- **Repositories:** CRUD for conversations and messages
- **Agent:** LangGraph multi-turn chat agent with conversation history support
- **Use Cases:** `StartConversationUseCase` + `SendMessageUseCase`
- **Endpoints:**
  - `POST /audiences/{id}/topics/{tid}/chat` — start conversation
  - `POST /audiences/{id}/topics/{tid}/chat/{conv_id}/messages` — send message
  - `GET /audiences/{id}/topics/{tid}/chat` — list conversations
  - `GET /audiences/{id}/topics/{tid}/chat/{conv_id}/messages` — list messages
  - `DELETE /audiences/{id}/topics/{tid}/chat/{conv_id}` — archive conversation

## Test plan
- [ ] Create a new conversation via POST and verify `conversation_id` is returned
- [ ] Send first message and verify AI response considers deep dive context
- [ ] Send follow-up message and verify AI references previous conversation context
- [ ] List conversations and verify the most recent appears first with auto-generated title
- [ ] List messages and verify chronological order with user/assistant roles
- [ ] Archive conversation and verify it cannot receive new messages
- [ ] Verify ownership checks (403 for non-owner)
- [ ] Verify validation (422 for question < 3 chars)
- [ ] Run migration and verify tables are created correctly

Closes #65