### PR TITLE
feat: temporal theme analysis (Hot Discussions & Top Content)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -46,6 +46,7 @@ from app.modules.topic_snapshots.domain.entities import topic_snapshot  # noqa: 
 from app.modules.notifications.domain.entities import notification  # noqa: E402
 from app.modules.topic_chat.domain.entities import topic_conversation  # noqa: E402
 from app.modules.topic_chat.domain.entities import topic_conversation_message  # noqa: E402
+from app.modules.theme_analysis.domain.entities import theme  # noqa: E402
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/71731c50ceea_add_theme_analyses_and_themes_tables.py
+++ b/alembic/versions/71731c50ceea_add_theme_analyses_and_themes_tables.py
@@ -1,0 +1,71 @@
+"""add theme_analyses and themes tables
+
+Revision ID: 71731c50ceea
+Revises: e7f8a9b0c1d2
+Create Date: 2026-02-25 11:54:12.717133
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '71731c50ceea'
+down_revision: Union[str, Sequence[str], None] = 'e7f8a9b0c1d2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('theme_analyses',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('audience_id', sa.UUID(), nullable=False),
+    sa.Column('status', sa.String(length=20), nullable=False),
+    sa.Column('time_window', sa.String(length=10), nullable=False),
+    sa.Column('period_start', sa.Date(), nullable=True),
+    sa.Column('period_end', sa.Date(), nullable=True),
+    sa.Column('communities_fingerprint', sa.String(length=64), nullable=False),
+    sa.Column('total_themes', sa.Integer(), nullable=True),
+    sa.Column('error_message', sa.Text(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['audience_id'], ['audiences.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_theme_analyses_audience_id'), 'theme_analyses', ['audience_id'], unique=False)
+    op.create_index(op.f('ix_theme_analyses_communities_fingerprint'), 'theme_analyses', ['communities_fingerprint'], unique=False)
+    op.create_index(op.f('ix_theme_analyses_status'), 'theme_analyses', ['status'], unique=False)
+    op.create_index(op.f('ix_theme_analyses_time_window'), 'theme_analyses', ['time_window'], unique=False)
+    op.create_table('themes',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('analysis_id', sa.UUID(), nullable=False),
+    sa.Column('name', sa.String(length=200), nullable=False),
+    sa.Column('summary', sa.Text(), nullable=True),
+    sa.Column('post_count', sa.Integer(), nullable=True),
+    sa.Column('avg_score', sa.Float(), nullable=True),
+    sa.Column('avg_comments', sa.Float(), nullable=True),
+    sa.Column('engagement_score', sa.Float(), nullable=True),
+    sa.Column('top_subreddits', sa.JSON(), nullable=True),
+    sa.Column('top_keywords', sa.JSON(), nullable=True),
+    sa.Column('representative_posts', sa.JSON(), nullable=True),
+    sa.Column('rank', sa.Integer(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['analysis_id'], ['theme_analyses.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_themes_analysis_id'), 'themes', ['analysis_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_themes_analysis_id'), table_name='themes')
+    op.drop_table('themes')
+    op.drop_index(op.f('ix_theme_analyses_time_window'), table_name='theme_analyses')
+    op.drop_index(op.f('ix_theme_analyses_status'), table_name='theme_analyses')
+    op.drop_index(op.f('ix_theme_analyses_communities_fingerprint'), table_name='theme_analyses')
+    op.drop_index(op.f('ix_theme_analyses_audience_id'), table_name='theme_analyses')
+    op.drop_table('theme_analyses')

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.routes import (
     topic_patterns_router,
     topic_sentiment_router,
     topic_ask_router,
+    theme_analysis_router,
     topic_chat_router,
     topic_snapshots_router,
     topics_router,
@@ -86,6 +87,7 @@ app.include_router(topic_snapshots_router)
 app.include_router(notifications_router)
 app.include_router(topic_ask_router)
 app.include_router(topic_chat_router)
+app.include_router(theme_analysis_router)
 
 
 @app.get("/")

--- a/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/prompts/theme_prompts.py
+++ b/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/prompts/theme_prompts.py
@@ -1,0 +1,94 @@
+"""Prompts para o agente de extração de temas temporais."""
+
+
+def get_extract_themes_prompt(
+    audience_name: str,
+    communities_str: str,
+    time_window: str,
+    period_start: str,
+    period_end: str,
+    total_posts: int,
+    posts_text: str,
+    language_directive: str = "",
+) -> str:
+    """Prompt do nó 1: extração de temas a partir dos posts filtrados."""
+    return f"""You are an expert Reddit analyst specializing in temporal trend detection.
+
+Audience: "{audience_name}"
+Communities: {communities_str}
+Time window: {time_window} ({period_start} to {period_end})
+Total posts in window: {total_posts}
+
+Below are the titles and text from posts in these communities during this period:
+
+{posts_text}
+
+---
+
+TASK: Identify the most prominent discussion themes from this {time_window} period.
+
+For each theme:
+1. Name (2-5 words, descriptive of the theme)
+2. Count how many posts relate to this theme
+3. Calculate average score and average comments for posts in this theme
+4. List the top subreddits where this theme appears, with post counts and avg scores
+5. Extract the 3-5 most representative/engaged posts (title, subreddit, score, permalink)
+6. List 5-10 keywords that characterize this theme
+
+Focus on TEMPORAL relevance — what makes this {time_window} period unique?
+Highlight themes that are spiking, emerging, or unusually active.
+
+Return between 3 and 8 themes, ranked by engagement potential.
+
+Respond in JSON format:
+[
+  {{
+    "name": "...",
+    "post_count": N,
+    "avg_score": N.N,
+    "avg_comments": N.N,
+    "top_subreddits": [{{"name": "...", "post_count": N, "avg_score": N.N}}],
+    "representative_posts": [{{"title": "...", "subreddit": "...", "score": N, "permalink": "..."}}],
+    "keywords": ["...", "..."]
+  }}
+]
+
+IMPORTANT: Return ONLY valid JSON array. No markdown, no explanation.{language_directive}"""
+
+
+def get_generate_summary_prompt(
+    audience_name: str,
+    communities_str: str,
+    time_window: str,
+    period_start: str,
+    period_end: str,
+    themes_json: str,
+    language_directive: str = "",
+) -> str:
+    """Prompt do nó 2: geração de resumo narrativo por tema."""
+    return f"""You are a newsletter writer summarizing Reddit discussions for a community manager.
+
+Audience: "{audience_name}"
+Time window: This {time_window} ({period_start} to {period_end})
+Communities: {communities_str}
+
+Here are the themes identified for this period:
+
+{themes_json}
+
+---
+
+TASK: Write a 2-3 sentence narrative summary for EACH theme.
+
+The summary should:
+- Be written in the style of a newsletter intro paragraph
+- Mention specific subreddits and topics naturally
+- Capture the MOOD and ENERGY of the discussions
+- Explain WHY this theme was relevant this {time_window}
+
+Respond in JSON:
+[
+  {{"theme_name": "...", "summary": "..."}}
+]
+
+IMPORTANT: Return ONLY valid JSON array. No markdown, no explanation.{language_directive}"""

--- a/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/state.py
+++ b/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/state.py
@@ -1,0 +1,42 @@
+"""Estado do agente de extração de temas temporais."""
+
+from typing import TypedDict
+
+
+class PostData(TypedDict):
+    id: str
+    subreddit: str
+    title: str
+    selftext: str
+    score: int
+    num_comments: int
+    created_utc: float
+    permalink: str
+
+
+class ExtractedTheme(TypedDict):
+    name: str
+    summary: str | None
+    post_count: int
+    avg_score: float
+    avg_comments: float
+    engagement_score: float | None
+    top_subreddits: list[dict]  # [{"name": "sub", "post_count": N, "avg_score": N}]
+    top_keywords: list[dict]  # [{"keyword": "...", "frequency": N}]
+    representative_posts: list[dict]  # [{"title": "...", "subreddit": "...", "score": N, "permalink": "..."}]
+    rank: int | None
+
+
+class ThemeExtractionState(TypedDict):
+    audience_name: str
+    audience_description: str | None
+    community_names: list[str]
+    posts: list[PostData]
+    total_posts: int
+    time_window: str  # "week" ou "month"
+    period_start: str
+    period_end: str
+    language: str
+
+    # Populados pelos nós
+    extracted_themes: list[ExtractedTheme]

--- a/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/theme_extraction_agent.py
+++ b/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/theme_extraction_agent.py
@@ -1,0 +1,201 @@
+"""Agente LangGraph para extração de temas temporais (2 nós)."""
+
+import json
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.shared.application.helpers.language_directive import (
+    get_language_directive,
+)
+from app.modules.theme_analysis.application.use_cases.extract_themes_use_case.agent.prompts.theme_prompts import (
+    get_extract_themes_prompt,
+    get_generate_summary_prompt,
+)
+from app.modules.theme_analysis.application.use_cases.extract_themes_use_case.agent.state import (
+    ExtractedTheme,
+    ThemeExtractionState,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_POSTS_CHARS = 80_000
+
+
+def _get_llm() -> ChatOpenAI:
+    return ChatOpenAI(
+        model=os.getenv("MODEL_NAME", "gpt-4o-mini"),
+        temperature=0,
+    )
+
+
+def _build_posts_text(posts: list[dict]) -> str:
+    """Monta texto dos posts para injetar no prompt, respeitando limite de caracteres."""
+    lines = []
+    total_chars = 0
+    for p in posts:
+        line = f"[r/{p['subreddit']}] (score:{p['score']}, comments:{p['num_comments']}) {p['title']}"
+        selftext = (p.get("selftext") or "")[:300]
+        if selftext:
+            line += f"\n  {selftext}"
+        if p.get("permalink"):
+            line += f"\n  permalink: {p['permalink']}"
+
+        if total_chars + len(line) > MAX_POSTS_CHARS:
+            break
+        lines.append(line)
+        total_chars += len(line)
+
+    return "\n\n".join(lines)
+
+
+def _calculate_engagement_score(theme: dict) -> float:
+    """Calcula engagement score composto."""
+    avg_score = theme.get("avg_score", 0) or 0
+    avg_comments = theme.get("avg_comments", 0) or 0
+    post_count = theme.get("post_count", 0) or 0
+    subreddit_diversity = len(theme.get("top_subreddits", []))
+
+    return (
+        (avg_score * 0.4)
+        + (avg_comments * 0.3)
+        + (post_count * 0.2)
+        + (subreddit_diversity * 0.1)
+    )
+
+
+def _parse_json_response(content: str) -> list[dict]:
+    """Tenta extrair JSON array do conteúdo da resposta do LLM."""
+    content = content.strip()
+    # Remove markdown code fences se presente
+    if content.startswith("```"):
+        lines = content.split("\n")
+        # Remove primeira e última linha (code fences)
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        content = "\n".join(lines).strip()
+
+    return json.loads(content)
+
+
+def extract_themes(state: ThemeExtractionState) -> dict:
+    """Nó 1: LLM identifica temas temporais a partir dos posts filtrados."""
+    posts = state["posts"]
+    if not posts:
+        return {"extracted_themes": []}
+
+    posts_text = _build_posts_text(posts)
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    communities_str = ", ".join(f"r/{c}" for c in state["community_names"])
+    prompt = get_extract_themes_prompt(
+        audience_name=state["audience_name"],
+        communities_str=communities_str,
+        time_window=state["time_window"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        total_posts=state["total_posts"],
+        posts_text=posts_text,
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+
+    try:
+        raw_themes = _parse_json_response(response.content)
+    except ValueError:
+        logger.error("Failed to parse themes JSON from LLM response")
+        return {"extracted_themes": []}
+
+    themes: list[ExtractedTheme] = []
+    for rank, raw in enumerate(raw_themes, start=1):
+        theme = ExtractedTheme(
+            name=raw.get("name", "Unknown Theme"),
+            summary=None,  # Preenchido no nó 2
+            post_count=raw.get("post_count", 0),
+            avg_score=raw.get("avg_score", 0),
+            avg_comments=raw.get("avg_comments", 0),
+            engagement_score=_calculate_engagement_score(raw),
+            top_subreddits=raw.get("top_subreddits", []),
+            top_keywords=[
+                {"keyword": kw, "frequency": 0}
+                for kw in raw.get("keywords", [])
+            ],
+            representative_posts=raw.get("representative_posts", []),
+            rank=rank,
+        )
+        themes.append(theme)
+
+    # Re-rankear por engagement_score
+    themes.sort(key=lambda t: t.get("engagement_score", 0) or 0, reverse=True)
+    for i, theme in enumerate(themes, start=1):
+        theme["rank"] = i
+
+    logger.info("Extracted %d themes from %d posts", len(themes), len(posts))
+    return {"extracted_themes": themes}
+
+
+def generate_summary(state: ThemeExtractionState) -> dict:
+    """Nó 2: LLM gera resumo narrativo para cada tema."""
+    themes = state.get("extracted_themes", [])
+    if not themes:
+        return {"extracted_themes": themes}
+
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+    communities_str = ", ".join(f"r/{c}" for c in state["community_names"])
+
+    # Preparar JSON dos temas para o prompt
+    themes_for_prompt = [
+        {
+            "name": t["name"],
+            "post_count": t["post_count"],
+            "avg_score": t["avg_score"],
+            "avg_comments": t["avg_comments"],
+            "top_subreddits": t["top_subreddits"],
+            "top_keywords": t["top_keywords"],
+        }
+        for t in themes
+    ]
+
+    prompt = get_generate_summary_prompt(
+        audience_name=state["audience_name"],
+        communities_str=communities_str,
+        time_window=state["time_window"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        themes_json=json.dumps(themes_for_prompt, indent=2),
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+
+    try:
+        summaries = _parse_json_response(response.content)
+    except ValueError:
+        logger.error("Failed to parse summaries JSON from LLM response")
+        return {"extracted_themes": themes}
+
+    # Mapear resumos aos temas por nome
+    summary_map = {s["theme_name"]: s["summary"] for s in summaries if "theme_name" in s}
+    for theme in themes:
+        theme["summary"] = summary_map.get(theme["name"])
+
+    logger.info("Generated summaries for %d themes", len(summary_map))
+    return {"extracted_themes": themes}
+
+
+def create_theme_extraction_agent():
+    """Cria o agente LangGraph para extração de temas temporais."""
+    workflow = StateGraph(ThemeExtractionState)
+
+    workflow.add_node("extract_themes", extract_themes)
+    workflow.add_node("generate_summary", generate_summary)
+
+    workflow.add_edge(START, "extract_themes")
+    workflow.add_edge("extract_themes", "generate_summary")
+    workflow.add_edge("generate_summary", END)
+
+    return workflow.compile()

--- a/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/extract_themes_use_case.py
+++ b/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/extract_themes_use_case.py
@@ -1,0 +1,260 @@
+"""Use case para extração de temas temporais (roda em background thread)."""
+
+import logging
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.theme_analysis.application.use_cases.extract_themes_use_case.agent.state import (
+    PostData,
+)
+from app.modules.theme_analysis.application.use_cases.extract_themes_use_case.agent.theme_extraction_agent import (
+    create_theme_extraction_agent,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+from app.modules.topics.infra.providers.reddit_provider.generic_reddit_provider import (
+    GenericRedditProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _filter_posts_by_window(posts: list[dict], window: str) -> list[dict]:
+    """Filtra posts por janela temporal baseado em created_utc."""
+    now = datetime.utcnow()
+    if window == "week":
+        cutoff = now - timedelta(days=7)
+    elif window == "month":
+        cutoff = now - timedelta(days=30)
+    else:
+        return posts
+
+    cutoff_ts = cutoff.timestamp()
+    return [p for p in posts if (p.get("created_utc") or 0) >= cutoff_ts]
+
+
+class ExtractThemesUseCase:
+    """
+    Coleta posts filtrados por janela temporal e extrai temas via LangGraph.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.theme_repo = ThemeAnalysisRepository(db)
+        self.reddit_provider = GenericRedditProvider()
+
+    def _collect_posts_for_window(
+        self, community_names: list[str], window: str
+    ) -> list[PostData]:
+        """Coleta posts do Reddit com sorts adequados para a janela temporal."""
+        all_raw_posts = []
+
+        for community in community_names:
+            if window == "week":
+                # Hot + new para capturar o que está quente e o que acabou de surgir
+                for sort in ("hot", "new"):
+                    result = self.reddit_provider.get_subreddit_posts(
+                        subreddit_name=community,
+                        sort=sort,
+                        limit=50,
+                    )
+                    for post in result.posts:
+                        all_raw_posts.append({
+                            "id": post.id,
+                            "subreddit": post.subreddit,
+                            "title": post.title,
+                            "selftext": post.selftext,
+                            "score": post.score,
+                            "num_comments": post.num_comments,
+                            "created_utc": post.created_utc,
+                            "permalink": post.permalink or "",
+                        })
+            elif window == "month":
+                # Top do mês para capturar melhor conteúdo
+                result = self.reddit_provider.get_subreddit_posts(
+                    subreddit_name=community,
+                    sort="top",
+                    limit=50,
+                    time_filter="month",
+                )
+                for post in result.posts:
+                    all_raw_posts.append({
+                        "id": post.id,
+                        "subreddit": post.subreddit,
+                        "title": post.title,
+                        "selftext": post.selftext,
+                        "score": post.score,
+                        "num_comments": post.num_comments,
+                        "created_utc": post.created_utc,
+                        "permalink": post.permalink or "",
+                    })
+
+        # Filtrar por janela temporal
+        filtered = _filter_posts_by_window(all_raw_posts, window)
+
+        # Deduplicar por post ID
+        seen_ids: set[str] = set()
+        unique_posts: list[PostData] = []
+        for post in filtered:
+            if post["id"] in seen_ids:
+                continue
+            seen_ids.add(post["id"])
+            unique_posts.append(
+                PostData(
+                    id=post["id"],
+                    subreddit=post["subreddit"],
+                    title=post["title"],
+                    selftext=post["selftext"],
+                    score=post["score"],
+                    num_comments=post["num_comments"],
+                    created_utc=post["created_utc"],
+                    permalink=post.get("permalink", ""),
+                )
+            )
+
+        return unique_posts
+
+    def execute(
+        self,
+        audience_id: UUID,
+        analysis_id: UUID,
+        window: str,
+        language: str = "en",
+    ) -> bool:
+        """
+        Executa a extração completa de temas temporais.
+
+        Args:
+            audience_id: ID da audiência
+            analysis_id: ID da análise já criada (status: processing)
+            window: Janela temporal (week ou month)
+            language: Idioma preferido do usuário
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        try:
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                self.theme_repo.mark_failed(analysis_id, "Audience not found")
+                return False
+
+            communities = self.audience_repo.get_communities(audience_id)
+            community_names = [c.subreddit_name for c in communities]
+
+            if not community_names:
+                self.theme_repo.mark_failed(analysis_id, "No communities in audience")
+                return False
+
+            # 1. Coletar posts filtrados por janela temporal
+            logger.info(
+                "Collecting %s posts for audience '%s' (%d communities)",
+                window,
+                audience.name,
+                len(community_names),
+            )
+            posts = self._collect_posts_for_window(community_names, window)
+
+            if not posts:
+                self.theme_repo.mark_failed(
+                    analysis_id,
+                    f"No posts found for {window} window",
+                )
+                return False
+
+            logger.info(
+                "Collected %d unique posts for %s window, running theme extraction agent",
+                len(posts),
+                window,
+            )
+
+            # 2. Calcular período
+            period_start, period_end = ThemeAnalysisRepository.get_period_bounds(window)
+
+            # 3. Rodar agente de extração
+            agent = create_theme_extraction_agent()
+            result = agent.invoke({
+                "audience_name": audience.name,
+                "audience_description": audience.description,
+                "community_names": community_names,
+                "posts": posts,
+                "total_posts": len(posts),
+                "time_window": window,
+                "period_start": str(period_start),
+                "period_end": str(period_end),
+                "language": language,
+                "extracted_themes": [],
+            })
+
+            extracted = result.get("extracted_themes", [])
+
+            if not extracted:
+                self.theme_repo.mark_failed(analysis_id, "No themes extracted")
+                return False
+
+            # 4. Salvar temas no banco
+            self.theme_repo.save_themes(analysis_id, extracted)
+
+            # 5. Marcar como pronto
+            self.theme_repo.mark_ready(analysis_id, total_themes=len(extracted))
+
+            # 6. Limpar análises antigas
+            self.theme_repo.delete_old_analyses(audience_id, window, keep_latest=2)
+
+            logger.info(
+                "Theme extraction complete for audience '%s' (%s): %d themes",
+                audience.name,
+                window,
+                len(extracted),
+            )
+
+            # 7. Notificar usuário
+            try:
+                from app.modules.notifications.application.services.notification_event_service import (
+                    NotificationEventService,
+                )
+
+                NotificationEventService(self.db).notify_analysis_complete(
+                    user_id=audience.user_id,
+                    analysis_type="theme_analysis",
+                    analysis_id=analysis_id,
+                    audience_id=audience_id,
+                    audience_name=audience.name,
+                )
+            except Exception:
+                logger.debug("Failed to send notification for theme analysis complete")
+
+            return True
+
+        except Exception as e:
+            logger.exception("Theme extraction failed for audience %s", audience_id)
+            try:
+                self.theme_repo.mark_failed(analysis_id, str(e))
+            except Exception:
+                pass
+            try:
+                from app.modules.notifications.application.services.notification_event_service import (
+                    NotificationEventService,
+                )
+
+                audience = self.audience_repo.find_by_id(audience_id)
+                if audience:
+                    NotificationEventService(self.db).notify_analysis_failed(
+                        user_id=audience.user_id,
+                        analysis_type="theme_analysis",
+                        analysis_id=analysis_id,
+                        audience_id=audience_id,
+                        audience_name=audience.name,
+                        error_message=str(e),
+                    )
+            except Exception:
+                pass
+            return False

--- a/app/modules/theme_analysis/application/use_cases/trigger_theme_analysis_use_case.py
+++ b/app/modules/theme_analysis/application/use_cases/trigger_theme_analysis_use_case.py
@@ -1,0 +1,124 @@
+"""Use case para disparar análise temporal de temas em background."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerThemeAnalysisUseCase:
+    """
+    Verifica se a análise de temas precisa ser processada
+    e dispara em background thread se necessário.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.theme_repo = ThemeAnalysisRepository(db)
+
+    def execute(
+        self,
+        audience_id: UUID,
+        window: str = "week",
+        language: str = "en",
+    ) -> dict:
+        """
+        Valida e dispara análise de temas.
+        Retorna dict com status e analysis_id.
+        """
+        communities = self.audience_repo.get_communities(audience_id)
+        community_names = [c.subreddit_name for c in communities]
+
+        if not community_names:
+            return {
+                "status": "failed",
+                "message": "No communities in audience",
+            }
+
+        # Gerar fingerprint com período
+        fingerprint = ThemeAnalysisRepository.generate_fingerprint(
+            audience_id, community_names, window
+        )
+
+        # Verificar se já existe análise para este período
+        existing = self.theme_repo.find_by_fingerprint(audience_id, fingerprint)
+        if existing:
+            if existing.status == "processing":
+                return {
+                    "status": "processing",
+                    "message": "Análise de temas já em andamento.",
+                    "analysis_id": str(existing.id),
+                }
+            if existing.status == "ready":
+                return {
+                    "status": "already_exists",
+                    "message": "Análise de temas já existe para este período.",
+                    "analysis_id": str(existing.id),
+                }
+
+        # Calcular período
+        period_start, period_end = ThemeAnalysisRepository.get_period_bounds(window)
+
+        # Criar registro de análise
+        analysis = self.theme_repo.create_analysis(
+            audience_id=audience_id,
+            fingerprint=fingerprint,
+            window=window,
+            period_start=period_start,
+            period_end=period_end,
+        )
+        logger.info(
+            "Triggering theme analysis (%s) for audience %s (analysis %s)",
+            window,
+            audience_id,
+            analysis.id,
+        )
+
+        # Disparar em background
+        self._run_in_background(audience_id, analysis.id, window, language)
+
+        return {
+            "status": "processing",
+            "message": f"Análise de temas ({window}) iniciada. Consulte novamente em alguns minutos.",
+            "analysis_id": str(analysis.id),
+        }
+
+    def _run_in_background(
+        self,
+        audience_id: UUID,
+        analysis_id: UUID,
+        window: str,
+        language: str = "en",
+    ) -> None:
+        """Dispara extração de temas em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.theme_analysis.application.use_cases.extract_themes_use_case.extract_themes_use_case import (
+                    ExtractThemesUseCase,
+                )
+
+                use_case = ExtractThemesUseCase(db)
+                use_case.execute(audience_id, analysis_id, window, language=language)
+            except Exception:
+                logger.exception(
+                    "Background theme extraction failed for audience %s", audience_id
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/theme_analysis/domain/entities/theme.py
+++ b/app/modules/theme_analysis/domain/entities/theme.py
@@ -1,0 +1,92 @@
+"""Entidades do módulo de análise temporal de temas."""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import JSON
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class ThemeAnalysis(Base):
+    """
+    Registro de uma análise temporal de temas de uma audiência.
+    Cada análise é associada a uma janela temporal (week ou month).
+    """
+
+    __tablename__ = "theme_analyses"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(
+        String(20), nullable=False, default="processing", index=True
+    )  # processing, ready, failed
+    time_window = Column(
+        String(10), nullable=False, index=True
+    )  # week, month
+    period_start = Column(Date, nullable=True)
+    period_end = Column(Date, nullable=True)
+    communities_fingerprint = Column(String(64), nullable=False, index=True)
+    total_themes = Column(Integer, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    themes = relationship(
+        "Theme",
+        back_populates="analysis",
+        cascade="all, delete-orphan",
+    )
+
+
+class Theme(Base):
+    """Tema extraído de uma análise temporal."""
+
+    __tablename__ = "themes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("theme_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name = Column(String(200), nullable=False)
+    summary = Column(Text, nullable=True)
+    post_count = Column(Integer, nullable=True)
+    avg_score = Column(Float, nullable=True)
+    avg_comments = Column(Float, nullable=True)
+    engagement_score = Column(Float, nullable=True)
+    top_subreddits = Column(JSON, nullable=True)  # [{"name": "sub", "post_count": N, "avg_score": N}]
+    top_keywords = Column(JSON, nullable=True)  # [{"keyword": "...", "frequency": N}]
+    representative_posts = Column(JSON, nullable=True)  # [{"title": "...", "subreddit": "...", "score": N, "permalink": "..."}]
+    rank = Column(Integer, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    analysis = relationship("ThemeAnalysis", back_populates="themes")

--- a/app/modules/theme_analysis/infra/repositories/theme_analysis_repository.py
+++ b/app/modules/theme_analysis/infra/repositories/theme_analysis_repository.py
@@ -1,0 +1,219 @@
+"""Repositório para operações com análises temporais de temas."""
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.theme_analysis.domain.entities.theme import Theme, ThemeAnalysis
+
+
+class ThemeAnalysisRepository:
+    """Repositório para operações com análises de temas temporais."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def get_period_bounds(window: str) -> tuple[date, date]:
+        """Calcula início e fim do período para a janela temporal."""
+        today = date.today()
+        if window == "week":
+            start = today - timedelta(days=today.weekday())
+            end = start + timedelta(days=6)
+        elif window == "month":
+            start = today.replace(day=1)
+            next_month = start.replace(day=28) + timedelta(days=4)
+            end = next_month - timedelta(days=next_month.day)
+        else:
+            start = today
+            end = today
+        return start, end
+
+    @staticmethod
+    def generate_fingerprint(
+        audience_id: UUID,
+        community_names: list[str],
+        window: str,
+    ) -> str:
+        """Gera fingerprint SHA256 incluindo período (semana ou mês ISO)."""
+        today = date.today()
+        if window == "week":
+            period_key = f"{today.isocalendar().year}-W{today.isocalendar()[1]:02d}"
+        elif window == "month":
+            period_key = f"{today.year}-{today.month:02d}"
+        else:
+            period_key = str(today)
+
+        sorted_names = sorted(n.lower() for n in community_names)
+        raw = f"{audience_id}|{'|'.join(sorted_names)}|{window}|{period_key}"
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    def find_latest_by_audience_and_window(
+        self, audience_id: UUID, window: str
+    ) -> ThemeAnalysis | None:
+        """Busca a análise mais recente para audiência e janela temporal."""
+        return (
+            self.db.query(ThemeAnalysis)
+            .filter(
+                ThemeAnalysis.audience_id == audience_id,
+                ThemeAnalysis.time_window == window,
+            )
+            .order_by(ThemeAnalysis.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, audience_id: UUID, fingerprint: str
+    ) -> ThemeAnalysis | None:
+        """Busca análise por fingerprint (mesmo período e comunidades)."""
+        return (
+            self.db.query(ThemeAnalysis)
+            .filter(
+                ThemeAnalysis.audience_id == audience_id,
+                ThemeAnalysis.communities_fingerprint == fingerprint,
+                ThemeAnalysis.status.in_(["ready", "processing"]),
+            )
+            .order_by(ThemeAnalysis.created_at.desc())
+            .first()
+        )
+
+    def create_analysis(
+        self,
+        audience_id: UUID,
+        fingerprint: str,
+        window: str,
+        period_start: date,
+        period_end: date,
+    ) -> ThemeAnalysis:
+        """Cria novo registro de análise com status 'processing'."""
+        analysis = ThemeAnalysis(
+            audience_id=audience_id,
+            communities_fingerprint=fingerprint,
+            status="processing",
+            time_window=window,
+            period_start=period_start,
+            period_end=period_end,
+        )
+        self.db.add(analysis)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_ready(
+        self, analysis_id: UUID, total_themes: int
+    ) -> ThemeAnalysis | None:
+        """Marca análise como pronta."""
+        analysis = (
+            self.db.query(ThemeAnalysis)
+            .filter(ThemeAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "ready"
+        analysis.total_themes = total_themes
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def mark_failed(
+        self, analysis_id: UUID, error_message: str
+    ) -> ThemeAnalysis | None:
+        """Marca análise como falha."""
+        analysis = (
+            self.db.query(ThemeAnalysis)
+            .filter(ThemeAnalysis.id == analysis_id)
+            .first()
+        )
+        if not analysis:
+            return None
+
+        analysis.status = "failed"
+        analysis.error_message = error_message
+        analysis.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis
+
+    def save_themes(
+        self, analysis_id: UUID, themes: list[dict]
+    ) -> list[Theme]:
+        """Salva lista de temas extraídos."""
+        entities = []
+        for theme_data in themes:
+            theme = Theme(
+                analysis_id=analysis_id,
+                name=theme_data["name"],
+                summary=theme_data.get("summary"),
+                post_count=theme_data.get("post_count"),
+                avg_score=theme_data.get("avg_score"),
+                avg_comments=theme_data.get("avg_comments"),
+                engagement_score=theme_data.get("engagement_score"),
+                top_subreddits=theme_data.get("top_subreddits"),
+                top_keywords=theme_data.get("top_keywords"),
+                representative_posts=theme_data.get("representative_posts"),
+                rank=theme_data.get("rank"),
+            )
+            self.db.add(theme)
+            entities.append(theme)
+
+        self.db.commit()
+        return entities
+
+    def get_themes(
+        self,
+        analysis_id: UUID,
+        sort_by: str = "rank",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Theme]:
+        """Lista temas de uma análise com ordenação."""
+        query = self.db.query(Theme).filter(
+            Theme.analysis_id == analysis_id
+        )
+
+        if sort_by == "engagement":
+            query = query.order_by(Theme.engagement_score.desc().nullslast())
+        elif sort_by == "post_count":
+            query = query.order_by(Theme.post_count.desc().nullslast())
+        elif sort_by == "name":
+            query = query.order_by(Theme.name.asc())
+        else:
+            query = query.order_by(Theme.rank.asc().nullslast())
+
+        return query.offset(offset).limit(limit).all()
+
+    def delete_old_analyses(
+        self, audience_id: UUID, window: str, keep_latest: int = 2
+    ) -> int:
+        """Remove análises antigas para a janela, mantendo as N mais recentes."""
+        latest_ids = (
+            self.db.query(ThemeAnalysis.id)
+            .filter(
+                ThemeAnalysis.audience_id == audience_id,
+                ThemeAnalysis.time_window == window,
+            )
+            .order_by(ThemeAnalysis.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(ThemeAnalysis)
+            .filter(
+                ThemeAnalysis.audience_id == audience_id,
+                ThemeAnalysis.time_window == window,
+                ThemeAnalysis.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -16,6 +16,7 @@ from app.routes.topic_snapshots import router as topic_snapshots_router
 from app.routes.notifications import router as notifications_router
 from app.routes.topic_ask import router as topic_ask_router
 from app.routes.topic_chat import router as topic_chat_router
+from app.routes.theme_analysis import router as theme_analysis_router
 
 __all__ = [
     "auth_router",
@@ -34,4 +35,5 @@ __all__ = [
     "notifications_router",
     "topic_ask_router",
     "topic_chat_router",
+    "theme_analysis_router",
 ]

--- a/app/routes/theme_analysis.py
+++ b/app/routes/theme_analysis.py
@@ -1,0 +1,166 @@
+"""Rotas para análise temporal de temas (Hot Discussions & Top Content)."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+from app.modules.theme_analysis.application.use_cases.trigger_theme_analysis_use_case import (
+    TriggerThemeAnalysisUseCase,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+
+router = APIRouter(
+    prefix="/audiences",
+    tags=["theme-analysis"],
+)
+
+AUDIENCE_NOT_FOUND = "Audiência não encontrada"
+VALID_WINDOWS = ("week", "month")
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Verifica se o usuário é dono da audiência."""
+    if str(audience.user_id) != str(current_user.id):
+        raise HTTPException(status_code=403, detail="Acesso negado a esta audiência")
+
+
+@router.get("/{audience_id}/themes")
+def list_themes(
+    audience_id: UUID,
+    window: str = Query("week", description="Janela temporal: week ou month"),
+    sort_by: str = Query("rank", description="Ordenação: rank, engagement, post_count, name"),
+    limit: int = 50,
+    offset: int = 0,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Lista temas temporais de uma audiência.
+
+    Retorna a análise mais recente para a janela temporal especificada.
+    Se não existe ou está em processamento, retorna status correspondente.
+    """
+    if window not in VALID_WINDOWS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Janela inválida. Use: {', '.join(VALID_WINDOWS)}",
+        )
+
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    theme_repo = ThemeAnalysisRepository(db)
+    latest = theme_repo.find_latest_by_audience_and_window(audience_id, window)
+
+    if not latest:
+        return {
+            "status": "no_analysis",
+            "message": f"Nenhuma análise de temas encontrada para {window}.",
+            "themes": [],
+            "total_themes": 0,
+        }
+
+    if latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "Análise de temas em andamento. Tente novamente em alguns minutos.",
+            "themes": [],
+            "total_themes": 0,
+        }
+
+    if latest.status == "failed":
+        return {
+            "status": "failed",
+            "message": f"Análise falhou: {latest.error_message or 'erro desconhecido'}",
+            "themes": [],
+            "total_themes": 0,
+        }
+
+    # Status ready — buscar temas
+    themes = theme_repo.get_themes(
+        analysis_id=latest.id,
+        sort_by=sort_by,
+        limit=limit,
+        offset=offset,
+    )
+
+    return {
+        "status": "ready",
+        "analysis_id": str(latest.id),
+        "audience_id": str(audience_id),
+        "time_window": latest.time_window,
+        "period_start": str(latest.period_start) if latest.period_start else None,
+        "period_end": str(latest.period_end) if latest.period_end else None,
+        "completed_at": latest.completed_at.isoformat() if latest.completed_at else None,
+        "total_themes": latest.total_themes,
+        "themes": [
+            {
+                "id": str(t.id),
+                "name": t.name,
+                "summary": t.summary,
+                "post_count": t.post_count,
+                "avg_score": t.avg_score,
+                "avg_comments": t.avg_comments,
+                "engagement_score": t.engagement_score,
+                "top_subreddits": t.top_subreddits,
+                "top_keywords": t.top_keywords,
+                "representative_posts": t.representative_posts,
+                "rank": t.rank,
+            }
+            for t in themes
+        ],
+    }
+
+
+@router.post("/{audience_id}/themes/refresh", status_code=202)
+def refresh_themes(
+    audience_id: UUID,
+    window: str = Query("week", description="Janela temporal: week ou month"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Dispara análise temporal de temas para uma audiência.
+    Retorna imediatamente com status 202.
+    """
+    if window not in VALID_WINDOWS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Janela inválida. Use: {', '.join(VALID_WINDOWS)}",
+        )
+
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    communities = audience_repo.get_communities(audience_id)
+    if not communities:
+        raise HTTPException(
+            status_code=400,
+            detail="Audiência não possui comunidades para análise",
+        )
+
+    trigger = TriggerThemeAnalysisUseCase(db)
+    result = trigger.execute(
+        audience_id=audience_id,
+        window=window,
+        language=current_user.preferred_language,
+    )
+
+    return result

--- a/docs/issue-68-theme-analysis-weekly.md
+++ b/docs/issue-68-theme-analysis-weekly.md
@@ -1,0 +1,238 @@
+# Issue #68 — Analise Temporal de Temas (Hot Discussions & Top Content)
+
+## Motivacao
+
+O sistema ja possui extracao de topicos por audiencia (Issue #29), deep dive (Issue #38), patterns (Issue #39) e sentiment (Issue #59). Todas essas analises trabalham com o **retrato atemporal** da audiencia — ou seja, analisam "o que existe agora" sem diferenciar o que aconteceu **esta semana** do que aconteceu **este mes**.
+
+Na aba **Temas** do frontend, o usuario espera duas visoes temporais distintas:
+
+- **Hot Discussions** — "O que esta sendo discutido esta semana?" (janela de 7 dias)
+- **Top Content** — "O que teve melhor desempenho este mes?" (janela de 30 dias)
+
+### Cenario do usuario
+
+O usuario tem uma audiencia "Pet Lovers" com comunidades como r/DogAdvice, r/cockatiel e r/turtle. Na segunda-feira, ele abre a aba Temas e quer saber o que foi mais discutido nas suas comunidades esta semana. Ele ve que "terapia com cachorros" explodiu esta semana (Hot Discussions), e que o post sobre "adocao de filhotes" foi o conteudo mais engajado do mes (Top Content).
+
+### Diferencial em relacao a aba Topicos
+
+| Aspecto | Aba Topicos (Issue #29) | Aba Temas (Issue #68) |
+|---------|------------------------|------------------------|
+| Janela temporal | Sem filtro — usa posts hot + top/month | Definida: 7 dias (hot) ou 30 dias (top) |
+| Trigger | Quando comunidades mudam (fingerprint) | Periodico + sob demanda (independe de mudanca) |
+| Granularidade | Topico individual (Dog, Rat, Friendship) | Tema agregado com resumo narrativo |
+| Objetivo | "Quais assuntos existem?" | "O que esta em alta agora?" |
+
+---
+
+## Solucao Adotada
+
+### Abordagem: Modulo independente `theme_analysis` com janela temporal
+
+Modulo dedicado que coleta posts **filtrados por data** e gera temas temporais. Independente de `audience_topics`, com suas proprias entidades, agente e repositorio.
+
+```
+POST /audiences/{id}/themes/refresh?window=week
+    → TriggerThemeAnalysisUseCase
+        → Gera fingerprint (SHA256 do audience_id + comunidades + window + period_key)
+        → Ja existe analise com mesmo fingerprint? → Retorna status
+        → Cria analise (status: "processing", window: "week")
+        → threading.Thread(daemon=True)
+            → ExtractThemesUseCase
+                → Coleta posts via Reddit API (hot + new para week; top/month para month)
+                → Filtra posts por created_utc dentro da janela temporal
+                → LangGraph: extract_themes → generate_summary
+                → Salva temas no banco → status: "ready"
+                → Notifica usuario via SSE
+
+GET /audiences/{id}/themes?window=week
+    → Busca analise mais recente para a janela
+    → "ready"      → retorna temas com resumo
+    → "processing" → retorna {status: "processing"}
+    → "failed"     → retorna erro
+    → nenhuma      → retorna {status: "no_analysis"}
+```
+
+### Decisoes arquiteturais
+
+1. **Modulo separado de audience_topics:** Os topicos (Issue #29) sao atemporais e disparados por mudanca de comunidades. Os temas sao temporais e disparados periodicamente ou sob demanda. Misturar responsabilidades tornaria ambos mais complexos.
+
+2. **Fingerprint inclui window + periodo:** O fingerprint inclui `audience_id + comunidades + window + calendar_week` (ou `calendar_month`). Assim, a mesma audiencia pode ter analises de semana e mes simultaneamente, e a analise so e reprocessada quando o periodo muda.
+
+3. **Coleta de posts com filtro de data:** Diferente do `collect_posts_for_communities` existente (que coleta hot + top/month indistintamente), o novo use case filtra posts por `created_utc`:
+   - **Week:** posts dos ultimos 7 dias (`created_utc >= now - 7d`)
+   - **Month:** posts dos ultimos 30 dias (`created_utc >= now - 30d`)
+
+4. **Sorts do Reddit por janela:**
+   - **Week (Hot Discussions):** `hot` + `new` — captura o que esta quente agora e o que acabou de surgir
+   - **Month (Top Content):** `top?t=month` — captura o melhor conteudo do mes por score
+
+5. **LangGraph com 2 nos:** No 1 (`extract_themes`) identifica temas agregados a partir dos posts filtrados. No 2 (`generate_summary`) gera o resumo narrativo de cada tema.
+
+6. **Reutilizacao do GenericRedditProvider:** O metodo `get_subreddit_posts` ja aceita `sort` e `time_filter`. Para a janela semanal, usamos `sort=hot` + `sort=new` e filtramos por `created_utc` no Python. Para a janela mensal, usamos `sort=top, time_filter=month`.
+
+7. **Engagement score composto:** Score que combina metricas para rankear temas:
+   ```
+   engagement_score = (avg_score * 0.4) + (avg_comments * 0.3) + (post_count * 0.2) + (subreddit_diversity * 0.1)
+   ```
+
+---
+
+## Entidades
+
+### `ThemeAnalysis` — tabela `theme_analyses`
+
+| Coluna | Tipo | Descricao |
+|--------|------|-----------|
+| id | UUID PK | |
+| audience_id | UUID FK → audiences | |
+| status | String(20) | processing, ready, failed |
+| time_window | String(10) | week, month |
+| period_start | Date | Inicio do periodo |
+| period_end | Date | Fim do periodo |
+| communities_fingerprint | String(64) | SHA256 para cache |
+| total_themes | Integer | |
+| error_message | Text | |
+| created_at | DateTime | |
+| updated_at | DateTime | |
+| completed_at | DateTime | |
+
+### `Theme` — tabela `themes`
+
+| Coluna | Tipo | Descricao |
+|--------|------|-----------|
+| id | UUID PK | |
+| analysis_id | UUID FK → theme_analyses | |
+| name | String(200) | Nome do tema |
+| summary | Text | Resumo narrativo gerado por IA |
+| post_count | Integer | Total de posts no periodo |
+| avg_score | Float | Score medio dos posts |
+| avg_comments | Float | Media de comentarios |
+| engagement_score | Float | Score composto de engajamento |
+| top_subreddits | JSON | [{name, post_count, avg_score}] |
+| top_keywords | JSON | [{keyword, frequency}] |
+| representative_posts | JSON | [{title, subreddit, score, permalink}] |
+| rank | Integer | Posicao por engagement_score |
+| created_at | DateTime | |
+
+---
+
+## Estrutura de Arquivos
+
+### Arquivos criados
+
+```
+app/modules/theme_analysis/
+├── domain/
+│   └── entities/
+│       └── theme.py                          # ThemeAnalysis + Theme
+├── application/
+│   └── use_cases/
+│       ├── trigger_theme_analysis_use_case.py
+│       └── extract_themes_use_case/
+│           ├── extract_themes_use_case.py     # Orquestrador
+│           └── agent/
+│               ├── state.py                   # ThemeExtractionState
+│               ├── theme_extraction_agent.py  # LangGraph 2 nos
+│               └── prompts/
+│                   └── theme_prompts.py       # Prompts por janela
+└── infra/
+    └── repositories/
+        └── theme_analysis_repository.py
+
+app/routes/theme_analysis.py                   # GET + POST endpoints
+```
+
+### Arquivos modificados
+
+| Arquivo | Mudanca |
+|---------|---------|
+| `app/main.py` | Registro do `theme_analysis_router` |
+| `app/routes/__init__.py` | Import e export do `theme_analysis_router` |
+| `alembic/env.py` | Import da entidade `theme` para autogenerate |
+
+---
+
+## Endpoints
+
+### POST `/audiences/{id}/themes/refresh?window=week|month`
+
+Dispara analise temporal de temas. Retorna 202.
+
+**Request:**
+```http
+POST /audiences/{audience_id}/themes/refresh?window=week
+Authorization: Bearer <token>
+```
+
+**Responses:**
+- `202` — Analise iniciada: `{status: "processing", analysis_id: "uuid"}`
+- `200` — Ja existe: `{status: "already_exists", analysis_id: "uuid"}`
+- `400` — Audiencia sem comunidades
+- `404` — Audiencia nao encontrada
+
+### GET `/audiences/{id}/themes?window=week|month`
+
+Consulta resultado da analise mais recente.
+
+**Request:**
+```http
+GET /audiences/{audience_id}/themes?window=week&sort_by=rank
+Authorization: Bearer <token>
+```
+
+**Responses:**
+- `status: "ready"` — Temas com resumo, metricas e posts representativos
+- `status: "processing"` — Analise em andamento
+- `status: "failed"` — Erro na analise
+- `status: "no_analysis"` — Nenhuma analise encontrada
+
+---
+
+## Agente LangGraph
+
+### No 1 — `extract_themes`
+
+Identifica temas temporais a partir dos posts filtrados. Foco em **relevancia temporal** — o que faz este periodo unico. Retorna entre 3 e 8 temas rankeados por engajamento.
+
+### No 2 — `generate_summary`
+
+Gera resumo narrativo estilo newsletter para cada tema. O resumo menciona subreddits e topicos naturalmente, captura o mood das discussoes e explica por que o tema foi relevante neste periodo.
+
+### Suporte multi-idioma
+
+Ambos os nos usam `get_language_directive()` para gerar conteudo no idioma preferido do usuario. JSON keys permanecem em ingles.
+
+---
+
+## Notificacoes
+
+Integrado com `NotificationEventService`:
+- `theme_analysis_complete` — Analise concluida com sucesso
+- `theme_analysis_failed` — Analise falhou
+
+---
+
+## Relacao com Outras Issues
+
+| Issue | Relacao |
+|-------|---------|
+| #29 — Audience Topic Analysis | Inspiracao arquitetural. Independente: temas sao temporais, topicos sao atemporais |
+| Theme 02 — Intent Classification | Proximo passo: os temas serao classificados por intencao |
+| Theme 03 — Narrative Summary | Integrado: resumo narrativo e gerado como parte deste modulo (no 2) |
+| Theme 04 — Structured Panel Data | Futuro: dados estruturados para dashboards |
+
+---
+
+## Migracao
+
+**Revision ID:** `71731c50ceea`
+**Tabelas criadas:** `theme_analyses`, `themes`
+**Indices:** audience_id, status, time_window, communities_fingerprint, analysis_id
+
+---
+
+## PR
+
+- **Issue:** [#68](https://github.com/robsonmvieira/oraculo-backend/issues/68)
+- **PR:** [#69](https://github.com/robsonmvieira/oraculo-backend/pull/69)
+- **Branch:** `feat/theme-analysis-weekly`


### PR DESCRIPTION
## Summary
- New `theme_analysis` module for detecting trending discussion themes per audience with two temporal windows: **week** (Hot Discussions) and **month** (Top Content)
- LangGraph agent with 2 nodes: `extract_themes` (identifies temporal themes) and `generate_summary` (generates narrative summaries)
- Fingerprint-based caching per calendar period (ISO week/month) to avoid reprocessing within the same period
- Full integration with SSE notifications, multi-language support, and engagement score ranking

## New Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/audiences/{id}/themes/refresh?window=week\|month` | Trigger analysis (202) |
| GET | `/audiences/{id}/themes?window=week\|month` | Query results |

## New Files
- `app/modules/theme_analysis/` — Complete module (domain, application, infra layers)
- `app/routes/theme_analysis.py` — API endpoints
- Alembic migration for `theme_analyses` and `themes` tables

## Modified Files
- `app/routes/__init__.py` — Router registration
- `app/main.py` — Router inclusion
- `alembic/env.py` — Entity import for autogenerate

## Test plan
- [ ] POST `/audiences/{id}/themes/refresh?window=week` triggers analysis and returns 202
- [ ] GET `/audiences/{id}/themes?window=week` returns `no_analysis` when none exists
- [ ] GET returns `processing` during background execution
- [ ] GET returns `ready` with themes, summaries, and metrics after completion
- [ ] POST `/audiences/{id}/themes/refresh?window=month` triggers monthly analysis
- [ ] Fingerprint cache prevents reprocessing in the same week/month
- [ ] Audience without communities returns 400

Closes #68