### PR TITLE
feat: community sync improvements — validation, limit and events

### DIFF
--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from dataclasses import dataclass, field
 from uuid import UUID
 
@@ -10,9 +11,18 @@ from app.modules.audience_keywords.application.use_cases.trigger_keyword_analysi
 from app.modules.audience_topics.application.use_cases.trigger_topic_analysis_use_case import (
     TriggerTopicAnalysisUseCase,
 )
+from app.modules.audiences.domain.constants import MAX_COMMUNITIES_PER_AUDIENCE
+from app.modules.audiences.domain.validators.subreddit_name_validator import (
+    validate_subreddit_names_format,
+)
 from app.modules.audiences.infra.repositories.audience_repository import (
     AudienceRepository,
 )
+from app.modules.notifications.application.services.notification_event_service import (
+    NotificationEventService,
+)
+from app.modules.shared.infra.cache.redit_cache import RedisCache
+from app.modules.shared.infra.database.database import SessionLocal
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +66,10 @@ class CreateAudienceUseCase:
         self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
 
     def execute(self, input_data: CreateAudienceInput) -> AudienceDTO:
+        if input_data.subreddit_names:
+            _validate_names_format(input_data.subreddit_names)
+            _validate_communities_limit(input_data.subreddit_names)
+
         audience = self.repository.create(
             name=input_data.name,
             description=input_data.description,
@@ -72,6 +86,13 @@ class CreateAudienceUseCase:
             self.trigger_topics.execute(audience.id)
             self.trigger_keywords.execute(audience.id)
 
+            # Validar existência no Reddit em background
+            _validate_communities_in_background(
+                audience.id,
+                audience.user_id,
+                input_data.subreddit_names,
+            )
+
         return AudienceDTO(
             id=audience.id,
             name=audience.name,
@@ -85,9 +106,12 @@ class UpdateAudienceUseCase:
     """Atualiza uma audiência existente."""
 
     def __init__(self, db: Session):
+        self.db = db
         self.repository = AudienceRepository(db)
         self.trigger_topics = TriggerTopicAnalysisUseCase(db)
         self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
+        self.notification_service = NotificationEventService(db)
+        self.cache = RedisCache()
 
     def execute(
         self, audience_id: UUID, input_data: UpdateAudienceInput
@@ -101,14 +125,9 @@ class UpdateAudienceUseCase:
             return None
 
         if input_data.subreddit_names is not None:
-            communities = self.repository.sync_communities(
-                audience_id, input_data.subreddit_names
+            communities_count = self._sync_and_notify(
+                audience_id, audience.user_id, input_data.subreddit_names
             )
-            communities_count = len(communities)
-
-            # Dispara análises quando comunidades mudam
-            self.trigger_topics.execute(audience_id)
-            self.trigger_keywords.execute(audience_id)
         else:
             communities_count = len(audience.communities)
 
@@ -119,6 +138,45 @@ class UpdateAudienceUseCase:
             user_id=audience.user_id,
             communities_count=communities_count,
         )
+
+    def _sync_and_notify(
+        self, audience_id: UUID, user_id: UUID, subreddit_names: list[str]
+    ) -> int:
+        """Valida, sincroniza comunidades e dispara análises/notificações."""
+        _validate_names_format(subreddit_names)
+        _validate_communities_limit(subreddit_names)
+
+        communities, to_add, to_remove = self.repository.sync_communities(
+            audience_id, subreddit_names
+        )
+
+        # Só dispara análises e notificações quando realmente mudou
+        if to_add or to_remove:
+            self.trigger_topics.execute(audience_id)
+            self.trigger_keywords.execute(audience_id)
+
+            self.notification_service.notify(
+                user_id=user_id,
+                type_="communities_changed",
+                title="Communities Updated",
+                message=(
+                    f"Audience communities updated: "
+                    f"{len(to_add)} added, {len(to_remove)} removed."
+                ),
+                metadata={
+                    "audience_id": str(audience_id),
+                    "added": sorted(to_add),
+                    "removed": sorted(to_remove),
+                },
+            )
+
+            for name in to_remove:
+                self.cache.delete(f"community_details_{name}")
+
+            if to_add:
+                _validate_communities_in_background(audience_id, user_id, list(to_add))
+
+        return len(communities)
 
 
 class DeleteAudienceUseCase:
@@ -140,6 +198,14 @@ class AddCommunityToAudienceUseCase:
         self.trigger_keywords = TriggerKeywordAnalysisUseCase(db)
 
     def execute(self, audience_id: UUID, subreddit_name: str) -> bool:
+        _validate_names_format([subreddit_name])
+
+        current_communities = self.repository.get_communities(audience_id)
+        if len(current_communities) >= MAX_COMMUNITIES_PER_AUDIENCE:
+            raise ValueError(
+                f"Maximum of {MAX_COMMUNITIES_PER_AUDIENCE} communities per audience reached."
+            )
+
         result = self.repository.add_community(audience_id, subreddit_name)
         if result is not None:
             self.trigger_topics.execute(audience_id)
@@ -161,3 +227,47 @@ class RemoveCommunityFromAudienceUseCase:
             self.trigger_topics.execute(audience_id)
             self.trigger_keywords.execute(audience_id)
         return removed
+
+
+def _validate_names_format(subreddit_names: list[str]) -> None:
+    """Valida formato dos nomes de subreddit. Levanta ValueError se inválido."""
+    _, invalid_names = validate_subreddit_names_format(subreddit_names)
+    if invalid_names:
+        raise ValueError(
+            f"Invalid subreddit name format: {', '.join(invalid_names)}. "
+            "Names must be 3-21 characters, alphanumeric and underscores only."
+        )
+
+
+def _validate_communities_limit(subreddit_names: list[str]) -> None:
+    """Valida limite de comunidades por audiência. Levanta ValueError se excedido."""
+    if len(subreddit_names) > MAX_COMMUNITIES_PER_AUDIENCE:
+        raise ValueError(
+            f"Maximum of {MAX_COMMUNITIES_PER_AUDIENCE} communities per audience exceeded. "
+            f"Received {len(subreddit_names)}."
+        )
+
+
+def _validate_communities_in_background(
+    audience_id: UUID, user_id: UUID, subreddit_names: list[str]
+) -> None:
+    """Dispara validação de existência no Reddit em background thread."""
+
+    def _run():
+        from app.modules.audiences.application.use_cases.validate_communities_use_case import (
+            ValidateCommunitiesUseCase,
+        )
+
+        db = SessionLocal()
+        try:
+            use_case = ValidateCommunitiesUseCase(db)
+            use_case.execute(audience_id, user_id, subreddit_names)
+        except Exception:
+            logger.exception(
+                "Background community validation failed for audience %s",
+                audience_id,
+            )
+        finally:
+            db.close()
+
+    threading.Thread(target=_run, daemon=True).start()

--- a/app/modules/audiences/application/use_cases/validate_communities_use_case.py
+++ b/app/modules/audiences/application/use_cases/validate_communities_use_case.py
@@ -1,0 +1,63 @@
+"""Validação assíncrona de existência de subreddits no Reddit."""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.notifications.application.services.notification_event_service import (
+    NotificationEventService,
+)
+from app.modules.topics.infra.providers.reddit_provider.generic_reddit_provider import (
+    GenericRedditProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ValidateCommunitiesUseCase:
+    """Valida existência de subreddits no Reddit em background."""
+
+    def __init__(self, db: Session):
+        self.audience_repo = AudienceRepository(db)
+        self.reddit_provider = GenericRedditProvider()
+        self.notification_service = NotificationEventService(db)
+
+    def execute(
+        self, audience_id: UUID, user_id: UUID, subreddit_names: list[str]
+    ) -> None:
+        """Valida cada subreddit no Reddit. Remove inválidos e notifica o usuário."""
+        invalid_names = []
+
+        for name in subreddit_names:
+            try:
+                self.reddit_provider.get_community_details(name)
+            except Exception:
+                logger.warning(
+                    "Subreddit '%s' not found on Reddit for audience %s",
+                    name,
+                    audience_id,
+                )
+                invalid_names.append(name)
+
+        if not invalid_names:
+            return
+
+        self.audience_repo.remove_communities_by_names(audience_id, invalid_names)
+
+        self.notification_service.notify(
+            user_id=user_id,
+            type_="communities_validation_failed",
+            title="Invalid Communities Removed",
+            message=(
+                f"The following communities were not found on Reddit and have been "
+                f"removed: {', '.join(invalid_names)}"
+            ),
+            metadata={
+                "audience_id": str(audience_id),
+                "invalid_names": invalid_names,
+            },
+        )

--- a/app/modules/audiences/domain/constants.py
+++ b/app/modules/audiences/domain/constants.py
@@ -1,0 +1,5 @@
+"""Constantes do módulo de audiências."""
+
+import os
+
+MAX_COMMUNITIES_PER_AUDIENCE = int(os.getenv("MAX_COMMUNITIES_PER_AUDIENCE", "50"))

--- a/app/modules/audiences/domain/validators/subreddit_name_validator.py
+++ b/app/modules/audiences/domain/validators/subreddit_name_validator.py
@@ -1,0 +1,26 @@
+"""Validação de formato de nomes de subreddit."""
+
+import re
+
+SUBREDDIT_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]{2,20}$")
+
+
+def validate_subreddit_name_format(name: str) -> bool:
+    """Valida formato do nome do subreddit (3-21 chars, alfanumérico + underscore)."""
+    return bool(SUBREDDIT_NAME_PATTERN.match(name))
+
+
+def validate_subreddit_names_format(names: list[str]) -> tuple[list[str], list[str]]:
+    """Separa nomes válidos e inválidos por formato.
+
+    Returns:
+        (valid_names, invalid_names)
+    """
+    valid = []
+    invalid = []
+    for name in names:
+        if validate_subreddit_name_format(name):
+            valid.append(name)
+        else:
+            invalid.append(name)
+    return valid, invalid

--- a/app/modules/audiences/infra/repositories/audience_repository.py
+++ b/app/modules/audiences/infra/repositories/audience_repository.py
@@ -36,11 +36,7 @@ class AudienceRepository:
         """
         Busca audiência por ID.
         """
-        return (
-            self.db.query(Audience)
-            .filter(Audience.id == audience_id)
-            .first()
-        )
+        return self.db.query(Audience).filter(Audience.id == audience_id).first()
 
     def find_all(self, user_id: UUID | None = None) -> list[Audience]:
         """
@@ -146,10 +142,13 @@ class AudienceRepository:
         self,
         audience_id: UUID,
         subreddit_names: list[str],
-    ) -> list[AudienceCommunity]:
+    ) -> tuple[list[AudienceCommunity], set[str], set[str]]:
         """
         Sincroniza comunidades de uma audiência com a lista desejada.
         Remove as que não estão na lista, adiciona as novas.
+
+        Returns:
+            (communities, to_add, to_remove)
         """
         current = self.get_communities(audience_id)
         current_names = {c.subreddit_name for c in current}
@@ -165,12 +164,22 @@ class AudienceRepository:
             ).delete(synchronize_session="fetch")
 
         for name in to_add:
-            self.db.add(
-                AudienceCommunity(audience_id=audience_id, subreddit_name=name)
-            )
+            self.db.add(AudienceCommunity(audience_id=audience_id, subreddit_name=name))
 
         self.db.commit()
-        return self.get_communities(audience_id)
+        return self.get_communities(audience_id), to_add, to_remove
+
+    def remove_communities_by_names(
+        self,
+        audience_id: UUID,
+        subreddit_names: list[str],
+    ) -> None:
+        """Remove comunidades específicas de uma audiência."""
+        self.db.query(AudienceCommunity).filter(
+            AudienceCommunity.audience_id == audience_id,
+            AudienceCommunity.subreddit_name.in_([n.lower() for n in subreddit_names]),
+        ).delete(synchronize_session="fetch")
+        self.db.commit()
 
     def get_communities(self, audience_id: UUID) -> list[AudienceCommunity]:
         """

--- a/app/modules/notifications/application/services/notification_event_service.py
+++ b/app/modules/notifications/application/services/notification_event_service.py
@@ -24,6 +24,8 @@ _TYPE_LABELS = {
     "theme_analysis": "Theme Analysis",
     "intent_classification": "Intent Classification",
     "theme_summary": "Theme Summary",
+    "communities_changed": "Communities Update",
+    "communities_validation_failed": "Community Validation",
 }
 
 
@@ -54,14 +56,16 @@ class NotificationEventService:
         )
 
         channel = f"notifications:{user_id}"
-        payload = json.dumps({
-            "id": str(notification.id),
-            "type": type_,
-            "title": title,
-            "message": message,
-            "metadata": metadata or {},
-            "created_at": notification.created_at.isoformat(),
-        })
+        payload = json.dumps(
+            {
+                "id": str(notification.id),
+                "type": type_,
+                "title": title,
+                "message": message,
+                "metadata": metadata or {},
+                "created_at": notification.created_at.isoformat(),
+            }
+        )
 
         try:
             self._redis.publish(channel, payload)
@@ -83,7 +87,9 @@ class NotificationEventService:
         """Notificação de análise concluída com sucesso."""
         label = _TYPE_LABELS.get(analysis_type, analysis_type)
         context = (
-            f" for topic '{topic_name}'" if topic_name else f" for audience '{audience_name}'"
+            f" for topic '{topic_name}'"
+            if topic_name
+            else f" for audience '{audience_name}'"
         )
 
         metadata = {
@@ -117,7 +123,9 @@ class NotificationEventService:
         """Notificação de análise que falhou."""
         label = _TYPE_LABELS.get(analysis_type, analysis_type)
         context = (
-            f" for topic '{topic_name}'" if topic_name else f" for audience '{audience_name}'"
+            f" for topic '{topic_name}'"
+            if topic_name
+            else f" for audience '{audience_name}'"
         )
 
         metadata = {

--- a/app/routes/audiences.py
+++ b/app/routes/audiences.py
@@ -83,7 +83,10 @@ def create_audience(
         user_id=current_user.id,
         subreddit_names=request.subreddit_names,
     )
-    audience = use_case.execute(input_data)
+    try:
+        audience = use_case.execute(input_data)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     return vars(audience)
 
 
@@ -131,7 +134,10 @@ def update_audience(
         description=request.description,
         subreddit_names=request.subreddit_names,
     )
-    updated = use_case.execute(audience_id, input_data)
+    try:
+        updated = use_case.execute(audience_id, input_data)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     return vars(updated)
 
 
@@ -174,7 +180,10 @@ def add_community_to_audience(
     _check_ownership(audience, current_user)
 
     use_case = AddCommunityToAudienceUseCase(db)
-    added = use_case.execute(audience_id, request.subreddit_name)
+    try:
+        added = use_case.execute(audience_id, request.subreddit_name)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     if not added:
         raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
     return {"added": True, "subreddit_name": request.subreddit_name}


### PR DESCRIPTION
## Summary

Implementa as 3 melhorias do sync de comunidades em audiências (Issue #47):

- **Validação de nomes:** Formato via regex (síncrono, 422) + existência no Reddit (assíncrono, background thread com notificação)
- **Limite de comunidades:** Máximo de 50 por audiência (configurável via `MAX_COMMUNITIES_PER_AUDIENCE`)
- **Evento de sync:** Notificação `communities_changed` via SSE + invalidação de cache Redis

### Detalhes

- Validação de formato aplicada consistentemente nos 3 endpoints (PUT update, POST create, POST add community)
- Análises de tópicos/keywords só são disparadas quando a lista realmente muda (otimização)
- Subreddits inexistentes são removidos automaticamente em background com notificação ao usuário

## Arquivos novos

- `app/modules/audiences/domain/validators/subreddit_name_validator.py`
- `app/modules/audiences/domain/constants.py`
- `app/modules/audiences/application/use_cases/validate_communities_use_case.py`

## Arquivos modificados

- `app/modules/audiences/infra/repositories/audience_repository.py`
- `app/modules/audiences/application/use_cases/manage_audience_use_case.py`
- `app/routes/audiences.py`
- `app/modules/notifications/application/services/notification_event_service.py`

## Test plan

- [ ] PUT com nome inválido (`"123"`, `"a"`) → esperar 422
- [ ] PUT com 51 comunidades → esperar 422
- [ ] PUT com comunidade inexistente (`"xyznonexistent999"`) → PUT 200, depois notificação de remoção
- [ ] PUT com comunidades válidas que mudam → notificação `communities_changed`
- [ ] PUT com mesma lista (sem mudança) → sem notificação, sem analyses disparadas
- [ ] POST create com nome inválido → 422
- [ ] POST add community com limite atingido → 422

Closes #91