### PR TITLE
feat: Theme 04 — Structured Panel Data

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -49,6 +49,7 @@ from app.modules.topic_chat.domain.entities import topic_conversation_message  #
 from app.modules.theme_analysis.domain.entities import theme  # noqa: E402
 from app.modules.intent_classification.domain.entities import intent_classification  # noqa: E402
 from app.modules.theme_analysis.domain.entities import theme_summary  # noqa: E402
+from app.modules.theme_analysis.domain.entities import theme_panel  # noqa: E402
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/8bdebac3c5cf_add_theme_panels_table.py
+++ b/alembic/versions/8bdebac3c5cf_add_theme_panels_table.py
@@ -1,0 +1,46 @@
+"""add theme_panels table
+
+Revision ID: 8bdebac3c5cf
+Revises: 4389392c3085
+Create Date: 2026-02-25 21:11:12.958884
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '8bdebac3c5cf'
+down_revision: Union[str, Sequence[str], None] = '4389392c3085'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('theme_panels',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('theme_id', sa.UUID(), nullable=False),
+    sa.Column('analysis_id', sa.UUID(), nullable=False),
+    sa.Column('subcategories', sa.JSON(), nullable=True),
+    sa.Column('related_topics', sa.JSON(), nullable=True),
+    sa.Column('subreddit_distribution', sa.JSON(), nullable=True),
+    sa.Column('action_links', sa.JSON(), nullable=True),
+    sa.Column('fingerprint', sa.String(length=64), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['analysis_id'], ['theme_analyses.id'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['theme_id'], ['themes.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_theme_panels_analysis_id'), 'theme_panels', ['analysis_id'], unique=False)
+    op.create_index(op.f('ix_theme_panels_fingerprint'), 'theme_panels', ['fingerprint'], unique=False)
+    op.create_index(op.f('ix_theme_panels_theme_id'), 'theme_panels', ['theme_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_theme_panels_theme_id'), table_name='theme_panels')
+    op.drop_index(op.f('ix_theme_panels_fingerprint'), table_name='theme_panels')
+    op.drop_index(op.f('ix_theme_panels_analysis_id'), table_name='theme_panels')
+    op.drop_table('theme_panels')

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/panel_agent.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/panel_agent.py
@@ -1,0 +1,105 @@
+"""Agente LangGraph para extração de subcategorias do painel de temas."""
+
+import json
+import logging
+import os
+import re
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.theme_analysis.application.use_cases.generate_theme_panel_use_case.agent.prompts.panel_prompts import (
+    get_extract_subcategories_prompt,
+)
+from app.modules.theme_analysis.application.use_cases.generate_theme_panel_use_case.agent.state import (
+    SubcategoryItem,
+    ThemePanelState,
+)
+from app.modules.shared.application.helpers.language_directive import (
+    get_language_directive,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_llm() -> ChatOpenAI:
+    """Retorna instância do LLM configurada."""
+    model_name = os.getenv("MODEL_NAME", "gpt-4o-mini")
+    return ChatOpenAI(model=model_name, temperature=0)
+
+
+def _parse_json_response(content: str) -> list[dict]:
+    """Extrai array JSON da resposta do LLM."""
+    cleaned = content.strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+    cleaned = re.sub(r"\s*```$", "", cleaned)
+    cleaned = cleaned.strip()
+
+    try:
+        result = json.loads(cleaned)
+        if isinstance(result, list):
+            return result
+        return []
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse LLM JSON response for panel subcategories")
+        return []
+
+
+def extract_subcategories(state: ThemePanelState) -> dict:
+    """
+    Nó único: Extrai subcategorias temáticas/emocionais de um tema.
+
+    Recebe posts do tema e retorna lista de subcategorias com contagens.
+    """
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    prompt = get_extract_subcategories_prompt(
+        audience_name=state["audience_name"],
+        theme_name=state["theme_name"],
+        time_window=state["time_window"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        posts_text=state.get("posts_text", "No posts available."),
+        language_directive=language_directive,
+    )
+
+    llm = _get_llm()
+    response = llm.invoke(prompt)
+    items = _parse_json_response(response.content)
+
+    if not items:
+        logger.error(
+            "Empty subcategories result from LLM for theme '%s'",
+            state["theme_name"],
+        )
+        return {"subcategories": None}
+
+    subcategories = [
+        SubcategoryItem(
+            name=item.get("name", ""),
+            count=item.get("count", 0),
+            description=item.get("description", ""),
+        )
+        for item in items
+        if item.get("name")
+    ]
+
+    # Ordenar por count desc
+    subcategories.sort(key=lambda x: x["count"], reverse=True)
+
+    logger.info(
+        "Extracted %d subcategories for theme '%s'",
+        len(subcategories),
+        state["theme_name"],
+    )
+
+    return {"subcategories": subcategories}
+
+
+def create_theme_panel_agent():
+    """Cria e compila o grafo LangGraph de extração de subcategorias."""
+    workflow = StateGraph(ThemePanelState)
+    workflow.add_node("extract_subcategories", extract_subcategories)
+    workflow.add_edge(START, "extract_subcategories")
+    workflow.add_edge("extract_subcategories", END)
+    return workflow.compile()

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/prompts/panel_prompts.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/prompts/panel_prompts.py
@@ -1,0 +1,52 @@
+"""Prompts para o agente de extração de subcategorias do painel."""
+
+
+def get_extract_subcategories_prompt(
+    audience_name: str,
+    theme_name: str,
+    time_window: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    language_directive: str = "",
+) -> str:
+    """Prompt para extração de subcategorias de um tema."""
+    return f"""You are a data analyst categorizing online discussions into meaningful subcategories.
+
+Audience: "{audience_name}"
+Theme: "{theme_name}"
+Period: {time_window} ({period_start} to {period_end})
+
+Below are posts belonging to this theme:
+
+{posts_text}
+
+---
+
+TASK: Identify 3-8 subcategories that describe the main FACETS of this theme.
+
+Subcategories should represent:
+- Emotional facets (e.g., "Frustration", "Celebration", "Concern")
+- Activity facets (e.g., "Questions", "Recommendations", "Debates")
+- Thematic facets (e.g., "Health-related", "Cost-related", "Training-related")
+
+For each subcategory:
+1. Give it a clear, single-word or short name (1-3 words)
+2. Count how many posts fit this subcategory
+3. Write a brief description (1 sentence)
+
+A post can belong to multiple subcategories.
+
+Respond in JSON array format:
+[
+  {{"name": "Frustration", "count": 15, "description": "Posts expressing frustration about costs or services"}},
+  {{"name": "Questions", "count": 32, "description": "Posts asking direct questions seeking specific answers"}}
+]
+
+RULES:
+- Return ONLY the JSON array, no additional text
+- Do not wrap in markdown code fences
+- Order by count descending
+- Minimum 3, maximum 8 subcategories
+
+{language_directive}"""

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/state.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/state.py
@@ -1,0 +1,27 @@
+"""Estado do agente de extração de subcategorias do painel."""
+
+from typing import TypedDict
+
+
+class SubcategoryItem(TypedDict):
+    """Subcategoria extraída pelo agente."""
+
+    name: str
+    count: int
+    description: str
+
+
+class ThemePanelState(TypedDict):
+    """Estado do grafo de geração de dados do painel."""
+
+    # Inputs
+    audience_name: str
+    theme_name: str
+    time_window: str
+    period_start: str
+    period_end: str
+    language: str
+    posts_text: str
+
+    # Output
+    subcategories: list[SubcategoryItem] | None

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/generate_theme_panel_use_case.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/generate_theme_panel_use_case.py
@@ -1,0 +1,393 @@
+"""Use case para geração de dados estruturados do painel de temas."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_panel_repository import (
+    ThemePanelRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_summary_repository import (
+    ThemeSummaryRepository,
+)
+from app.modules.theme_analysis.application.use_cases.generate_theme_panel_use_case.agent.panel_agent import (
+    create_theme_panel_agent,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_POSTS_CHARS = 30000
+
+
+class GenerateThemePanelUseCase:
+    """
+    Gera dados estruturados do painel para um tema individual.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.theme_repo = ThemeAnalysisRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.panel_repo = ThemePanelRepository(db)
+        self.summary_repo = ThemeSummaryRepository(db)
+
+    def execute(
+        self,
+        audience_id: UUID,
+        theme_id: UUID,
+        analysis_id: UUID,
+        window: str,
+        fingerprint: str,
+        language: str = "en",
+    ) -> bool:
+        """
+        Executa a geração completa dos dados estruturados do painel.
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        try:
+            # 1. Buscar audiência
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                logger.error("Audience %s not found for theme panel", audience_id)
+                return False
+
+            # 2. Buscar theme_analysis e o tema específico
+            theme_analysis = self.theme_repo.find_latest_by_audience_and_window(
+                audience_id, window
+            )
+            if not theme_analysis or theme_analysis.status != "ready":
+                logger.error("Theme analysis not ready for audience %s", audience_id)
+                return False
+
+            themes = self.theme_repo.get_themes(analysis_id=theme_analysis.id)
+            theme = next((t for t in themes if str(t.id) == str(theme_id)), None)
+            if not theme:
+                logger.error(
+                    "Theme %s not found in analysis %s", theme_id, theme_analysis.id
+                )
+                return False
+
+            # 3. Carregar posts da análise para o prompt
+            theme_posts = self.theme_repo.get_posts(theme_analysis.id)
+            posts_text = self._build_posts_text(theme_posts)
+
+            period_start = (
+                str(theme_analysis.period_start) if theme_analysis.period_start else ""
+            )
+            period_end = (
+                str(theme_analysis.period_end) if theme_analysis.period_end else ""
+            )
+
+            # 4. Invocar agente para extrair subcategorias
+            agent = create_theme_panel_agent()
+            result = agent.invoke(
+                {
+                    "audience_name": audience.name,
+                    "theme_name": theme.name,
+                    "time_window": window,
+                    "period_start": period_start,
+                    "period_end": period_end,
+                    "language": language,
+                    "posts_text": posts_text,
+                    "subcategories": None,
+                }
+            )
+
+            subcategories = result.get("subcategories") or []
+
+            # 5. Agregar subreddits do Theme 01 (já existe no tema)
+            subreddit_distribution = self._build_subreddit_distribution(theme)
+
+            # 6. Cruzar tópicos da audiência com posts do tema
+            related_topics = self._find_related_topics(audience_id, theme_posts)
+
+            # 7. Montar action links
+            action_links = {
+                "view_all": f"/audiences/{audience_id}/topics?theme_filter={theme_id}",
+                "patterns": f"/audiences/{audience_id}/patterns",
+                "ask": f"/audiences/{audience_id}/topics/ask",
+                "copy_summary": True,
+            }
+
+            # 8. Salvar painel no banco
+            self.panel_repo.create_panel(
+                theme_id=theme_id,
+                analysis_id=analysis_id,
+                fingerprint=fingerprint,
+                subcategories=subcategories,
+                related_topics=related_topics,
+                subreddit_distribution=subreddit_distribution,
+                action_links=action_links,
+            )
+
+            # 9. Limpar painéis antigos
+            self.panel_repo.delete_old_panels(theme_id, keep_latest=2)
+
+            logger.info(
+                "Theme panel generated for theme '%s' (audience '%s', %s): "
+                "%d subcategories, %d related topics, %d subreddits",
+                theme.name,
+                audience.name,
+                window,
+                len(subcategories),
+                len(related_topics),
+                len(subreddit_distribution),
+            )
+
+            # 10. Notificar usuário
+            try:
+                from app.modules.notifications.application.services.notification_event_service import (
+                    NotificationEventService,
+                )
+
+                NotificationEventService(self.db).notify_analysis_complete(
+                    user_id=audience.user_id,
+                    analysis_type="theme_panel",
+                    analysis_id=analysis_id,
+                    audience_id=audience_id,
+                    audience_name=audience.name,
+                )
+            except Exception:
+                logger.debug("Failed to send notification for theme panel complete")
+
+            return True
+
+        except Exception as e:
+            logger.exception("Theme panel generation failed for theme %s", theme_id)
+            try:
+                from app.modules.notifications.application.services.notification_event_service import (
+                    NotificationEventService,
+                )
+
+                audience = self.audience_repo.find_by_id(audience_id)
+                if audience:
+                    NotificationEventService(self.db).notify_analysis_failed(
+                        user_id=audience.user_id,
+                        analysis_type="theme_panel",
+                        analysis_id=analysis_id,
+                        audience_id=audience_id,
+                        audience_name=audience.name,
+                        error_message=str(e),
+                    )
+            except Exception:
+                pass
+            return False
+
+    def _build_posts_text(self, theme_posts: list) -> str:
+        """Formata posts para injeção no prompt do agente."""
+        lines: list[str] = []
+        total_chars = 0
+
+        for post in theme_posts:
+            selftext = (post.selftext or "")[:300]
+            entry = (
+                f"[r/{post.subreddit}] (score: {post.score or 0}, "
+                f"comments: {post.num_comments or 0})\n"
+                f"Title: {post.title}\n"
+            )
+            if selftext.strip():
+                entry += f"Body: {selftext}\n"
+            entry += "---\n"
+
+            if total_chars + len(entry) > MAX_POSTS_CHARS:
+                break
+            lines.append(entry)
+            total_chars += len(entry)
+
+        return "".join(lines) if lines else "No posts available."
+
+    def _build_subreddit_distribution(self, theme) -> list[dict]:
+        """Agrega distribuição de subreddits do campo top_subreddits do Theme 01."""
+        top_subs = theme.top_subreddits or []
+        return [
+            {
+                "name": f"r/{sub.get('name', '')}",
+                "post_count": sub.get("post_count", 0),
+                "avg_score": sub.get("avg_score", 0),
+            }
+            for sub in top_subs
+            if sub.get("name")
+        ]
+
+    def _find_related_topics(
+        self,
+        audience_id: UUID,
+        theme_posts: list,
+    ) -> list[dict]:
+        """
+        Cruza posts do tema com tópicos da audiência por keyword matching.
+        Sem LLM — puramente programático.
+        """
+        try:
+            # Buscar análise de tópicos mais recente (ready)
+            latest_analysis = self.topic_repo.find_latest_ready(audience_id)
+            if not latest_analysis:
+                return []
+
+            audience_topics = self.topic_repo.get_topics(analysis_id=latest_analysis.id)
+            if not audience_topics:
+                return []
+
+            related: dict[str, dict] = {}
+
+            for topic in audience_topics:
+                keywords = self._extract_keywords(topic.name, topic.description)
+                count = 0
+                for post in theme_posts:
+                    text = f"{post.title or ''} {post.selftext or ''}".lower()
+                    if any(kw in text for kw in keywords):
+                        count += 1
+                if count > 0:
+                    related[topic.name] = {
+                        "name": topic.name,
+                        "count": count,
+                        "topic_id": str(topic.id),
+                    }
+
+            # Ordenar por count desc
+            return sorted(related.values(), key=lambda x: x["count"], reverse=True)
+
+        except Exception:
+            logger.debug("Failed to find related topics, continuing without them")
+            return []
+
+    @staticmethod
+    def _extract_keywords(name: str, description: str | None) -> list[str]:
+        """Extrai keywords do nome e descrição do tópico para matching."""
+        keywords = set()
+
+        # Nome do tópico como keyword principal
+        if name:
+            keywords.add(name.lower().strip())
+            # Palavras individuais do nome (se > 1 palavra)
+            words = name.lower().strip().split()
+            if len(words) > 1:
+                for word in words:
+                    if len(word) > 2:
+                        keywords.add(word)
+
+        # Palavras significativas da descrição
+        if description:
+            desc_words = description.lower().strip().split()
+            stop_words = {
+                "the",
+                "a",
+                "an",
+                "is",
+                "are",
+                "was",
+                "were",
+                "be",
+                "been",
+                "being",
+                "have",
+                "has",
+                "had",
+                "do",
+                "does",
+                "did",
+                "will",
+                "would",
+                "could",
+                "should",
+                "may",
+                "might",
+                "must",
+                "shall",
+                "can",
+                "need",
+                "dare",
+                "ought",
+                "used",
+                "to",
+                "of",
+                "in",
+                "for",
+                "on",
+                "with",
+                "at",
+                "by",
+                "from",
+                "as",
+                "into",
+                "through",
+                "during",
+                "before",
+                "after",
+                "above",
+                "below",
+                "between",
+                "out",
+                "off",
+                "over",
+                "under",
+                "again",
+                "further",
+                "then",
+                "once",
+                "and",
+                "but",
+                "or",
+                "nor",
+                "not",
+                "so",
+                "yet",
+                "both",
+                "either",
+                "neither",
+                "each",
+                "every",
+                "all",
+                "any",
+                "few",
+                "more",
+                "most",
+                "other",
+                "some",
+                "such",
+                "no",
+                "only",
+                "own",
+                "same",
+                "than",
+                "too",
+                "very",
+                "just",
+                "about",
+                "this",
+                "that",
+                "these",
+                "those",
+                "it",
+                "its",
+                "they",
+                "them",
+                "their",
+                "what",
+                "which",
+                "who",
+                "whom",
+                "how",
+                "when",
+                "where",
+                "why",
+            }
+            for word in desc_words:
+                if len(word) > 3 and word not in stop_words:
+                    keywords.add(word)
+
+        return list(keywords)

--- a/app/modules/theme_analysis/application/use_cases/trigger_theme_panel_use_case.py
+++ b/app/modules/theme_analysis/application/use_cases/trigger_theme_panel_use_case.py
@@ -1,0 +1,143 @@
+"""Trigger para geração de dados estruturados do painel de temas."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
+    ThemeAnalysisRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_panel_repository import (
+    ThemePanelRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_summary_repository import (
+    ThemeSummaryRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerThemePanelUseCase:
+    """
+    Verifica pré-requisitos e dispara geração de dados do painel em background.
+    Requer que exista uma theme_analysis com status 'ready' e um tema válido.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.theme_repo = ThemeAnalysisRepository(db)
+        self.panel_repo = ThemePanelRepository(db)
+        self.summary_repo = ThemeSummaryRepository(db)
+
+    def execute(
+        self,
+        audience_id: UUID,
+        theme_id: UUID,
+        window: str = "week",
+        language: str = "en",
+    ) -> dict:
+        """
+        Valida e dispara geração de dados do painel.
+        Retorna dict com status e informações.
+        """
+        # 1. Buscar theme_analysis ready
+        theme_analysis = self.theme_repo.find_latest_by_audience_and_window(
+            audience_id, window
+        )
+        if not theme_analysis or theme_analysis.status != "ready":
+            return {
+                "status": "error",
+                "message": "No theme analysis found for this period. Run theme analysis first.",
+            }
+
+        # 2. Verificar se o tema existe na análise
+        themes = self.theme_repo.get_themes(analysis_id=theme_analysis.id)
+        theme = next((t for t in themes if str(t.id) == str(theme_id)), None)
+        if not theme:
+            return {
+                "status": "error",
+                "message": "Theme not found in the current analysis.",
+            }
+
+        # 3. Gerar fingerprint
+        # Usar summary_id se existir para invalidar cache quando sumário muda
+        summary = self.summary_repo.find_by_theme_id(theme_id)
+        summary_id = summary.id if summary else None
+        fingerprint = ThemePanelRepository.generate_fingerprint(theme_id, summary_id)
+
+        # 4. Verificar se já existe painel com mesmo fingerprint
+        existing = self.panel_repo.find_by_fingerprint(theme_id, fingerprint)
+        if existing:
+            return {
+                "status": "already_exists",
+                "message": "Painel de dados já existe para este tema com os dados atuais.",
+                "panel_id": str(existing.id),
+            }
+
+        logger.info(
+            "Triggering theme panel for theme '%s' (audience %s, %s)",
+            theme.name,
+            audience_id,
+            window,
+        )
+
+        # 5. Disparar em background
+        self._run_in_background(
+            audience_id=audience_id,
+            theme_id=theme_id,
+            analysis_id=theme_analysis.id,
+            window=window,
+            fingerprint=fingerprint,
+            language=language,
+        )
+
+        return {
+            "status": "processing",
+            "message": f"Dados do painel para '{theme.name}' sendo gerados. Consulte novamente em alguns minutos.",
+            "theme_id": str(theme_id),
+        }
+
+    def _run_in_background(
+        self,
+        audience_id: UUID,
+        theme_id: UUID,
+        analysis_id: UUID,
+        window: str,
+        fingerprint: str,
+        language: str = "en",
+    ) -> None:
+        """Dispara geração de painel em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.theme_analysis.application.use_cases.generate_theme_panel_use_case.generate_theme_panel_use_case import (
+                    GenerateThemePanelUseCase,
+                )
+
+                use_case = GenerateThemePanelUseCase(db)
+                use_case.execute(
+                    audience_id,
+                    theme_id,
+                    analysis_id,
+                    window,
+                    fingerprint,
+                    language=language,
+                )
+            except Exception:
+                logger.exception(
+                    "Background theme panel generation failed for theme %s",
+                    theme_id,
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/theme_analysis/domain/entities/theme_panel.py
+++ b/app/modules/theme_analysis/domain/entities/theme_panel.py
@@ -1,0 +1,58 @@
+"""Entidade para dados estruturados do painel de temas."""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    String,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.types import JSON
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class ThemePanel(Base):
+    """
+    Dados estruturados do painel de um tema individual.
+    Agrega subcategorias (IA), tópicos relacionados (programático) e distribuição de subreddits.
+    """
+
+    __tablename__ = "theme_panels"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    theme_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("themes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("theme_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    subcategories = Column(
+        JSON, nullable=True
+    )  # [{"name": "Frustration", "count": 15, "description": "..."}]
+    related_topics = Column(
+        JSON, nullable=True
+    )  # [{"name": "Dog", "count": 3, "topic_id": "uuid"}]
+    subreddit_distribution = Column(
+        JSON, nullable=True
+    )  # [{"name": "r/dogbreed", "post_count": 8, "avg_score": 45.2}]
+    action_links = Column(
+        JSON, nullable=True
+    )  # {"view_all": "...", "patterns": "...", "ask": "...", "copy_summary": true}
+    fingerprint = Column(String(64), nullable=False, index=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    theme = relationship("Theme")
+    analysis = relationship("ThemeAnalysis")

--- a/app/modules/theme_analysis/infra/repositories/theme_panel_repository.py
+++ b/app/modules/theme_analysis/infra/repositories/theme_panel_repository.py
@@ -1,0 +1,99 @@
+"""Repositório para operações com dados estruturados do painel de temas."""
+
+import hashlib
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.theme_analysis.domain.entities.theme_panel import ThemePanel
+
+
+class ThemePanelRepository:
+    """Repositório para operações com painéis de dados estruturados."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def generate_fingerprint(
+        theme_id: UUID,
+        summary_id: UUID | None = None,
+    ) -> str:
+        """Gera fingerprint SHA256 baseado no theme_id e opcionalmente no summary_id."""
+        raw = str(theme_id)
+        if summary_id:
+            raw += f"|{summary_id}"
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    def find_by_theme_id(self, theme_id: UUID) -> ThemePanel | None:
+        """Busca o painel mais recente para um tema."""
+        return (
+            self.db.query(ThemePanel)
+            .filter(ThemePanel.theme_id == theme_id)
+            .order_by(ThemePanel.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, theme_id: UUID, fingerprint: str
+    ) -> ThemePanel | None:
+        """Busca painel por fingerprint (mesmo tema + mesma fonte de dados)."""
+        return (
+            self.db.query(ThemePanel)
+            .filter(
+                ThemePanel.theme_id == theme_id,
+                ThemePanel.fingerprint == fingerprint,
+            )
+            .order_by(ThemePanel.created_at.desc())
+            .first()
+        )
+
+    def create_panel(
+        self,
+        theme_id: UUID,
+        analysis_id: UUID,
+        fingerprint: str,
+        subcategories: list[dict] | None = None,
+        related_topics: list[dict] | None = None,
+        subreddit_distribution: list[dict] | None = None,
+        action_links: dict | None = None,
+    ) -> ThemePanel:
+        """Cria novo painel de dados estruturados para um tema."""
+        panel = ThemePanel(
+            theme_id=theme_id,
+            analysis_id=analysis_id,
+            fingerprint=fingerprint,
+            subcategories=subcategories,
+            related_topics=related_topics,
+            subreddit_distribution=subreddit_distribution,
+            action_links=action_links,
+        )
+        self.db.add(panel)
+        self.db.commit()
+        self.db.refresh(panel)
+        return panel
+
+    def delete_old_panels(self, theme_id: UUID, keep_latest: int = 2) -> int:
+        """Remove painéis antigos de um tema, mantendo os N mais recentes."""
+        latest_ids = (
+            self.db.query(ThemePanel.id)
+            .filter(ThemePanel.theme_id == theme_id)
+            .order_by(ThemePanel.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(ThemePanel)
+            .filter(
+                ThemePanel.theme_id == theme_id,
+                ThemePanel.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/routes/theme_analysis.py
+++ b/app/routes/theme_analysis.py
@@ -17,8 +17,14 @@ from app.modules.theme_analysis.application.use_cases.trigger_theme_analysis_use
 from app.modules.theme_analysis.application.use_cases.trigger_theme_summary_use_case import (
     TriggerThemeSummaryUseCase,
 )
+from app.modules.theme_analysis.application.use_cases.trigger_theme_panel_use_case import (
+    TriggerThemePanelUseCase,
+)
 from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
     ThemeAnalysisRepository,
+)
+from app.modules.theme_analysis.infra.repositories.theme_panel_repository import (
+    ThemePanelRepository,
 )
 from app.modules.theme_analysis.infra.repositories.theme_summary_repository import (
     ThemeSummaryRepository,
@@ -31,6 +37,7 @@ router = APIRouter(
 
 AUDIENCE_NOT_FOUND = "Audiência não encontrada"
 VALID_WINDOWS = ("week", "month")
+WINDOW_QUERY_DESC = "Janela temporal: week ou month"
 
 
 def _check_ownership(audience, current_user: User) -> None:
@@ -42,8 +49,10 @@ def _check_ownership(audience, current_user: User) -> None:
 @router.get("/{audience_id}/themes")
 def list_themes(
     audience_id: UUID,
-    window: str = Query("week", description="Janela temporal: week ou month"),
-    sort_by: str = Query("rank", description="Ordenação: rank, engagement, post_count, name"),
+    window: str = Query("week", description=WINDOW_QUERY_DESC),
+    sort_by: str = Query(
+        "rank", description="Ordenação: rank, engagement, post_count, name"
+    ),
     limit: int = 50,
     offset: int = 0,
     current_user: User = Depends(get_current_user),
@@ -110,7 +119,9 @@ def list_themes(
         "time_window": latest.time_window,
         "period_start": str(latest.period_start) if latest.period_start else None,
         "period_end": str(latest.period_end) if latest.period_end else None,
-        "completed_at": latest.completed_at.isoformat() if latest.completed_at else None,
+        "completed_at": latest.completed_at.isoformat()
+        if latest.completed_at
+        else None,
         "total_themes": latest.total_themes,
         "themes": [
             {
@@ -134,7 +145,7 @@ def list_themes(
 @router.post("/{audience_id}/themes/refresh", status_code=202)
 def refresh_themes(
     audience_id: UUID,
-    window: str = Query("week", description="Janela temporal: week ou month"),
+    window: str = Query("week", description=WINDOW_QUERY_DESC),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -218,7 +229,7 @@ def get_theme_summary(
 def refresh_theme_summary(
     audience_id: UUID,
     theme_id: UUID,
-    window: str = Query("week", description="Janela temporal: week ou month"),
+    window: str = Query("week", description=WINDOW_QUERY_DESC),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -251,3 +262,198 @@ def refresh_theme_summary(
         raise HTTPException(status_code=400, detail=result["message"])
 
     return result
+
+
+@router.get("/{audience_id}/themes/{theme_id}/panel")
+def get_theme_panel(
+    audience_id: UUID,
+    theme_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Retorna os dados estruturados do painel de um tema.
+
+    Inclui subcategorias, tópicos relacionados e distribuição de subreddits.
+    Se não existe painel, retorna status 'no_panel'.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    panel_repo = ThemePanelRepository(db)
+    panel = panel_repo.find_by_theme_id(theme_id)
+
+    if not panel:
+        return {
+            "status": "no_panel",
+            "message": "Nenhum painel encontrado para este tema. Dispare a geração primeiro.",
+        }
+
+    return {
+        "status": "ready",
+        "theme_id": str(panel.theme_id),
+        "subcategories": {
+            "total": len(panel.subcategories) if panel.subcategories else 0,
+            "items": panel.subcategories or [],
+        },
+        "related_topics": {
+            "total": len(panel.related_topics) if panel.related_topics else 0,
+            "items": panel.related_topics or [],
+        },
+        "subreddit_distribution": {
+            "total": len(panel.subreddit_distribution)
+            if panel.subreddit_distribution
+            else 0,
+            "items": panel.subreddit_distribution or [],
+        },
+        "actions": panel.action_links or {},
+        "created_at": panel.created_at.isoformat() if panel.created_at else None,
+    }
+
+
+@router.post("/{audience_id}/themes/{theme_id}/panel/refresh", status_code=202)
+def refresh_theme_panel(
+    audience_id: UUID,
+    theme_id: UUID,
+    window: str = Query("week", description=WINDOW_QUERY_DESC),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Dispara geração de dados estruturados do painel para um tema.
+    Retorna imediatamente com status 202.
+    """
+    if window not in VALID_WINDOWS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Janela inválida. Use: {', '.join(VALID_WINDOWS)}",
+        )
+
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    trigger = TriggerThemePanelUseCase(db)
+    result = trigger.execute(
+        audience_id=audience_id,
+        theme_id=theme_id,
+        window=window,
+        language=current_user.preferred_language,
+    )
+
+    if result["status"] == "error":
+        raise HTTPException(status_code=400, detail=result["message"])
+
+    return result
+
+
+def _build_default_actions(audience_id: UUID, theme_id: UUID) -> dict:
+    """Monta action links padrão quando não há painel salvo."""
+    return {
+        "view_all": f"/audiences/{audience_id}/topics?theme_filter={theme_id}",
+        "patterns": f"/audiences/{audience_id}/patterns",
+        "ask": f"/audiences/{audience_id}/topics/ask",
+        "copy_summary": True,
+    }
+
+
+def _serialize_summary(summary) -> dict:
+    """Serializa sumário narrativo para resposta da API."""
+    if not summary:
+        return {"status": "no_summary"}
+    return {
+        "status": "ready",
+        "narrative": summary.narrative,
+        "emotional_tone": summary.emotional_tone,
+        "tone_description": summary.tone_description,
+        "highlights": summary.highlights,
+        "key_themes": summary.key_themes,
+        "intent_breakdown": summary.intent_breakdown,
+        "week_differentiator": summary.week_differentiator,
+    }
+
+
+def _serialize_panel(panel) -> dict:
+    """Serializa painel de dados estruturados para resposta da API."""
+    if not panel:
+        return {"status": "no_panel"}
+    return {
+        "status": "ready",
+        "subcategories": panel.subcategories,
+        "related_topics": panel.related_topics,
+        "subreddit_distribution": panel.subreddit_distribution,
+    }
+
+
+def _find_ready_analysis(theme_repo, audience_id: UUID):
+    """Busca análise de temas ready, tentando week e depois month."""
+    for window in VALID_WINDOWS:
+        analysis = theme_repo.find_latest_by_audience_and_window(audience_id, window)
+        if analysis and analysis.status == "ready":
+            return analysis
+    return None
+
+
+@router.get("/{audience_id}/themes/{theme_id}/full")
+def get_theme_full(
+    audience_id: UUID,
+    theme_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Retorna dados completos de um tema: metadados + sumário + painel.
+
+    Endpoint combinado para o frontend carregar o painel direito em um único request.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    theme_repo = ThemeAnalysisRepository(db)
+    latest = _find_ready_analysis(theme_repo, audience_id)
+    if not latest:
+        raise HTTPException(
+            status_code=404,
+            detail="Nenhuma análise de temas encontrada.",
+        )
+
+    themes = theme_repo.get_themes(analysis_id=latest.id)
+    theme = next((t for t in themes if str(t.id) == str(theme_id)), None)
+    if not theme:
+        raise HTTPException(status_code=404, detail="Tema não encontrado.")
+
+    summary = ThemeSummaryRepository(db).find_by_theme_id(theme_id)
+    panel = ThemePanelRepository(db).find_by_theme_id(theme_id)
+
+    return {
+        "theme": {
+            "id": str(theme.id),
+            "name": theme.name,
+            "summary": theme.summary,
+            "time_window": latest.time_window,
+            "period_start": str(latest.period_start) if latest.period_start else None,
+            "period_end": str(latest.period_end) if latest.period_end else None,
+            "post_count": theme.post_count,
+            "avg_score": theme.avg_score,
+            "avg_comments": theme.avg_comments,
+            "engagement_score": theme.engagement_score,
+            "top_keywords": theme.top_keywords,
+            "rank": theme.rank,
+        },
+        "summary": _serialize_summary(summary),
+        "panel": _serialize_panel(panel),
+        "actions": panel.action_links
+        if panel
+        else _build_default_actions(audience_id, theme_id),
+    }


### PR DESCRIPTION
## Summary
- Add `ThemePanel` entity and `theme_panels` table with Alembic migration
- Add `ThemePanelRepository` with fingerprint-based caching (same pattern as ThemeSummary)
- Add `TriggerThemePanelUseCase` for async background generation
- Add `GenerateThemePanelUseCase` with:
  - LangGraph agent (1 node: `extract_subcategories`) for AI-powered subcategory extraction
  - Programmatic keyword matching to cross-reference audience topics (Issue #29) with theme posts
  - Direct aggregation of subreddit distribution from Theme 01 data
- Add 3 new endpoints to `theme_analysis.py`:
  - `GET /audiences/{id}/themes/{theme_id}/panel` — retrieve structured panel data
  - `POST /audiences/{id}/themes/{theme_id}/panel/refresh` — trigger panel generation (202)
  - `GET /audiences/{id}/themes/{theme_id}/full` — combined summary + panel in one request

## Test plan
- [ ] `POST /audiences/{id}/themes/{theme_id}/panel/refresh` returns 202 and triggers background generation
- [ ] `GET /audiences/{id}/themes/{theme_id}/panel` returns subcategories, related topics, and subreddit distribution
- [ ] `GET /audiences/{id}/themes/{theme_id}/full` returns combined theme + summary + panel data
- [ ] Fingerprint caching prevents duplicate panel generation
- [ ] Theme without audience topics returns empty `related_topics`
- [ ] Subreddit distribution correctly mirrors Theme 01 `top_subreddits` data

Closes #18