### PR TITLE
fix: normalize LLM response content for Gemini compatibility

### DIFF
--- a/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/keyword_extraction_agent.py
+++ b/app/modules/audience_keywords/application/use_cases/extract_keywords_use_case/agent/keyword_extraction_agent.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.audience_keywords.application.use_cases.extract_keywords_use_case.agent.prompts.keyword_extraction_prompts import (
@@ -45,7 +47,7 @@ def extract_keywords(state: KeywordExtractionState) -> dict:
     keywords: list[ExtractedKeyword] = []
     rank = 1
 
-    for line in response.content.strip().split("\n"):
+    for line in extract_response_text(response).split("\n"):
         line = line.strip()
         if not line or "|" not in line:
             continue

--- a/app/modules/audience_templates/application/use_cases/generate_audience_template_use_case.py
+++ b/app/modules/audience_templates/application/use_cases/generate_audience_template_use_case.py
@@ -3,6 +3,8 @@ import re
 from dataclasses import dataclass
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from sqlalchemy.orm import Session
 
 from app.modules.audience_templates.domain.entities.audience_template import (
@@ -141,7 +143,7 @@ Responda APENAS com os termos separados por vírgula, sem explicações.
 Exemplo: startups, entrepreneur, saas founders, bootstrapped, indie hackers"""
 
         response = self.llm.invoke(prompt)
-        keywords = [k.strip() for k in response.content.split(",")]
+        keywords = [k.strip() for k in extract_response_text(response).split(",")]
         return keywords[:8]
 
     def _search_subreddits(self, keywords: list[str]) -> list[dict]:
@@ -221,7 +223,7 @@ SaaS"""
 
         # Parsear resposta
         selected_names = set()
-        for line in response.content.strip().split("\n"):
+        for line in extract_response_text(response).split("\n"):
             name = line.strip().lower().replace("r/", "").replace("-", "")
             if name:
                 selected_names.add(name)

--- a/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/topic_extraction_agent.py
+++ b/app/modules/audience_topics/application/use_cases/extract_topics_use_case/agent/topic_extraction_agent.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.audience_topics.application.use_cases.extract_topics_use_case.agent.prompts.topic_extraction_prompts import (
@@ -78,7 +80,7 @@ def extract_topics(state: TopicExtractionState) -> dict:
     topics: list[ExtractedTopic] = []
     rank = 1
 
-    for line in response.content.strip().split("\n"):
+    for line in extract_response_text(response).split("\n"):
         line = line.strip()
         if not line or "|" not in line:
             continue
@@ -170,7 +172,7 @@ def estimate_growth(state: TopicExtractionState) -> dict:
 
     # Parse growth results
     growth_map = {}
-    for line in response.content.strip().split("\n"):
+    for line in extract_response_text(response).split("\n"):
         line = line.strip()
         if not line or "|" not in line:
             continue

--- a/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/audience_expansion_agent.py
+++ b/app/modules/audiences/application/use_cases/expand_audience_use_case/agent/audience_expansion_agent.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.audiences.application.use_cases.expand_audience_use_case.agent.prompts.audience_expansion_prompts import (
@@ -40,7 +42,7 @@ def analyze_audience_theme(state: AudienceExpansionState) -> dict:
 
     theme = "General"
 
-    for line in response.content.strip().split("\n"):
+    for line in extract_response_text(response).split("\n"):
         if line.startswith("THEME:"):
             theme = line.replace("THEME:", "").strip()
 
@@ -101,7 +103,7 @@ def rank_and_explain(state: AudienceExpansionState) -> dict:
     candidate_map = {c["name"].lower(): c for c in real_candidates}
 
     suggestions: list[RankedSuggestion] = []
-    for line in response.content.strip().split("\n"):
+    for line in extract_response_text(response).split("\n"):
         line = line.strip()
         if not line or "|" not in line:
             continue

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -7,6 +7,8 @@ import re
 from collections import Counter
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.intent_classification.application.use_cases.classify_intents_use_case.agent.prompts.intent_prompts import (
@@ -127,7 +129,7 @@ def classify_intents(state: IntentClassificationState) -> dict:
         )
 
         response = llm.invoke(prompt)
-        batch_results = _parse_json_response(response.content)
+        batch_results = _parse_json_response(extract_response_text(response))
 
         for result in batch_results:
             post_id = result.get("post_id", "")
@@ -251,7 +253,7 @@ def aggregate_intents(state: IntentClassificationState) -> dict:
         )
 
         response = llm.invoke(prompt)
-        descriptions = _parse_json_response(response.content)
+        descriptions = _parse_json_response(extract_response_text(response))
 
         # Mapear descrições para agregações
         desc_map = {

--- a/app/modules/shared/application/services/llm_factory.py
+++ b/app/modules/shared/application/services/llm_factory.py
@@ -125,6 +125,29 @@ def create_llm(
     )
 
 
+def extract_response_text(response) -> str:
+    """Extract text content from an LLM response, normalizing across providers.
+
+    Gemini may return response.content as a list of parts instead of a plain
+    string.  This helper guarantees a plain ``str`` is returned regardless of
+    the provider used.
+    """
+    content = response.content
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                parts.append(part.get("text", ""))
+            else:
+                parts.append(str(part))
+        return "".join(parts).strip()
+    return str(content).strip()
+
+
 # ---------------------------------------------------------------------------
 # Context limits factory
 # ---------------------------------------------------------------------------

--- a/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/theme_extraction_agent.py
+++ b/app/modules/theme_analysis/application/use_cases/extract_themes_use_case/agent/theme_extraction_agent.py
@@ -5,6 +5,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.shared.application.helpers.language_directive import (
@@ -104,7 +106,7 @@ def extract_themes(state: ThemeExtractionState) -> dict:
     response = llm.invoke(prompt)
 
     try:
-        raw_themes = _parse_json_response(response.content)
+        raw_themes = _parse_json_response(extract_response_text(response))
     except ValueError:
         logger.error("Failed to parse themes JSON from LLM response")
         return {"extracted_themes": []}
@@ -172,7 +174,7 @@ def generate_summary(state: ThemeExtractionState) -> dict:
     response = llm.invoke(prompt)
 
     try:
-        summaries = _parse_json_response(response.content)
+        summaries = _parse_json_response(extract_response_text(response))
     except ValueError:
         logger.error("Failed to parse summaries JSON from LLM response")
         return {"extracted_themes": themes}

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/panel_agent.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_panel_use_case/agent/panel_agent.py
@@ -6,6 +6,8 @@ import os
 import re
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.theme_analysis.application.use_cases.generate_theme_panel_use_case.agent.prompts.panel_prompts import (
@@ -65,7 +67,7 @@ def extract_subcategories(state: ThemePanelState) -> dict:
 
     llm = _get_llm()
     response = llm.invoke(prompt)
-    items = _parse_json_response(response.content)
+    items = _parse_json_response(extract_response_text(response))
 
     if not items:
         logger.error(

--- a/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/summary_agent.py
+++ b/app/modules/theme_analysis/application/use_cases/generate_theme_summary_use_case/agent/summary_agent.py
@@ -6,6 +6,8 @@ import os
 import re
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.theme_analysis.application.use_cases.generate_theme_summary_use_case.agent.prompts.summary_prompts import (
@@ -111,7 +113,7 @@ def generate_rich_summary(state: ThemeSummaryState) -> dict:
 
     llm = _get_llm()
     response = llm.invoke(prompt)
-    result = _parse_json_response(response.content)
+    result = _parse_json_response(extract_response_text(response))
 
     if not result:
         logger.error(

--- a/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/ask_agent.py
+++ b/app/modules/topic_ask/application/use_cases/ask_topic_use_case/agent/ask_agent.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.topic_ask.application.use_cases.ask_topic_use_case.agent.prompts.ask_prompts import (
@@ -80,7 +82,7 @@ def answer_question(state: TopicAskState) -> dict:
         (response.content[:200] if response.content else "<EMPTY>"),
     )
 
-    answer = response.content.strip() if response.content else ""
+    answer = extract_response_text(response) if response.content else ""
 
     if not answer:
         logger.warning(

--- a/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/behavioral_pattern_agent.py
+++ b/app/modules/topic_behavioral_patterns/application/use_cases/detect_behavioral_patterns_use_case/agent/behavioral_pattern_agent.py
@@ -6,6 +6,7 @@ from langgraph.graph import END, START, StateGraph
 from app.modules.shared.application.services.llm_factory import (
     ContextLimits,
     create_llm,
+    extract_response_text,
     get_context_limits,
 )
 from app.modules.topic_behavioral_patterns.application.use_cases.detect_behavioral_patterns_use_case.agent.prompts.behavioral_pattern_prompts import (
@@ -111,7 +112,7 @@ def detect_behavioral_patterns(state: BehavioralPatternState) -> dict:
     )
 
     response = llm.invoke(prompt)
-    content = response.content.strip()
+    content = extract_response_text(response)
 
     if content.startswith("```"):
         content = content.split("\n", 1)[1] if "\n" in content else content[3:]

--- a/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/chat_agent.py
+++ b/app/modules/topic_chat/application/use_cases/send_message_use_case/agent/chat_agent.py
@@ -3,6 +3,8 @@ import os
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.topic_chat.application.use_cases.send_message_use_case.agent.prompts.chat_prompts import (
@@ -85,7 +87,7 @@ def answer_with_history(state: TopicChatState) -> dict:
 
     response = llm.invoke(langchain_messages)
 
-    answer = response.content.strip() if response.content else ""
+    answer = extract_response_text(response) if response.content else ""
 
     if not answer:
         logger.warning(

--- a/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/deep_dive_agent.py
+++ b/app/modules/topic_deep_dive/application/use_cases/extract_deep_dive_use_case/agent/deep_dive_agent.py
@@ -7,6 +7,7 @@ from langgraph.graph import END, START, StateGraph
 from app.modules.shared.application.services.llm_factory import (
     ContextLimits,
     create_llm,
+    extract_response_text,
     get_context_limits,
 )
 from app.modules.topic_deep_dive.application.use_cases.extract_deep_dive_use_case.agent.prompts.deep_dive_prompts import (
@@ -145,7 +146,7 @@ def analyze_deep_dive(state: DeepDiveState) -> dict:
     )
 
     response = llm.invoke(prompt)
-    content = response.content.strip()
+    content = extract_response_text(response)
 
     # Clean markdown code blocks if present
     if content.startswith("```"):
@@ -184,7 +185,7 @@ def extract_representative_posts(state: DeepDiveState) -> dict:
     )
 
     response = llm.invoke(prompt)
-    content = response.content.strip()
+    content = extract_response_text(response)
 
     # Clean markdown code blocks if present
     if content.startswith("```"):

--- a/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/pattern_detection_agent.py
+++ b/app/modules/topic_patterns/application/use_cases/detect_patterns_use_case/agent/pattern_detection_agent.py
@@ -7,6 +7,7 @@ from langgraph.graph import END, START, StateGraph
 from app.modules.shared.application.services.llm_factory import (
     ContextLimits,
     create_llm,
+    extract_response_text,
     get_context_limits,
 )
 from app.modules.topic_patterns.application.use_cases.detect_patterns_use_case.agent.prompts.pattern_detection_prompts import (
@@ -161,7 +162,7 @@ def detect_patterns(state: PatternDetectionState) -> dict:
     )
 
     response = llm.invoke(prompt)
-    content = response.content.strip()
+    content = extract_response_text(response)
 
     # Clean markdown code blocks if present
     if content.startswith("```"):

--- a/app/modules/topic_sentiment/application/use_cases/extract_sentiment_use_case/agent/sentiment_agent.py
+++ b/app/modules/topic_sentiment/application/use_cases/extract_sentiment_use_case/agent/sentiment_agent.py
@@ -3,6 +3,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.topic_sentiment.application.use_cases.extract_sentiment_use_case.agent.prompts.sentiment_prompts import (
@@ -115,7 +117,7 @@ def analyze_sentiment(state: SentimentAnalysisState) -> dict:
     )
 
     response = llm.invoke(prompt)
-    content = response.content.strip()
+    content = extract_response_text(response)
 
     # Clean markdown code blocks if present
     if content.startswith("```"):

--- a/app/modules/topics/application/use_cases/get_community_details_use_case/agent/communit_detail_analiser_agent.py
+++ b/app/modules/topics/application/use_cases/get_community_details_use_case/agent/communit_detail_analiser_agent.py
@@ -1,6 +1,8 @@
 import os
 
 from langchain_openai import ChatOpenAI
+
+from app.modules.shared.application.services.llm_factory import extract_response_text
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.topics.application.use_cases.get_community_details_use_case.agent.prompts.analizy_community_prompt import (
@@ -29,7 +31,7 @@ def analyze_community(state: CommunityAnalyzerState) -> dict:
     response = llm.invoke(prompt)
 
     # Parsear a resposta - separar por vírgula e limpar espaços
-    terms = [term.strip() for term in response.content.split(",")]
+    terms = [term.strip() for term in extract_response_text(response).split(",")]
 
     return {"derived_terms": terms[:10]}
 

--- a/app/modules/topics/application/use_cases/get_community_details_use_case/agent/node.py
+++ b/app/modules/topics/application/use_cases/get_community_details_use_case/agent/node.py
@@ -3,6 +3,8 @@ import os
 
 from langchain_openai import ChatOpenAI
 
+from app.modules.shared.application.services.llm_factory import extract_response_text
+
 from app.modules.topics.application.use_cases.get_community_details_use_case.agent.state import (
     CommunityAnalyzerState,
 )
@@ -32,7 +34,7 @@ Exemplo: marketing, digital, saas, startup, tecnologia, negócios, empreendedori
     response = llm.invoke(prompt)
 
     # Parsear a resposta - separar por vírgula e limpar espaços
-    terms = [term.strip() for term in response.content.split(",")]
+    terms = [term.strip() for term in extract_response_text(response).split(",")]
 
     return {"derived_terms": terms[:10]}  # Garantir no máximo 10 termos
 """


### PR DESCRIPTION
## Summary
- Added `extract_response_text()` helper in `llm_factory.py` to normalize LLM response content across providers (OpenAI returns `str`, Gemini returns `list` of parts)
- Updated all 16 agents to use the new helper instead of `response.content.strip()` directly
- Fixes `'list' object has no attribute 'strip'` error when using Gemini 3.1 Pro

## Test plan
- [ ] Trigger behavioral patterns analysis with Gemini provider and verify no `strip()` error
- [ ] Trigger deep dive analysis with Gemini provider
- [ ] Trigger pattern detection with Gemini provider
- [ ] Verify OpenAI-based agents still work correctly (no regression)