### PR TITLE
Theme 03 — Narrative Summary Module

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -48,6 +48,7 @@ from app.modules.topic_chat.domain.entities import topic_conversation  # noqa: E
 from app.modules.topic_chat.domain.entities import topic_conversation_message  # noqa: E402
 from app.modules.theme_analysis.domain.entities import theme  # noqa: E402
 from app.modules.intent_classification.domain.entities import intent_classification  # noqa: E402
+from app.modules.theme_analysis.domain.entities import theme_summary  # noqa: E402
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/4389392c3085_add_theme_summaries_table.py
+++ b/alembic/versions/4389392c3085_add_theme_summaries_table.py
@@ -1,0 +1,50 @@
+"""add theme_summaries table
+
+Revision ID: 4389392c3085
+Revises: dbdaec64de50
+Create Date: 2026-02-25 17:01:42.102706
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4389392c3085'
+down_revision: Union[str, Sequence[str], None] = 'dbdaec64de50'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('theme_summaries',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('theme_id', sa.UUID(), nullable=False),
+    sa.Column('analysis_id', sa.UUID(), nullable=False),
+    sa.Column('narrative', sa.Text(), nullable=True),
+    sa.Column('highlights', sa.JSON(), nullable=True),
+    sa.Column('emotional_tone', sa.String(length=30), nullable=True),
+    sa.Column('tone_description', sa.String(length=200), nullable=True),
+    sa.Column('key_themes', sa.JSON(), nullable=True),
+    sa.Column('intent_breakdown', sa.JSON(), nullable=True),
+    sa.Column('week_differentiator', sa.Text(), nullable=True),
+    sa.Column('fingerprint', sa.String(length=64), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['analysis_id'], ['theme_analyses.id'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['theme_id'], ['themes.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_theme_summaries_analysis_id'), 'theme_summaries', ['analysis_id'], unique=False)
+    op.create_index(op.f('ix_theme_summaries_fingerprint'), 'theme_summaries', ['fingerprint'], unique=False)
+    op.create_index(op.f('ix_theme_summaries_theme_id'), 'theme_summaries', ['theme_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_theme_summaries_theme_id'), table_name='theme_summaries')
+    op.drop_index(op.f('ix_theme_summaries_fingerprint'), table_name='theme_summaries')
+    op.drop_index(op.f('ix_theme_summaries_analysis_id'), table_name='theme_summaries')
+    op.drop_table('theme_summaries')

--- a/app/modules/notifications/application/services/notification_event_service.py
+++ b/app/modules/notifications/application/services/notification_event_service.py
@@ -23,6 +23,7 @@ _TYPE_LABELS = {
     "behavioral_pattern": "Behavioral Patterns",
     "theme_analysis": "Theme Analysis",
     "intent_classification": "Intent Classification",
+    "theme_summary": "Theme Summary",
 }
 
 

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/prompts/summary_prompts.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/prompts/summary_prompts.py
@@ -1,0 +1,108 @@
+"""Prompts para o agente de geração de sumário narrativo."""
+
+
+def get_generate_summary_prompt(
+    audience_name: str,
+    time_window: str,
+    period_start: str,
+    period_end: str,
+    theme_name: str,
+    communities_str: str,
+    post_count: int,
+    avg_score: float,
+    avg_comments: float,
+    top_subreddits_str: str,
+    representative_posts_text: str,
+    intent_section: str = "",
+    week_diff_instruction: str = "",
+    language_directive: str = "",
+) -> str:
+    """Prompt para geração de sumário narrativo enriquecido."""
+    return f"""You are a community intelligence analyst writing a briefing for a product manager.
+
+Audience: "{audience_name}"
+Period: {time_window} ({period_start} to {period_end})
+Theme: "{theme_name}"
+Communities: {communities_str}
+
+THEME METRICS:
+- Total posts: {post_count}
+- Average score: {avg_score:.1f}
+- Average comments: {avg_comments:.1f}
+- Top subreddits: {top_subreddits_str}
+
+TOP POSTS:
+{representative_posts_text}
+
+{intent_section}
+
+---
+
+TASK: Write a rich narrative summary for this theme.
+
+Your output should be a JSON object with these fields:
+
+1. "narrative": A 2-4 paragraph summary in newsletter style. Write as if you're briefing someone
+   who hasn't read any of the posts. Be specific — mention subreddit names, reference interesting
+   posts by topic (not by title), capture the mood of the discussions. The narrative should feel
+   like reading a "This week in {audience_name}" newsletter.
+
+2. "highlights": An array of 3-5 notable posts that deserve attention. For each:
+   {{"title": "...", "subreddit": "...", "score": N, "why_notable": "1-sentence reason"}}
+
+3. "emotional_tone": One of: "positive", "mixed", "tense", "neutral", "celebratory", "concerned", "supportive"
+
+4. "tone_description": A short phrase describing the overall emotional tone (e.g., "Warm and supportive with pockets of concern about vet costs")
+
+5. "key_themes": Array of 3-7 sub-themes mentioned in the narrative:
+   [{{"theme": "short name", "description": "1 sentence"}}]
+
+{week_diff_instruction}
+
+RULES:
+- Return ONLY the JSON object, no additional text
+- Do not wrap in markdown code fences
+- The "highlights" should reference actual posts from the TOP POSTS section
+- The "narrative" should be engaging and actionable, not generic
+
+{language_directive}"""
+
+
+def build_intent_section(intent_breakdown: dict) -> str:
+    """Constrói a seção de intenções para o prompt, se dados disponíveis."""
+    total = sum(intent_breakdown.values())
+    if total == 0:
+        return ""
+
+    lines = ["INTENT BREAKDOWN (how people are engaging):"]
+    intent_labels = {
+        "advice_request": "Advice Requests",
+        "pain_and_anger": "Pain & Anger",
+        "solution_request": "Solution Requests",
+        "self_promotion": "Self-Promotion",
+        "ideas": "Ideas",
+        "news": "News",
+    }
+
+    for key, label in intent_labels.items():
+        count = intent_breakdown.get(key, 0)
+        if count > 0:
+            pct = (count / total) * 100
+            lines.append(f"- {label}: {count} posts ({pct:.0f}%)")
+
+    lines.append("")
+    lines.append("Incorporate these intent patterns into the narrative naturally.")
+    lines.append(
+        "For example, if advice requests dominate, mention that the community is actively seeking guidance."
+    )
+
+    return "\n".join(lines)
+
+
+def build_week_diff_instruction(time_window: str, previous_themes: list[str]) -> str:
+    """Constrói instrução para diferenciador temporal, se dados históricos disponíveis."""
+    previous_themes_str = ", ".join(previous_themes)
+    return (
+        f'6. "week_differentiator": One sentence explaining what made this {time_window} different from '
+        f"the previous one. Last {time_window}'s themes were: {previous_themes_str}"
+    )

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/state.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/state.py
@@ -1,0 +1,54 @@
+"""Estado do agente de geração de sumário narrativo."""
+
+from typing import TypedDict
+
+
+class ThemeData(TypedDict):
+    """Dados do tema para geração do sumário."""
+
+    theme_id: str
+    theme_name: str
+    summary: str | None
+    post_count: int
+    avg_score: float
+    avg_comments: float
+    top_subreddits: list[dict]  # [{"name": "...", "post_count": N, "avg_score": N}]
+    top_keywords: list[dict]  # [{"keyword": "...", "frequency": N}]
+    representative_posts: list[dict]  # [{"title": "...", "subreddit": "...", "score": N, "permalink": "..."}]
+
+
+class SummaryResult(TypedDict):
+    """Resultado da geração do sumário narrativo."""
+
+    narrative: str
+    highlights: list[dict]  # [{"title": "...", "subreddit": "...", "score": N, "why_notable": "..."}]
+    emotional_tone: str
+    tone_description: str
+    key_themes: list[dict]  # [{"theme": "...", "description": "..."}]
+    week_differentiator: str | None
+
+
+class ThemeSummaryState(TypedDict):
+    """Estado do grafo de geração de sumário narrativo."""
+
+    # Inputs
+    audience_name: str
+    audience_description: str | None
+    community_names: list[str]
+    time_window: str
+    period_start: str
+    period_end: str
+    language: str
+
+    # Dados do tema
+    theme_data: ThemeData
+    posts_text: str  # Posts formatados para o prompt
+
+    # Dados opcionais de intenções (Theme 02)
+    intent_breakdown: dict | None  # {"advice_request": N, ...}
+
+    # Dados históricos opcionais
+    previous_themes: list[str] | None
+
+    # Output
+    summary_result: SummaryResult | None

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/summary_agent.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/summary_agent.py
@@ -1,0 +1,151 @@
+"""Agente LangGraph para geração de sumário narrativo enriquecido."""
+
+import json
+import logging
+import os
+import re
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.theme_analysis.application.use_cases.generate_theme_summary_use_case.agent.prompts.summary_prompts import (
+    build_intent_section,
+    build_week_diff_instruction,
+    get_generate_summary_prompt,
+)
+from app.modules.theme_analysis.application.use_cases.generate_theme_summary_use_case.agent.state import (
+    SummaryResult,
+    ThemeSummaryState,
+)
+from app.modules.shared.application.helpers.language_directive import (
+    get_language_directive,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_TONES = {
+    "positive",
+    "mixed",
+    "tense",
+    "neutral",
+    "celebratory",
+    "concerned",
+    "supportive",
+}
+
+
+def _get_llm() -> ChatOpenAI:
+    """Retorna instância do LLM configurada."""
+    model_name = os.getenv("MODEL_NAME", "gpt-4o-mini")
+    return ChatOpenAI(model=model_name, temperature=0)
+
+
+def _parse_json_response(content: str) -> dict:
+    """Extrai objeto JSON da resposta do LLM."""
+    cleaned = content.strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+    cleaned = re.sub(r"\s*```$", "", cleaned)
+    cleaned = cleaned.strip()
+
+    try:
+        result = json.loads(cleaned)
+        if isinstance(result, dict):
+            return result
+        return {}
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse LLM JSON response for theme summary")
+        return {}
+
+
+def generate_rich_summary(state: ThemeSummaryState) -> dict:
+    """
+    Nó único: Gera sumário narrativo enriquecido para um tema.
+
+    Recebe dados do tema, posts representativos, métricas e opcionalmente
+    dados de intenção (Theme 02). Retorna JSON estruturado com narrativa,
+    highlights, tom emocional e sub-temas.
+    """
+    theme_data = state["theme_data"]
+    language_directive = get_language_directive(state.get("language", "en"))
+    communities_str = ", ".join(state.get("community_names", []))
+
+    # Formatar top subreddits
+    top_subs = theme_data.get("top_subreddits") or []
+    top_subreddits_str = ", ".join(
+        f"r/{s['name']} ({s.get('post_count', 0)} posts)" for s in top_subs[:5]
+    )
+
+    # Posts representativos formatados
+    posts_text = state.get("posts_text", "No posts available.")
+
+    # Seção de intenções (opcional)
+    intent_breakdown = state.get("intent_breakdown")
+    intent_section = ""
+    if intent_breakdown:
+        intent_section = build_intent_section(intent_breakdown)
+
+    # Instrução de diferenciador temporal (opcional)
+    previous_themes = state.get("previous_themes")
+    week_diff_instruction = ""
+    if previous_themes:
+        week_diff_instruction = build_week_diff_instruction(
+            state["time_window"], previous_themes
+        )
+
+    prompt = get_generate_summary_prompt(
+        audience_name=state["audience_name"],
+        time_window=state["time_window"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        theme_name=theme_data["theme_name"],
+        communities_str=communities_str,
+        post_count=theme_data.get("post_count", 0),
+        avg_score=theme_data.get("avg_score", 0),
+        avg_comments=theme_data.get("avg_comments", 0),
+        top_subreddits_str=top_subreddits_str,
+        representative_posts_text=posts_text,
+        intent_section=intent_section,
+        week_diff_instruction=week_diff_instruction,
+        language_directive=language_directive,
+    )
+
+    llm = _get_llm()
+    response = llm.invoke(prompt)
+    result = _parse_json_response(response.content)
+
+    if not result:
+        logger.error("Empty summary result from LLM for theme '%s'", theme_data["theme_name"])
+        return {"summary_result": None}
+
+    # Validar emotional_tone
+    tone = result.get("emotional_tone", "neutral")
+    if tone not in VALID_TONES:
+        tone = "neutral"
+
+    summary_result = SummaryResult(
+        narrative=result.get("narrative", ""),
+        highlights=result.get("highlights", []),
+        emotional_tone=tone,
+        tone_description=result.get("tone_description", ""),
+        key_themes=result.get("key_themes", []),
+        week_differentiator=result.get("week_differentiator"),
+    )
+
+    logger.info(
+        "Generated rich summary for theme '%s': tone=%s, %d highlights, %d sub-themes",
+        theme_data["theme_name"],
+        tone,
+        len(summary_result["highlights"]),
+        len(summary_result["key_themes"]),
+    )
+
+    return {"summary_result": summary_result}
+
+
+def create_theme_summary_agent():
+    """Cria e compila o grafo LangGraph de geração de sumário narrativo."""
+    workflow = StateGraph(ThemeSummaryState)
+    workflow.add_node("generate_rich_summary", generate_rich_summary)
+    workflow.add_edge(START, "generate_rich_summary")
+    workflow.add_edge("generate_rich_summary", END)
+    return workflow.compile()

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/generate_theme_summary_use_case.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/generate_theme_summary_use_case.py
@@ -1,0 +1,286 @@
+"""Use case para geração de sumário narrativo enriquecido de um tema."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.intent_classification.infra.repositories.intent_classification_repository import (
+    IntentClassificationRepository,
+)
+from app.modules.theme_analysis.application.use_cases.generate_theme_summary_use_case.agent.summary_agent import (
+    create_theme_summary_agent,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_summary_repository import (
+    ThemeSummaryRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_POSTS_CHARS = 80_000
+
+
+class GenerateThemeSummaryUseCase:
+    """
+    Gera sumário narrativo enriquecido para um tema individual.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.theme_repo = ThemeAnalysisRepository(db)
+        self.intent_repo = IntentClassificationRepository(db)
+        self.summary_repo = ThemeSummaryRepository(db)
+
+    def execute(
+        self,
+        audience_id: UUID,
+        theme_id: UUID,
+        analysis_id: UUID,
+        window: str,
+        fingerprint: str,
+        language: str = "en",
+    ) -> bool:
+        """
+        Executa a geração completa do sumário narrativo.
+
+        Args:
+            audience_id: ID da audiência
+            theme_id: ID do tema para gerar o sumário
+            analysis_id: ID da theme_analysis fonte
+            window: Janela temporal (week ou month)
+            fingerprint: Fingerprint para o sumário
+            language: Idioma preferido do usuário
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        try:
+            # 1. Buscar audiência
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                logger.error("Audience %s not found for theme summary", audience_id)
+                return False
+
+            # 2. Buscar theme_analysis e o tema específico
+            theme_analysis = self.theme_repo.find_latest_by_audience_and_window(
+                audience_id, window
+            )
+            if not theme_analysis or theme_analysis.status != "ready":
+                logger.error("Theme analysis not ready for audience %s", audience_id)
+                return False
+
+            # Buscar o tema específico
+            themes = self.theme_repo.get_themes(analysis_id=theme_analysis.id)
+            theme = next((t for t in themes if str(t.id) == str(theme_id)), None)
+            if not theme:
+                logger.error("Theme %s not found in analysis %s", theme_id, theme_analysis.id)
+                return False
+
+            # 3. Carregar posts da análise para formatar no prompt
+            theme_posts = self.theme_repo.get_posts(theme_analysis.id)
+            posts_text = self._build_posts_text(theme_posts)
+
+            # 4. Buscar dados de comunidades
+            communities = self.audience_repo.get_communities(audience_id)
+            community_names = [c.subreddit_name for c in communities]
+
+            period_start = (
+                str(theme_analysis.period_start) if theme_analysis.period_start else ""
+            )
+            period_end = (
+                str(theme_analysis.period_end) if theme_analysis.period_end else ""
+            )
+
+            # 5. Opcionalmente buscar dados de intenção (Theme 02)
+            intent_breakdown = self._get_intent_breakdown(audience_id, window)
+
+            # 6. Buscar temas anteriores para diferenciador temporal
+            previous_themes = self._get_previous_themes(audience_id, window, theme_analysis.id)
+
+            # 7. Preparar dados do tema
+            theme_data = {
+                "theme_id": str(theme.id),
+                "theme_name": theme.name,
+                "summary": theme.summary,
+                "post_count": theme.post_count or 0,
+                "avg_score": theme.avg_score or 0,
+                "avg_comments": theme.avg_comments or 0,
+                "top_subreddits": theme.top_subreddits or [],
+                "top_keywords": theme.top_keywords or [],
+                "representative_posts": theme.representative_posts or [],
+            }
+
+            # 8. Invocar agente
+            agent = create_theme_summary_agent()
+            result = agent.invoke(
+                {
+                    "audience_name": audience.name,
+                    "audience_description": audience.description,
+                    "community_names": community_names,
+                    "time_window": window,
+                    "period_start": period_start,
+                    "period_end": period_end,
+                    "language": language,
+                    "theme_data": theme_data,
+                    "posts_text": posts_text,
+                    "intent_breakdown": intent_breakdown,
+                    "previous_themes": previous_themes,
+                    "summary_result": None,
+                }
+            )
+
+            summary_result = result.get("summary_result")
+            if not summary_result:
+                logger.error("No summary result from agent for theme %s", theme_id)
+                return False
+
+            # 9. Salvar sumário
+            self.summary_repo.create_summary(
+                theme_id=theme_id,
+                analysis_id=analysis_id,
+                fingerprint=fingerprint,
+                narrative=summary_result["narrative"],
+                highlights=summary_result["highlights"],
+                emotional_tone=summary_result["emotional_tone"],
+                tone_description=summary_result["tone_description"],
+                key_themes=summary_result["key_themes"],
+                intent_breakdown=intent_breakdown,
+                week_differentiator=summary_result.get("week_differentiator"),
+            )
+
+            # 10. Limpar sumários antigos
+            self.summary_repo.delete_old_summaries(theme_id, keep_latest=2)
+
+            logger.info(
+                "Theme summary generated for theme '%s' (audience '%s', %s)",
+                theme.name,
+                audience.name,
+                window,
+            )
+
+            # 11. Notificar usuário
+            try:
+                from app.modules.notifications.application.services.notification_event_service import (
+                    NotificationEventService,
+                )
+
+                NotificationEventService(self.db).notify_analysis_complete(
+                    user_id=audience.user_id,
+                    analysis_type="theme_summary",
+                    analysis_id=analysis_id,
+                    audience_id=audience_id,
+                    audience_name=audience.name,
+                )
+            except Exception:
+                logger.debug("Failed to send notification for theme summary complete")
+
+            return True
+
+        except Exception as e:
+            logger.exception(
+                "Theme summary generation failed for theme %s", theme_id
+            )
+            try:
+                from app.modules.notifications.application.services.notification_event_service import (
+                    NotificationEventService,
+                )
+
+                audience = self.audience_repo.find_by_id(audience_id)
+                if audience:
+                    NotificationEventService(self.db).notify_analysis_failed(
+                        user_id=audience.user_id,
+                        analysis_type="theme_summary",
+                        analysis_id=analysis_id,
+                        audience_id=audience_id,
+                        audience_name=audience.name,
+                        error_message=str(e),
+                    )
+            except Exception:
+                pass
+            return False
+
+    def _build_posts_text(self, theme_posts: list) -> str:
+        """Formata posts para injeção no prompt do agente."""
+        lines: list[str] = []
+        total_chars = 0
+
+        for post in theme_posts:
+            selftext = (post.selftext or "")[:300]
+            entry = (
+                f"[r/{post.subreddit}] (score: {post.score or 0}, "
+                f"comments: {post.num_comments or 0})\n"
+                f"Title: {post.title}\n"
+            )
+            if selftext.strip():
+                entry += f"Body: {selftext}\n"
+            if post.permalink:
+                entry += f"permalink: {post.permalink}\n"
+            entry += "---\n"
+
+            if total_chars + len(entry) > MAX_POSTS_CHARS:
+                break
+            lines.append(entry)
+            total_chars += len(entry)
+
+        return "".join(lines) if lines else "No posts available."
+
+    def _get_intent_breakdown(
+        self, audience_id: UUID, window: str
+    ) -> dict | None:
+        """Busca dados de intenção do Theme 02 se disponíveis."""
+        try:
+            latest_intent = self.intent_repo.find_latest_by_audience_and_window(
+                audience_id, window
+            )
+            if not latest_intent or latest_intent.status != "ready":
+                return None
+
+            summaries = self.intent_repo.get_intent_summaries(latest_intent.id)
+            if not summaries:
+                return None
+
+            return {s.intent_category: s.post_count for s in summaries}
+
+        except Exception:
+            logger.debug("Failed to fetch intent breakdown, continuing without it")
+            return None
+
+    def _get_previous_themes(
+        self, audience_id: UUID, window: str, current_analysis_id: UUID
+    ) -> list[str] | None:
+        """Busca nomes de temas da análise anterior para diferenciador temporal."""
+        try:
+            from app.modules.theme_analysis.domain.entities.theme import ThemeAnalysis
+
+            # Buscar a análise anterior (não a atual)
+            previous = (
+                self.db.query(ThemeAnalysis)
+                .filter(
+                    ThemeAnalysis.audience_id == audience_id,
+                    ThemeAnalysis.time_window == window,
+                    ThemeAnalysis.status == "ready",
+                    ThemeAnalysis.id != current_analysis_id,
+                )
+                .order_by(ThemeAnalysis.created_at.desc())
+                .first()
+            )
+            if not previous:
+                return None
+
+            previous_themes = self.theme_repo.get_themes(analysis_id=previous.id)
+            if not previous_themes:
+                return None
+
+            return [t.name for t in previous_themes]
+
+        except Exception:
+            logger.debug("Failed to fetch previous themes, continuing without them")
+            return None

--- a/app/modules/theme_analysis/application/use_cases/trigger_theme_summary_use_case.py
+++ b/app/modules/theme_analysis/application/use_cases/trigger_theme_summary_use_case.py
@@ -1,0 +1,159 @@
+"""Use case para disparar geração de sumário narrativo em background."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_summary_repository import (
+    ThemeSummaryRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerThemeSummaryUseCase:
+    """
+    Verifica pré-requisitos e dispara geração de sumário narrativo em background.
+    Requer que exista uma theme_analysis com status 'ready' e um tema válido.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.theme_repo = ThemeAnalysisRepository(db)
+        self.summary_repo = ThemeSummaryRepository(db)
+
+    def execute(
+        self,
+        audience_id: UUID,
+        theme_id: UUID,
+        window: str = "week",
+        language: str = "en",
+    ) -> dict:
+        """
+        Valida e dispara geração de sumário narrativo.
+        Retorna dict com status e informações.
+        """
+        # 1. Buscar theme_analysis ready
+        theme_analysis = self.theme_repo.find_latest_by_audience_and_window(
+            audience_id, window
+        )
+        if not theme_analysis or theme_analysis.status != "ready":
+            return {
+                "status": "error",
+                "message": "No theme analysis found for this period. Run theme analysis first.",
+            }
+
+        # 2. Verificar se o tema existe na análise
+        themes = self.theme_repo.get_themes(analysis_id=theme_analysis.id)
+        theme = next((t for t in themes if str(t.id) == str(theme_id)), None)
+        if not theme:
+            return {
+                "status": "error",
+                "message": "Theme not found in the current analysis.",
+            }
+
+        # 3. Gerar fingerprint
+        # Buscar intent_analysis_id se disponível
+        intent_analysis_id = self._get_intent_analysis_id(audience_id, window)
+        fingerprint = ThemeSummaryRepository.generate_fingerprint(
+            theme_id, intent_analysis_id
+        )
+
+        # 4. Verificar se já existe sumário com mesmo fingerprint
+        existing = self.summary_repo.find_by_fingerprint(theme_id, fingerprint)
+        if existing:
+            return {
+                "status": "already_exists",
+                "message": "Sumário narrativo já existe para este tema com os dados atuais.",
+                "summary_id": str(existing.id),
+            }
+
+        logger.info(
+            "Triggering theme summary for theme '%s' (audience %s, %s)",
+            theme.name,
+            audience_id,
+            window,
+        )
+
+        # 5. Disparar em background
+        self._run_in_background(
+            audience_id=audience_id,
+            theme_id=theme_id,
+            analysis_id=theme_analysis.id,
+            window=window,
+            fingerprint=fingerprint,
+            language=language,
+        )
+
+        return {
+            "status": "processing",
+            "message": f"Sumário narrativo para '{theme.name}' sendo gerado. Consulte novamente em alguns minutos.",
+            "theme_id": str(theme_id),
+        }
+
+    def _get_intent_analysis_id(
+        self, audience_id: UUID, window: str
+    ) -> UUID | None:
+        """Busca ID da classificação de intenção se disponível."""
+        try:
+            from app.modules.intent_classification.infra.repositories.intent_classification_repository import (
+                IntentClassificationRepository,
+            )
+
+            intent_repo = IntentClassificationRepository(self.db)
+            latest = intent_repo.find_latest_by_audience_and_window(
+                audience_id, window
+            )
+            if latest and latest.status == "ready":
+                return latest.id
+        except Exception:
+            pass
+        return None
+
+    def _run_in_background(
+        self,
+        audience_id: UUID,
+        theme_id: UUID,
+        analysis_id: UUID,
+        window: str,
+        fingerprint: str,
+        language: str = "en",
+    ) -> None:
+        """Dispara geração de sumário em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.theme_analysis.application.use_cases.generate_theme_summary_use_case.generate_theme_summary_use_case import (
+                    GenerateThemeSummaryUseCase,
+                )
+
+                use_case = GenerateThemeSummaryUseCase(db)
+                use_case.execute(
+                    audience_id,
+                    theme_id,
+                    analysis_id,
+                    window,
+                    fingerprint,
+                    language=language,
+                )
+            except Exception:
+                logger.exception(
+                    "Background theme summary generation failed for theme %s",
+                    theme_id,
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/theme_analysis/domain/entities/theme_summary.py
+++ b/app/modules/theme_analysis/domain/entities/theme_summary.py
@@ -1,0 +1,60 @@
+"""Entidade para sumário narrativo enriquecido de temas."""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.types import JSON
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class ThemeSummary(Base):
+    """
+    Sumário narrativo enriquecido de um tema individual.
+    Gerado a partir dos dados do Theme 01 e opcionalmente do Theme 02.
+    """
+
+    __tablename__ = "theme_summaries"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    theme_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("themes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("theme_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    narrative = Column(Text, nullable=True)
+    highlights = Column(
+        JSON, nullable=True
+    )  # [{"title": "...", "subreddit": "...", "score": N, "why_notable": "..."}]
+    emotional_tone = Column(String(30), nullable=True)
+    tone_description = Column(String(200), nullable=True)
+    key_themes = Column(
+        JSON, nullable=True
+    )  # [{"theme": "...", "description": "..."}]
+    intent_breakdown = Column(
+        JSON, nullable=True
+    )  # {"advice_request": N, "pain_and_anger": N, ...}
+    week_differentiator = Column(Text, nullable=True)
+    fingerprint = Column(String(64), nullable=False, index=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    theme = relationship("Theme")
+    analysis = relationship("ThemeAnalysis")

--- a/app/modules/theme_analysis/infra/repositories/theme_summary_repository.py
+++ b/app/modules/theme_analysis/infra/repositories/theme_summary_repository.py
@@ -1,0 +1,105 @@
+"""Repositório para operações com sumários narrativos de temas."""
+
+import hashlib
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.theme_analysis.domain.entities.theme_summary import ThemeSummary
+
+
+class ThemeSummaryRepository:
+    """Repositório para operações com sumários narrativos enriquecidos."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def generate_fingerprint(
+        theme_id: UUID,
+        intent_analysis_id: UUID | None = None,
+    ) -> str:
+        """Gera fingerprint SHA256 baseado no theme_id e opcionalmente no intent_analysis_id."""
+        raw = str(theme_id)
+        if intent_analysis_id:
+            raw += f"|{intent_analysis_id}"
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    def find_by_theme_id(self, theme_id: UUID) -> ThemeSummary | None:
+        """Busca o sumário mais recente para um tema."""
+        return (
+            self.db.query(ThemeSummary)
+            .filter(ThemeSummary.theme_id == theme_id)
+            .order_by(ThemeSummary.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, theme_id: UUID, fingerprint: str
+    ) -> ThemeSummary | None:
+        """Busca sumário por fingerprint (mesmo tema + mesma fonte de intents)."""
+        return (
+            self.db.query(ThemeSummary)
+            .filter(
+                ThemeSummary.theme_id == theme_id,
+                ThemeSummary.fingerprint == fingerprint,
+            )
+            .order_by(ThemeSummary.created_at.desc())
+            .first()
+        )
+
+    def create_summary(
+        self,
+        theme_id: UUID,
+        analysis_id: UUID,
+        fingerprint: str,
+        narrative: str,
+        highlights: list[dict] | None = None,
+        emotional_tone: str | None = None,
+        tone_description: str | None = None,
+        key_themes: list[dict] | None = None,
+        intent_breakdown: dict | None = None,
+        week_differentiator: str | None = None,
+    ) -> ThemeSummary:
+        """Cria novo sumário narrativo para um tema."""
+        summary = ThemeSummary(
+            theme_id=theme_id,
+            analysis_id=analysis_id,
+            fingerprint=fingerprint,
+            narrative=narrative,
+            highlights=highlights,
+            emotional_tone=emotional_tone,
+            tone_description=tone_description,
+            key_themes=key_themes,
+            intent_breakdown=intent_breakdown,
+            week_differentiator=week_differentiator,
+        )
+        self.db.add(summary)
+        self.db.commit()
+        self.db.refresh(summary)
+        return summary
+
+    def delete_old_summaries(self, theme_id: UUID, keep_latest: int = 2) -> int:
+        """Remove sumários antigos de um tema, mantendo os N mais recentes."""
+        latest_ids = (
+            self.db.query(ThemeSummary.id)
+            .filter(ThemeSummary.theme_id == theme_id)
+            .order_by(ThemeSummary.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(ThemeSummary)
+            .filter(
+                ThemeSummary.theme_id == theme_id,
+                ThemeSummary.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/routes/theme_analysis.py
+++ b/app/routes/theme_analysis.py
@@ -14,8 +14,14 @@ from app.modules.shared.infra.database.database import get_db
 from app.modules.theme_analysis.application.use_cases.trigger_theme_analysis_use_case import (
     TriggerThemeAnalysisUseCase,
 )
+from app.modules.theme_analysis.application.use_cases.trigger_theme_summary_use_case import (
+    TriggerThemeSummaryUseCase,
+)
 from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
     ThemeAnalysisRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_summary_repository import (
+    ThemeSummaryRepository,
 )
 
 router = APIRouter(
@@ -162,5 +168,86 @@ def refresh_themes(
         window=window,
         language=current_user.preferred_language,
     )
+
+    return result
+
+
+@router.get("/{audience_id}/themes/{theme_id}/summary")
+def get_theme_summary(
+    audience_id: UUID,
+    theme_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Retorna o sumário narrativo enriquecido de um tema.
+
+    Se não existe sumário, retorna status 'no_summary'.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    summary_repo = ThemeSummaryRepository(db)
+    summary = summary_repo.find_by_theme_id(theme_id)
+
+    if not summary:
+        return {
+            "status": "no_summary",
+            "message": "Nenhum sumário encontrado para este tema. Dispare a geração primeiro.",
+        }
+
+    return {
+        "status": "ready",
+        "theme_id": str(summary.theme_id),
+        "narrative": summary.narrative,
+        "highlights": summary.highlights,
+        "emotional_tone": summary.emotional_tone,
+        "tone_description": summary.tone_description,
+        "key_themes": summary.key_themes,
+        "intent_breakdown": summary.intent_breakdown,
+        "week_differentiator": summary.week_differentiator,
+        "created_at": summary.created_at.isoformat() if summary.created_at else None,
+    }
+
+
+@router.post("/{audience_id}/themes/{theme_id}/summary/refresh", status_code=202)
+def refresh_theme_summary(
+    audience_id: UUID,
+    theme_id: UUID,
+    window: str = Query("week", description="Janela temporal: week ou month"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Dispara geração de sumário narrativo enriquecido para um tema.
+    Retorna imediatamente com status 202.
+    """
+    if window not in VALID_WINDOWS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Janela inválida. Use: {', '.join(VALID_WINDOWS)}",
+        )
+
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    trigger = TriggerThemeSummaryUseCase(db)
+    result = trigger.execute(
+        audience_id=audience_id,
+        theme_id=theme_id,
+        window=window,
+        language=current_user.preferred_language,
+    )
+
+    if result["status"] == "error":
+        raise HTTPException(status_code=400, detail=result["message"])
 
     return result


### PR DESCRIPTION
## Summary

- Add rich narrative summary generation for individual themes (Theme 03)
- Extend `theme_analysis` module with LangGraph agent (1-node graph), repository, trigger use case, and API endpoints
- Optionally incorporates Theme 02 intent classification data when available
- Includes Alembic migration for `theme_summaries` table and SSE notification support

## New Files

| File | Description |
|------|-------------|
| `theme_summary.py` (entity) | SQLAlchemy model for `theme_summaries` table |
| `theme_summary_repository.py` | Repository with fingerprint, CRUD, and cleanup |
| `trigger_theme_summary_use_case.py` | Sync trigger with fingerprint dedup |
| `generate_theme_summary_use_case.py` | Background use case with LLM agent invocation |
| `agent/state.py` | TypedDicts for LangGraph state |
| `agent/summary_agent.py` | 1-node LangGraph graph (`generate_rich_summary`) |
| `agent/prompts/summary_prompts.py` | Prompt templates with i18n and intent section |
| Alembic migration | `theme_summaries` table with indexes |

## Modified Files

| File | Change |
|------|--------|
| `app/routes/theme_analysis.py` | +2 endpoints (GET summary, POST refresh) |
| `notification_event_service.py` | Add `theme_summary` notification type |
| `alembic/env.py` | Import `theme_summary` entity |

## Endpoints

- `GET /audiences/{id}/themes/{theme_id}/summary` — fetch narrative summary
- `POST /audiences/{id}/themes/{theme_id}/summary/refresh` — trigger generation (202)

## Test plan

- [x] All imports load without errors
- [x] Fingerprint generation works with/without intent data
- [x] Prompt builder generates correct intent sections and temporal differentiators
- [x] LangGraph agent compiles successfully
- [x] Routes registered in FastAPI app
- [x] Notification type registered
- [x] Ruff linter passes
- [x] GET summary returns `no_summary` when no data
- [x] POST refresh returns 400 when no theme analysis exists
- [x] POST refresh returns 400 for invalid window
- [x] GET summary returns 404 for non-existent audience

Closes #71