### PR TITLE
feat: expand StorageService with S3 CRUD and uploaded_files table

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -52,6 +52,7 @@ from app.modules.theme_analysis.domain.entities import theme_summary  # noqa: E4
 from app.modules.theme_analysis.domain.entities import theme_panel  # noqa: E402
 from app.modules.content_suggestions.domain.entities import content_suggestion  # noqa: E402
 from app.modules.content_suggestions.domain.entities import content_draft  # noqa: E402
+from app.modules.shared.domain.entities import uploaded_file  # noqa: E402
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/cc2c9c233554_add_uploaded_files_table.py
+++ b/alembic/versions/cc2c9c233554_add_uploaded_files_table.py
@@ -1,0 +1,42 @@
+"""add uploaded_files table
+
+Revision ID: cc2c9c233554
+Revises: c1d2e3f4a5b6
+Create Date: 2026-03-03 09:55:08.415138
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'cc2c9c233554'
+down_revision: Union[str, Sequence[str], None] = 'c1d2e3f4a5b6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('uploaded_files',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('key', sa.String(length=500), nullable=False),
+    sa.Column('url', sa.Text(), nullable=False),
+    sa.Column('content_type', sa.String(length=100), nullable=False),
+    sa.Column('size_bytes', sa.BigInteger(), nullable=True),
+    sa.Column('original_name', sa.String(length=500), nullable=True),
+    sa.Column('uploaded_by', sa.UUID(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+    sa.ForeignKeyConstraint(['uploaded_by'], ['users.id'], ondelete='SET NULL'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_uploaded_files_key'), 'uploaded_files', ['key'], unique=True)
+    op.create_index(op.f('ix_uploaded_files_uploaded_by'), 'uploaded_files', ['uploaded_by'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_uploaded_files_uploaded_by'), table_name='uploaded_files')
+    op.drop_index(op.f('ix_uploaded_files_key'), table_name='uploaded_files')
+    op.drop_table('uploaded_files')

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
 
     # AWS/S3 settings
     s3_bucket_name: Optional[str] = None
+    s3_root_prefix: str = "oraculo-backend"
     aws_region: str = "us-east-1"
     s3_access_key: Optional[str] = None
     s3_secret_key: Optional[str] = None

--- a/app/modules/shared/application/services/storage_service.py
+++ b/app/modules/shared/application/services/storage_service.py
@@ -192,5 +192,6 @@ class StorageService:
     # ------------------------------------------------------------------ #
 
     def generate_key(self, prefix: str = "content-images", extension: str = "png") -> str:
-        """Gera chave unica para upload."""
-        return f"{prefix}/{uuid.uuid4()}.{extension}"
+        """Gera chave unica para upload com namespace do projeto."""
+        root = settings.s3_root_prefix
+        return f"{root}/{prefix}/{uuid.uuid4()}.{extension}"

--- a/app/modules/shared/application/services/storage_service.py
+++ b/app/modules/shared/application/services/storage_service.py
@@ -1,4 +1,4 @@
-"""Servico de upload para S3-compatible storage."""
+"""Servico de CRUD para arquivos em S3-compatible storage."""
 
 import logging
 import uuid
@@ -6,6 +6,7 @@ from typing import Optional
 
 import boto3
 from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
 
 from app.config import settings
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class StorageService:
-    """Wrapper para upload de arquivos no S3."""
+    """Wrapper para operacoes CRUD de arquivos no S3."""
 
     def __init__(
         self,
@@ -34,6 +35,10 @@ class StorageService:
             aws_secret_access_key=secret_key or settings.s3_secret_key,
             config=BotoConfig(signature_version="s3v4"),
         )
+
+    # ------------------------------------------------------------------ #
+    # Upload
+    # ------------------------------------------------------------------ #
 
     def upload(
         self,
@@ -62,6 +67,129 @@ class StorageService:
         url = f"https://{self._bucket}.s3.{self._region}.amazonaws.com/{key}"
         logger.info("Uploaded %d bytes to s3://%s/%s", len(data), self._bucket, key)
         return url
+
+    # ------------------------------------------------------------------ #
+    # Delete
+    # ------------------------------------------------------------------ #
+
+    def delete(self, key: str) -> bool:
+        """
+        Remove um arquivo do S3.
+
+        Args:
+            key: Chave do arquivo no bucket.
+
+        Returns:
+            True se a operacao foi executada sem erros.
+        """
+        self._client.delete_object(Bucket=self._bucket, Key=key)
+        logger.info("Deleted s3://%s/%s", self._bucket, key)
+        return True
+
+    def delete_many(self, keys: list[str]) -> int:
+        """
+        Remove multiplos arquivos do S3 em uma unica chamada.
+
+        Args:
+            keys: Lista de chaves a serem removidas.
+
+        Returns:
+            Quantidade de arquivos efetivamente deletados.
+        """
+        if not keys:
+            return 0
+
+        response = self._client.delete_objects(
+            Bucket=self._bucket,
+            Delete={"Objects": [{"Key": k} for k in keys], "Quiet": True},
+        )
+        deleted_count = len(keys) - len(response.get("Errors", []))
+        logger.info(
+            "Bulk deleted %d/%d objects from s3://%s",
+            deleted_count,
+            len(keys),
+            self._bucket,
+        )
+        return deleted_count
+
+    # ------------------------------------------------------------------ #
+    # Read / Download
+    # ------------------------------------------------------------------ #
+
+    def get_presigned_url(self, key: str, expiration: int = 3600) -> str:
+        """
+        Gera URL pre-assinada para download temporario.
+
+        Args:
+            key: Chave do arquivo no bucket.
+            expiration: Tempo de validade em segundos (padrao: 1 hora).
+
+        Returns:
+            URL pre-assinada para GET do objeto.
+        """
+        url = self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self._bucket, "Key": key},
+            ExpiresIn=expiration,
+        )
+        logger.info("Generated presigned URL for s3://%s/%s (expires in %ds)", self._bucket, key, expiration)
+        return url
+
+    # ------------------------------------------------------------------ #
+    # List
+    # ------------------------------------------------------------------ #
+
+    def list_objects(self, prefix: str, max_keys: int = 100) -> list[dict]:
+        """
+        Lista objetos no bucket filtrados por prefixo.
+
+        Args:
+            prefix: Prefixo (pasta) para filtrar (ex: 'content-images/').
+            max_keys: Maximo de resultados retornados.
+
+        Returns:
+            Lista de dicts com 'key', 'size' e 'last_modified'.
+        """
+        response = self._client.list_objects_v2(
+            Bucket=self._bucket,
+            Prefix=prefix,
+            MaxKeys=max_keys,
+        )
+        objects = [
+            {
+                "key": obj["Key"],
+                "size": obj["Size"],
+                "last_modified": obj["LastModified"],
+            }
+            for obj in response.get("Contents", [])
+        ]
+        logger.info("Listed %d objects under s3://%s/%s", len(objects), self._bucket, prefix)
+        return objects
+
+    # ------------------------------------------------------------------ #
+    # Metadata
+    # ------------------------------------------------------------------ #
+
+    def get_file_size(self, key: str) -> int | None:
+        """
+        Retorna o tamanho em bytes de um arquivo no S3.
+
+        Args:
+            key: Chave do arquivo no bucket.
+
+        Returns:
+            Tamanho em bytes ou None se o arquivo nao existir.
+        """
+        try:
+            response = self._client.head_object(Bucket=self._bucket, Key=key)
+            return response["ContentLength"]
+        except ClientError:
+            logger.warning("File not found: s3://%s/%s", self._bucket, key)
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
 
     def generate_key(self, prefix: str = "content-images", extension: str = "png") -> str:
         """Gera chave unica para upload."""

--- a/app/modules/shared/domain/entities/uploaded_file.py
+++ b/app/modules/shared/domain/entities/uploaded_file.py
@@ -1,0 +1,33 @@
+"""Entidade generica para rastrear arquivos enviados ao S3."""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class UploadedFile(Base):
+    """Registro centralizado de arquivos armazenados no S3."""
+
+    __tablename__ = "uploaded_files"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    key = Column(String(500), nullable=False, unique=True, index=True)
+    url = Column(Text, nullable=False)
+    content_type = Column(String(100), nullable=False, default="application/octet-stream")
+    size_bytes = Column(BigInteger, nullable=True)
+    original_name = Column(String(500), nullable=True)
+    uploaded_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/app/modules/shared/infra/repositories/uploaded_file_repository.py
+++ b/app/modules/shared/infra/repositories/uploaded_file_repository.py
@@ -1,0 +1,68 @@
+"""Repositorio para registros de arquivos enviados ao S3."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.shared.domain.entities.uploaded_file import UploadedFile
+
+logger = logging.getLogger(__name__)
+
+
+class UploadedFileRepository:
+    """CRUD para a tabela uploaded_files."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def save(self, uploaded_file: UploadedFile) -> UploadedFile:
+        """Persiste um novo registro de arquivo."""
+        self.db.add(uploaded_file)
+        self.db.commit()
+        self.db.refresh(uploaded_file)
+        return uploaded_file
+
+    def find_by_id(self, file_id: UUID) -> UploadedFile | None:
+        """Busca registro por ID."""
+        return (
+            self.db.query(UploadedFile)
+            .filter(UploadedFile.id == file_id)
+            .first()
+        )
+
+    def find_by_key(self, key: str) -> UploadedFile | None:
+        """Busca registro pela chave S3."""
+        return (
+            self.db.query(UploadedFile)
+            .filter(UploadedFile.key == key)
+            .first()
+        )
+
+    def find_by_uploader(self, user_id: UUID) -> list[UploadedFile]:
+        """Lista arquivos enviados por um usuario."""
+        return (
+            self.db.query(UploadedFile)
+            .filter(UploadedFile.uploaded_by == user_id)
+            .order_by(UploadedFile.created_at.desc())
+            .all()
+        )
+
+    def delete(self, file_id: UUID) -> bool:
+        """Remove registro por ID."""
+        uploaded_file = self.find_by_id(file_id)
+        if not uploaded_file:
+            return False
+        self.db.delete(uploaded_file)
+        self.db.commit()
+        return True
+
+    def delete_by_key(self, key: str) -> bool:
+        """Remove registro pela chave S3."""
+        deleted = (
+            self.db.query(UploadedFile)
+            .filter(UploadedFile.key == key)
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted > 0


### PR DESCRIPTION
## Summary

- Expand `StorageService` with full CRUD: `delete`, `delete_many`, `get_presigned_url`, `list_objects`, `get_file_size`
- Create `uploaded_files` table (entity + repository) for centralized file tracking
- Add Alembic migration for new table

## Test plan

- [ ] Run `make migrate` to apply the migration
- [ ] Verify `uploaded_files` table exists with correct schema and indexes
- [ ] Test `StorageService.delete()` with a valid S3 key
- [ ] Test `StorageService.get_presigned_url()` returns accessible URL
- [ ] Test `StorageService.list_objects()` with existing prefix
- [ ] Test `UploadedFileRepository.save()` and `find_by_key()`
- [ ] Confirm `make lint` passes on all modified files

Closes #88