### PR TITLE
feat: add pain_and_anger sentiment subcategories and topic keywords

### DIFF
--- a/alembic/versions/21a88f94dc62_add_pain_anger_subcategories.py
+++ b/alembic/versions/21a88f94dc62_add_pain_anger_subcategories.py
@@ -1,0 +1,55 @@
+"""add pain_anger_subcategories
+
+Revision ID: 21a88f94dc62
+Revises: 768ceb994b1f
+Create Date: 2026-02-28 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "21a88f94dc62"
+down_revision: Union[str, None] = "768ceb994b1f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "post_intent_classifications",
+        sa.Column("sentiment", sa.String(length=30), nullable=True),
+    )
+    op.add_column(
+        "post_intent_classifications",
+        sa.Column("topic_keyword", sa.String(length=50), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_post_intent_classifications_sentiment"),
+        "post_intent_classifications",
+        ["sentiment"],
+        unique=False,
+    )
+
+    op.add_column(
+        "intent_summaries",
+        sa.Column("subcategories", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "intent_summaries",
+        sa.Column("topic_keywords", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("intent_summaries", "topic_keywords")
+    op.drop_column("intent_summaries", "subcategories")
+    op.drop_index(
+        op.f("ix_post_intent_classifications_sentiment"),
+        table_name="post_intent_classifications",
+    )
+    op.drop_column("post_intent_classifications", "topic_keyword")
+    op.drop_column("post_intent_classifications", "sentiment")

--- a/alembic/versions/21a88f94dc62_add_pain_anger_subcategories.py
+++ b/alembic/versions/21a88f94dc62_add_pain_anger_subcategories.py
@@ -20,21 +20,6 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.add_column(
-        "post_intent_classifications",
-        sa.Column("sentiment", sa.String(length=30), nullable=True),
-    )
-    op.add_column(
-        "post_intent_classifications",
-        sa.Column("topic_keyword", sa.String(length=50), nullable=True),
-    )
-    op.create_index(
-        op.f("ix_post_intent_classifications_sentiment"),
-        "post_intent_classifications",
-        ["sentiment"],
-        unique=False,
-    )
-
-    op.add_column(
         "intent_summaries",
         sa.Column("subcategories", sa.JSON(), nullable=True),
     )
@@ -47,9 +32,3 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("intent_summaries", "topic_keywords")
     op.drop_column("intent_summaries", "subcategories")
-    op.drop_index(
-        op.f("ix_post_intent_classifications_sentiment"),
-        table_name="post_intent_classifications",
-    )
-    op.drop_column("post_intent_classifications", "topic_keyword")
-    op.drop_column("post_intent_classifications", "sentiment")

--- a/alembic/versions/5691f9523392_drop_per_post_pain_anger_columns.py
+++ b/alembic/versions/5691f9523392_drop_per_post_pain_anger_columns.py
@@ -1,0 +1,44 @@
+"""drop per_post pain_anger columns
+
+Revision ID: 5691f9523392
+Revises: 21a88f94dc62
+Create Date: 2026-02-28 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5691f9523392"
+down_revision: Union[str, None] = "21a88f94dc62"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index(
+        op.f("ix_post_intent_classifications_sentiment"),
+        table_name="post_intent_classifications",
+    )
+    op.drop_column("post_intent_classifications", "topic_keyword")
+    op.drop_column("post_intent_classifications", "sentiment")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "post_intent_classifications",
+        sa.Column("sentiment", sa.String(length=30), nullable=True),
+    )
+    op.add_column(
+        "post_intent_classifications",
+        sa.Column("topic_keyword", sa.String(length=50), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_post_intent_classifications_sentiment"),
+        "post_intent_classifications",
+        ["sentiment"],
+        unique=False,
+    )

--- a/alembic/versions/7a65e81501c8_drop_top_subreddits_from_intent_summaries.py
+++ b/alembic/versions/7a65e81501c8_drop_top_subreddits_from_intent_summaries.py
@@ -1,0 +1,29 @@
+"""drop top_subreddits from intent_summaries
+
+Revision ID: 7a65e81501c8
+Revises: 5691f9523392
+Create Date: 2026-02-28 17:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7a65e81501c8"
+down_revision: Union[str, None] = "5691f9523392"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("intent_summaries", "top_subreddits")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "intent_summaries",
+        sa.Column("top_subreddits", sa.JSON(), nullable=True),
+    )

--- a/alembic/versions/a3b2c1d0e5f4_readd_top_subreddits_to_intent_summaries.py
+++ b/alembic/versions/a3b2c1d0e5f4_readd_top_subreddits_to_intent_summaries.py
@@ -1,0 +1,29 @@
+"""re-add top_subreddits to intent_summaries
+
+Revision ID: a3b2c1d0e5f4
+Revises: 7a65e81501c8
+Create Date: 2026-02-28 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3b2c1d0e5f4"
+down_revision: Union[str, None] = "7a65e81501c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "intent_summaries",
+        sa.Column("top_subreddits", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("intent_summaries", "top_subreddits")

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -78,6 +78,43 @@ def _build_posts_batch_text(posts: list[dict], max_chars: int = MAX_POSTS_CHARS)
     return "".join(lines)
 
 
+def _extract_pain_anger_subcategories(
+    posts_in_cat: list[dict],
+) -> tuple[dict | None, dict | None]:
+    """Extrai subcategorias de sentimento e topic keywords para pain_and_anger."""
+    sentiment_counter = Counter(
+        p["sentiment"] for p in posts_in_cat if p.get("sentiment")
+    )
+    subcategories = dict(sentiment_counter.most_common(10)) if sentiment_counter else None
+
+    keyword_counter = Counter(
+        p["topic_keyword"] for p in posts_in_cat if p.get("topic_keyword")
+    )
+    topic_keywords = dict(keyword_counter.most_common(10)) if keyword_counter else None
+
+    return subcategories, topic_keywords
+
+
+def _extract_sentiment_and_keyword(result: dict) -> tuple[str | None, str | None]:
+    """Extrai e valida sentiment e topic_keyword de um resultado de classificação."""
+    sentiment = None
+    topic_keyword = None
+
+    raw_sentiment = result.get("sentiment")
+    if raw_sentiment and isinstance(raw_sentiment, str):
+        raw_sentiment = raw_sentiment.strip().lower()
+        if raw_sentiment and len(raw_sentiment) <= 30:
+            sentiment = raw_sentiment
+
+    raw_keyword = result.get("topic_keyword")
+    if raw_keyword and isinstance(raw_keyword, str):
+        raw_keyword = raw_keyword.strip()
+        if raw_keyword:
+            topic_keyword = raw_keyword.split()[0][:50].lower()
+
+    return sentiment, topic_keyword
+
+
 def _parse_json_response(content: str) -> list[dict]:
     """Extrai array JSON da resposta do LLM."""
     cleaned = content.strip()
@@ -93,6 +130,44 @@ def _parse_json_response(content: str) -> list[dict]:
     except json.JSONDecodeError:
         logger.warning("Failed to parse LLM JSON response")
         return []
+
+
+def _validate_and_build_classified_post(
+    result: dict, post_lookup: dict[str, dict]
+) -> ClassifiedPost | None:
+    """Valida um resultado de classificação e constrói o ClassifiedPost."""
+    post_id = result.get("post_id", "")
+    primary = result.get("primary_intent", "")
+    secondary = result.get("secondary_intent")
+
+    if primary not in VALID_INTENTS:
+        logger.warning("Invalid primary_intent '%s' for post %s, skipping", primary, post_id)
+        return None
+
+    if secondary and secondary not in VALID_INTENTS:
+        secondary = None
+
+    original = post_lookup.get(post_id)
+    if not original:
+        logger.warning("Post ID '%s' not found in batch, skipping", post_id)
+        return None
+
+    sentiment, topic_keyword = (
+        _extract_sentiment_and_keyword(result)
+        if primary == "pain_and_anger"
+        else (None, None)
+    )
+
+    return ClassifiedPost(
+        post_id=post_id,
+        post_title=original["title"],
+        post_subreddit=original["subreddit"],
+        primary_intent=primary,
+        secondary_intent=secondary,
+        confidence=result.get("confidence", "medium"),
+        sentiment=sentiment,
+        topic_keyword=topic_keyword,
+    )
 
 
 def classify_intents(state: IntentClassificationState) -> dict:
@@ -132,38 +207,9 @@ def classify_intents(state: IntentClassificationState) -> dict:
         batch_results = _parse_json_response(extract_response_text(response))
 
         for result in batch_results:
-            post_id = result.get("post_id", "")
-            primary = result.get("primary_intent", "")
-            secondary = result.get("secondary_intent")
-
-            # Validar categoria
-            if primary not in VALID_INTENTS:
-                logger.warning(
-                    "Invalid primary_intent '%s' for post %s, skipping",
-                    primary,
-                    post_id,
-                )
-                continue
-
-            if secondary and secondary not in VALID_INTENTS:
-                secondary = None
-
-            # Buscar dados do post original
-            original = post_lookup.get(post_id)
-            if not original:
-                logger.warning("Post ID '%s' not found in batch, skipping", post_id)
-                continue
-
-            all_classified.append(
-                ClassifiedPost(
-                    post_id=post_id,
-                    post_title=original["title"],
-                    post_subreddit=original["subreddit"],
-                    primary_intent=primary,
-                    secondary_intent=secondary,
-                    confidence=result.get("confidence", "medium"),
-                )
-            )
+            classified = _validate_and_build_classified_post(result, post_lookup)
+            if classified:
+                all_classified.append(classified)
 
         logger.info(
             "Classified batch %d-%d: %d posts",
@@ -215,12 +261,21 @@ def aggregate_intents(state: IntentClassificationState) -> dict:
             for p in posts_in_cat[:5]
         ]
 
+        # Subcategorias de sentimento e topic keywords (apenas pain_and_anger)
+        subcategories, topic_keywords_agg = (
+            _extract_pain_anger_subcategories(posts_in_cat)
+            if category == "pain_and_anger"
+            else (None, None)
+        )
+
         aggregations.append(
             {
                 "category": category,
                 "post_count": len(posts_in_cat),
                 "top_subreddits": top_subs,
                 "sample_posts": sample,
+                "subcategories": subcategories,
+                "topic_keywords": topic_keywords_agg,
             }
         )
 

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -13,6 +13,7 @@ from langgraph.graph import END, START, StateGraph
 
 from app.modules.intent_classification.application.use_cases.classify_intents_use_case.agent.prompts.intent_prompts import (
     get_aggregate_intents_prompt,
+    get_analyze_pain_anger_prompt,
     get_classify_intents_prompt,
 )
 from app.modules.intent_classification.application.use_cases.classify_intents_use_case.agent.state import (
@@ -78,43 +79,6 @@ def _build_posts_batch_text(posts: list[dict], max_chars: int = MAX_POSTS_CHARS)
     return "".join(lines)
 
 
-def _extract_pain_anger_subcategories(
-    posts_in_cat: list[dict],
-) -> tuple[dict | None, dict | None]:
-    """Extrai subcategorias de sentimento e topic keywords para pain_and_anger."""
-    sentiment_counter = Counter(
-        p["sentiment"] for p in posts_in_cat if p.get("sentiment")
-    )
-    subcategories = dict(sentiment_counter.most_common(10)) if sentiment_counter else None
-
-    keyword_counter = Counter(
-        p["topic_keyword"] for p in posts_in_cat if p.get("topic_keyword")
-    )
-    topic_keywords = dict(keyword_counter.most_common(10)) if keyword_counter else None
-
-    return subcategories, topic_keywords
-
-
-def _extract_sentiment_and_keyword(result: dict) -> tuple[str | None, str | None]:
-    """Extrai e valida sentiment e topic_keyword de um resultado de classificação."""
-    sentiment = None
-    topic_keyword = None
-
-    raw_sentiment = result.get("sentiment")
-    if raw_sentiment and isinstance(raw_sentiment, str):
-        raw_sentiment = raw_sentiment.strip().lower()
-        if raw_sentiment and len(raw_sentiment) <= 30:
-            sentiment = raw_sentiment
-
-    raw_keyword = result.get("topic_keyword")
-    if raw_keyword and isinstance(raw_keyword, str):
-        raw_keyword = raw_keyword.strip()
-        if raw_keyword:
-            topic_keyword = raw_keyword.split()[0][:50].lower()
-
-    return sentiment, topic_keyword
-
-
 def _parse_json_response(content: str) -> list[dict]:
     """Extrai array JSON da resposta do LLM."""
     cleaned = content.strip()
@@ -152,11 +116,8 @@ def _validate_and_build_classified_post(
         logger.warning("Post ID '%s' not found in batch, skipping", post_id)
         return None
 
-    sentiment, topic_keyword = (
-        _extract_sentiment_and_keyword(result)
-        if primary == "pain_and_anger"
-        else (None, None)
-    )
+    raw_confidence = result.get("confidence", "medium")
+    confidence = raw_confidence if raw_confidence in ("high", "medium", "low") else "medium"
 
     return ClassifiedPost(
         post_id=post_id,
@@ -164,9 +125,7 @@ def _validate_and_build_classified_post(
         post_subreddit=original["subreddit"],
         primary_intent=primary,
         secondary_intent=secondary,
-        confidence=result.get("confidence", "medium"),
-        sentiment=sentiment,
-        topic_keyword=topic_keyword,
+        confidence=confidence,
     )
 
 
@@ -248,34 +207,20 @@ def aggregate_intents(state: IntentClassificationState) -> dict:
         if not posts_in_cat:
             continue
 
-        # Top subreddits por frequência
-        sub_counter = Counter(p["post_subreddit"] for p in posts_in_cat)
-        top_subs = [
-            {"name": name, "count": count} for name, count in sub_counter.most_common(5)
-        ]
-
-        # Sample posts (primeiros 5 — já que não temos score individual no ClassifiedPost,
-        # usamos os primeiros 5 como representativos)
+        # Sample posts (primeiros 5)
         sample = [
             {"title": p["post_title"], "subreddit": p["post_subreddit"]}
             for p in posts_in_cat[:5]
         ]
 
-        # Subcategorias de sentimento e topic keywords (apenas pain_and_anger)
-        subcategories, topic_keywords_agg = (
-            _extract_pain_anger_subcategories(posts_in_cat)
-            if category == "pain_and_anger"
-            else (None, None)
-        )
-
         aggregations.append(
             {
                 "category": category,
                 "post_count": len(posts_in_cat),
-                "top_subreddits": top_subs,
                 "sample_posts": sample,
-                "subcategories": subcategories,
-                "topic_keywords": topic_keywords_agg,
+                "subcategories": None,
+                "topic_keywords": None,
+                "top_subreddits": None,
             }
         )
 
@@ -293,7 +238,6 @@ def aggregate_intents(state: IntentClassificationState) -> dict:
             {
                 "category": a["category"],
                 "post_count": a["post_count"],
-                "top_subreddits": [s["name"] for s in a["top_subreddits"][:3]],
                 "sample_titles": [s["title"] for s in a["sample_posts"][:3]],
             }
             for a in aggregations
@@ -321,12 +265,122 @@ def aggregate_intents(state: IntentClassificationState) -> dict:
     return {"intent_aggregations": aggregations}
 
 
+def _parse_json_object_response(content: str) -> dict:
+    """Extrai objeto JSON da resposta do LLM."""
+    cleaned = content.strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+    cleaned = re.sub(r"\s*```$", "", cleaned)
+    cleaned = cleaned.strip()
+
+    try:
+        result = json.loads(cleaned)
+        if isinstance(result, dict):
+            return result
+        return {}
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse LLM JSON object response")
+        return {}
+
+
+def analyze_pain_anger(state: IntentClassificationState) -> dict:
+    """
+    Nó 3: Analisa posts pain_and_anger para extrair subcategorias de sentimento e tópicos.
+
+    Envia TODOS os posts classificados como pain_and_anger ao LLM em uma única chamada
+    para obter distribuições agregadas de sentimentos e topic keywords.
+    Também computa top_subreddits (de quais comunidades vêm os posts pain_and_anger).
+    """
+    aggregations = state.get("intent_aggregations", [])
+    classified = state.get("classified_posts", [])
+
+    # Filtrar posts pain_and_anger
+    pain_posts = [p for p in classified if p["primary_intent"] == "pain_and_anger"]
+    if not pain_posts:
+        return {"intent_aggregations": aggregations}
+
+    # Computar top_subreddits a partir dos posts pain_and_anger
+    subreddit_counter = Counter(p["post_subreddit"] for p in pain_posts)
+    top_subreddits = [
+        {"name": name, "count": count}
+        for name, count in subreddit_counter.most_common(10)
+    ]
+
+    # Construir texto de posts para o prompt
+    posts_text = _build_posts_batch_text(
+        [
+            {
+                "id": p["post_id"],
+                "subreddit": p["post_subreddit"],
+                "title": p["post_title"],
+                "score": 0,
+                "num_comments": 0,
+            }
+            for p in pain_posts
+        ]
+    )
+
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    prompt = get_analyze_pain_anger_prompt(
+        audience_name=state["audience_name"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        posts_text=posts_text,
+        total_posts=len(pain_posts),
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+    result = _parse_json_object_response(extract_response_text(response))
+
+    subcategories = result.get("subcategories")
+    topic_keywords = result.get("topic_keywords")
+
+    # Validar e limitar a 10 itens
+    if isinstance(subcategories, dict):
+        subcategories = dict(
+            sorted(subcategories.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        subcategories = None
+
+    if isinstance(topic_keywords, dict):
+        topic_keywords = dict(
+            sorted(topic_keywords.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        topic_keywords = None
+
+    # Atualizar a agregação de pain_and_anger
+    updated = []
+    for agg in aggregations:
+        if agg["category"] == "pain_and_anger":
+            agg = {
+                **agg,
+                "subcategories": subcategories,
+                "topic_keywords": topic_keywords,
+                "top_subreddits": top_subreddits,
+            }
+        updated.append(agg)
+
+    logger.info(
+        "Pain & Anger analysis: %d subcategories, %d topic keywords, %d subreddits",
+        len(subcategories) if subcategories else 0,
+        len(topic_keywords) if topic_keywords else 0,
+        len(top_subreddits),
+    )
+    return {"intent_aggregations": updated}
+
+
 def create_intent_classification_agent():
     """Cria e compila o grafo LangGraph de classificação de intenção."""
     workflow = StateGraph(IntentClassificationState)
     workflow.add_node("classify_intents", classify_intents)
     workflow.add_node("aggregate_intents", aggregate_intents)
+    workflow.add_node("analyze_pain_anger", analyze_pain_anger)
     workflow.add_edge(START, "classify_intents")
     workflow.add_edge("classify_intents", "aggregate_intents")
-    workflow.add_edge("aggregate_intents", END)
+    workflow.add_edge("aggregate_intents", "analyze_pain_anger")
+    workflow.add_edge("analyze_pain_anger", END)
     return workflow.compile()

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -38,7 +38,9 @@ Respond in JSON format. For each post, provide:
     "post_id": "reddit_post_id",
     "primary_intent": "category_name",
     "secondary_intent": "category_name_or_null",
-    "confidence": "high|medium|low"
+    "confidence": "high|medium|low",
+    "sentiment": "specific_emotion_or_null",
+    "topic_keyword": "single_word_topic_or_null"
   }}
 ]
 
@@ -48,6 +50,9 @@ RULES:
 - A post about a bad experience asking for advice = primary: "pain_and_anger", secondary: "advice_request"
 - When in doubt between two categories, pick the one that reflects the author's MAIN purpose
 - Use "high" confidence when the intent is unambiguous, "medium" when reasonable, "low" when unclear
+- "sentiment" and "topic_keyword" are ONLY for posts where primary_intent is "pain_and_anger". For all other categories, set both to null
+- "sentiment" must be a single specific emotion label (e.g., "frustration", "anger", "disappointment", "concern", "anxiety", "sadness", "helplessness", "resentment", "overwhelm", "desperation"). Pick the single most dominant emotion
+- "topic_keyword" must be a SINGLE word that captures the main subject of the post (e.g., "dog", "pricing", "support", "bug", "shipping"). Pick the most specific applicable word
 - Return ONLY the JSON array, no additional text
 {language_directive}"""
 

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -38,9 +38,7 @@ Respond in JSON format. For each post, provide:
     "post_id": "reddit_post_id",
     "primary_intent": "category_name",
     "secondary_intent": "category_name_or_null",
-    "confidence": "high|medium|low",
-    "sentiment": "specific_emotion_or_null",
-    "topic_keyword": "single_word_topic_or_null"
+    "confidence": "high|medium|low"
   }}
 ]
 
@@ -50,9 +48,6 @@ RULES:
 - A post about a bad experience asking for advice = primary: "pain_and_anger", secondary: "advice_request"
 - When in doubt between two categories, pick the one that reflects the author's MAIN purpose
 - Use "high" confidence when the intent is unambiguous, "medium" when reasonable, "low" when unclear
-- "sentiment" and "topic_keyword" are ONLY for posts where primary_intent is "pain_and_anger". For all other categories, set both to null
-- "sentiment" must be a single specific emotion label (e.g., "frustration", "anger", "disappointment", "concern", "anxiety", "sadness", "helplessness", "resentment", "overwhelm", "desperation"). Pick the single most dominant emotion
-- "topic_keyword" must be a SINGLE word that captures the main subject of the post (e.g., "dog", "pricing", "support", "bug", "shipping"). Pick the most specific applicable word
 - Return ONLY the JSON array, no additional text
 {language_directive}"""
 
@@ -89,4 +84,55 @@ RULES:
 - Include only categories that have posts (post_count > 0)
 - Descriptions should be actionable — help a product manager spot opportunities
 - Return ONLY the JSON array, no additional text
+{language_directive}"""
+
+
+def get_analyze_pain_anger_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+) -> str:
+    """Prompt para análise holística de sentimentos e tópicos em posts pain_and_anger."""
+    return f"""You are an expert psychologist and community analyst specializing in understanding emotional expressions in online communities.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total pain_and_anger posts: {total_posts}
+
+Below are ALL posts classified as "pain_and_anger" from this audience's communities.
+Your task is to analyze them holistically and identify:
+
+1. **Sentiment subcategories**: What specific emotions are people expressing? (e.g., frustration, anger, disappointment, anxiety, sadness, concern, helplessness, etc.)
+2. **Topic keywords**: What specific subjects/themes are causing these emotions? Use single words. (e.g., pricing, support, quality, shipping, dog, behavior, etc.)
+
+POSTS:
+{posts_text}
+
+---
+
+Respond in JSON format:
+{{
+  "subcategories": {{
+    "emotion_name": count,
+    "emotion_name": count
+  }},
+  "topic_keywords": {{
+    "keyword": count,
+    "keyword": count
+  }}
+}}
+
+RULES:
+- subcategories: Return up to 10 emotions, sorted by count descending
+- topic_keywords: Return up to 10 single-word topics, sorted by count descending
+- Each count represents how many posts express that emotion or relate to that topic
+- A single post can contribute to multiple emotions or topics
+- Use lowercase for all keys
+- Emotions should be specific (use "frustration" not "negative", use "anxiety" not "bad")
+- Topics should be single words that capture the core subject (use "pricing" not "high prices")
+- The sum of subcategory counts may exceed total_posts (one post can express multiple emotions)
+- Return ONLY the JSON object, no additional text
 {language_directive}"""

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/state.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/state.py
@@ -23,6 +23,8 @@ class ClassifiedPost(TypedDict):
     primary_intent: str
     secondary_intent: str | None
     confidence: str  # high, medium, low
+    sentiment: str | None  # Apenas para pain_and_anger
+    topic_keyword: str | None  # Apenas para pain_and_anger
 
 
 class IntentAggregation(TypedDict):
@@ -34,6 +36,8 @@ class IntentAggregation(TypedDict):
     top_subreddits: list[dict]  # [{"name": "...", "count": N}]
     sample_posts: list[dict]  # [{"title": "...", "subreddit": "...", "score": N}]
     rank: int
+    subcategories: dict | None  # {"frustration": 15, "anger": 4} — só pain_and_anger
+    topic_keywords: dict | None  # {"dog": 15, "behavior": 8} — só pain_and_anger
 
 
 class IntentClassificationState(TypedDict):

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/state.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/state.py
@@ -23,8 +23,6 @@ class ClassifiedPost(TypedDict):
     primary_intent: str
     secondary_intent: str | None
     confidence: str  # high, medium, low
-    sentiment: str | None  # Apenas para pain_and_anger
-    topic_keyword: str | None  # Apenas para pain_and_anger
 
 
 class IntentAggregation(TypedDict):
@@ -33,11 +31,11 @@ class IntentAggregation(TypedDict):
     category: str
     post_count: int
     description: str | None
-    top_subreddits: list[dict]  # [{"name": "...", "count": N}]
-    sample_posts: list[dict]  # [{"title": "...", "subreddit": "...", "score": N}]
+    sample_posts: list[dict]  # [{"title": "...", "subreddit": "..."}]
     rank: int
     subcategories: dict | None  # {"frustration": 15, "anger": 4} — só pain_and_anger
     topic_keywords: dict | None  # {"dog": 15, "behavior": 8} — só pain_and_anger
+    top_subreddits: list[dict] | None  # [{"name": "r/dogs", "count": 20}] — só pain_and_anger  # {"dog": 15, "behavior": 8} — só pain_and_anger  # {"dog": 15, "behavior": 8} — só pain_and_anger
 
 
 class IntentClassificationState(TypedDict):

--- a/app/modules/intent_classification/domain/entities/intent_classification.py
+++ b/app/modules/intent_classification/domain/entities/intent_classification.py
@@ -78,6 +78,8 @@ class PostIntentClassification(Base):
     primary_intent = Column(String(30), nullable=False, index=True)
     secondary_intent = Column(String(30), nullable=True)
     confidence = Column(String(10), nullable=False)  # high, medium, low
+    sentiment = Column(String(30), nullable=True, index=True)  # Apenas para pain_and_anger
+    topic_keyword = Column(String(50), nullable=True)  # Apenas para pain_and_anger
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
@@ -106,6 +108,8 @@ class IntentSummary(Base):
     sample_posts = Column(
         JSON, nullable=True
     )  # [{"title": "...", "subreddit": "...", "score": N}]
+    subcategories = Column(JSON, nullable=True)  # {"frustration": 15, "anger": 4, ...}
+    topic_keywords = Column(JSON, nullable=True)  # {"dog": 15, "behavior": 8, ...}
     rank = Column(Integer, nullable=True)
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/app/modules/intent_classification/domain/entities/intent_classification.py
+++ b/app/modules/intent_classification/domain/entities/intent_classification.py
@@ -78,8 +78,6 @@ class PostIntentClassification(Base):
     primary_intent = Column(String(30), nullable=False, index=True)
     secondary_intent = Column(String(30), nullable=True)
     confidence = Column(String(10), nullable=False)  # high, medium, low
-    sentiment = Column(String(30), nullable=True, index=True)  # Apenas para pain_and_anger
-    topic_keyword = Column(String(50), nullable=True)  # Apenas para pain_and_anger
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
@@ -104,10 +102,10 @@ class IntentSummary(Base):
     intent_category = Column(String(30), nullable=False)
     post_count = Column(Integer, nullable=False)
     description = Column(Text, nullable=True)
-    top_subreddits = Column(JSON, nullable=True)  # [{"name": "sub", "count": N}]
     sample_posts = Column(
         JSON, nullable=True
-    )  # [{"title": "...", "subreddit": "...", "score": N}]
+    )  # [{"title": "...", "subreddit": "..."}]
+    top_subreddits = Column(JSON, nullable=True)  # [{"name": "r/dogs", "count": 20}]
     subcategories = Column(JSON, nullable=True)  # {"frustration": 15, "anger": 4, ...}
     topic_keywords = Column(JSON, nullable=True)  # {"dog": 15, "behavior": 8, ...}
     rank = Column(Integer, nullable=True)

--- a/app/modules/intent_classification/infra/repositories/intent_classification_repository.py
+++ b/app/modules/intent_classification/infra/repositories/intent_classification_repository.py
@@ -126,8 +126,6 @@ class IntentClassificationRepository:
                 primary_intent=cls_data["primary_intent"],
                 secondary_intent=cls_data.get("secondary_intent"),
                 confidence=cls_data.get("confidence", "medium"),
-                sentiment=cls_data.get("sentiment"),
-                topic_keyword=cls_data.get("topic_keyword"),
             )
             self.db.add(classification)
         self.db.commit()
@@ -141,8 +139,8 @@ class IntentClassificationRepository:
                 intent_category=summary_data["category"],
                 post_count=summary_data["post_count"],
                 description=summary_data.get("description"),
-                top_subreddits=summary_data.get("top_subreddits"),
                 sample_posts=summary_data.get("sample_posts"),
+                top_subreddits=summary_data.get("top_subreddits"),
                 subcategories=summary_data.get("subcategories"),
                 topic_keywords=summary_data.get("topic_keywords"),
                 rank=summary_data.get("rank"),

--- a/app/modules/intent_classification/infra/repositories/intent_classification_repository.py
+++ b/app/modules/intent_classification/infra/repositories/intent_classification_repository.py
@@ -126,6 +126,8 @@ class IntentClassificationRepository:
                 primary_intent=cls_data["primary_intent"],
                 secondary_intent=cls_data.get("secondary_intent"),
                 confidence=cls_data.get("confidence", "medium"),
+                sentiment=cls_data.get("sentiment"),
+                topic_keyword=cls_data.get("topic_keyword"),
             )
             self.db.add(classification)
         self.db.commit()
@@ -141,6 +143,8 @@ class IntentClassificationRepository:
                 description=summary_data.get("description"),
                 top_subreddits=summary_data.get("top_subreddits"),
                 sample_posts=summary_data.get("sample_posts"),
+                subcategories=summary_data.get("subcategories"),
+                topic_keywords=summary_data.get("topic_keywords"),
                 rank=summary_data.get("rank"),
             )
             self.db.add(summary)

--- a/app/routes/intent_classification.py
+++ b/app/routes/intent_classification.py
@@ -150,8 +150,8 @@ def list_intents(
                 "post_count": s.post_count,
                 "percentage": percentage,
                 "description": s.description,
-                "top_subreddits": s.top_subreddits or [],
                 "sample_posts": s.sample_posts or [],
+                "top_subreddits": s.top_subreddits or [],
                 "subcategories": s.subcategories or {},
                 "topic_keywords": s.topic_keywords or {},
                 "rank": s.rank,
@@ -230,8 +230,6 @@ def list_intent_posts(
                 "primary_intent": p.primary_intent,
                 "secondary_intent": p.secondary_intent,
                 "confidence": p.confidence,
-                "sentiment": p.sentiment,
-                "topic_keyword": p.topic_keyword,
             }
             for p in posts
         ],

--- a/app/routes/intent_classification.py
+++ b/app/routes/intent_classification.py
@@ -152,6 +152,8 @@ def list_intents(
                 "description": s.description,
                 "top_subreddits": s.top_subreddits or [],
                 "sample_posts": s.sample_posts or [],
+                "subcategories": s.subcategories or {},
+                "topic_keywords": s.topic_keywords or {},
                 "rank": s.rank,
             }
         )
@@ -228,6 +230,8 @@ def list_intent_posts(
                 "primary_intent": p.primary_intent,
                 "secondary_intent": p.secondary_intent,
                 "confidence": p.confidence,
+                "sentiment": p.sentiment,
+                "topic_keyword": p.topic_keyword,
             }
             for p in posts
         ],


### PR DESCRIPTION
## Summary
- Enrich `pain_and_anger` intent category with **sentiment subcategories** (up to 10) and **topic keywords** (up to 10) with aggregated counts
- LLM classifies each `pain_and_anger` post with a dominant sentiment (e.g. frustration, anger, concern) and a single-word topic keyword (e.g. dog, pricing, behavior) during the existing classification step
- New fields exposed in both `GET /audiences/{id}/themes/intents` and `GET /audiences/{id}/themes/intents/pain_and_anger/posts` endpoints

## Changes
- **Migration**: New columns `sentiment`, `topic_keyword` on `post_intent_classifications`; `subcategories`, `topic_keywords` (JSON) on `intent_summaries`
- **Entities**: Updated `PostIntentClassification` and `IntentSummary` SQLAlchemy models
- **Prompt**: Extended classification prompt to extract sentiment and topic_keyword for pain_and_anger posts
- **Agent**: Added validation helpers and Counter-based aggregation for subcategories/keywords
- **Repository**: Persist new fields in save methods
- **Routes**: Include new fields in API responses

## Test plan
- [ ] Run `make migrate` to apply the new migration
- [ ] Trigger `POST /audiences/{id}/themes/intents/refresh?window=week`
- [ ] Verify `GET /audiences/{id}/themes/intents?window=week` returns `subcategories` and `topic_keywords` for `pain_and_anger`
- [ ] Verify `GET /audiences/{id}/themes/intents/pain_and_anger/posts` returns `sentiment` and `topic_keyword` per post
- [ ] Verify other categories return `{}` / `null` for the new fields (backward compatible)

Closes #79