### PR TITLE
fix: correct broken entity imports in alembic env.py

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -37,16 +37,14 @@ from app.modules.similar_communities.domain.entities import community_embedding 
 from app.modules.similar_communities.domain.entities import user_feedback  # noqa: E402, F401
 from app.modules.audience_templates.domain.entities import audience_template  # noqa: E402, F401
 from app.modules.audience_topics.domain.entities import audience_topic  # noqa: E402, F401
-from app.modules.audience_topics.domain.entities import audience_topic_analysis  # noqa: E402, F401
 from app.modules.topic_deep_dive.domain.entities import topic_deep_dive  # noqa: E402, F401
-from app.modules.notifications.domain.entities import analysis_notification  # noqa: E402, F401
-from app.modules.topic_sentiment.domain.entities import topic_sentiment_analysis  # noqa: E402, F401
-from app.modules.topic_patterns.domain.entities import topic_pattern_analysis  # noqa: E402, F401
+from app.modules.notifications.domain.entities import notification  # noqa: E402, F401
+from app.modules.topic_sentiment.domain.entities import topic_sentiment  # noqa: E402, F401
+from app.modules.topic_patterns.domain.entities import topic_pattern  # noqa: E402, F401
 from app.modules.topic_chat.domain.entities import topic_conversation  # noqa: E402, F401
 from app.modules.topic_chat.domain.entities import topic_conversation_message  # noqa: E402, F401
 from app.modules.intent_ask.domain.entities import intent_ask_log  # noqa: E402, F401
 from app.modules.content_suggestions.domain.entities import content_draft  # noqa: E402, F401
-from app.modules.weekly_theme.domain.entities import weekly_theme_analysis  # noqa: E402, F401
 
 target_metadata = [Base.metadata]
 

--- a/app/modules/topics/application/use_cases/get_community_details_use_case/agent/node.py
+++ b/app/modules/topics/application/use_cases/get_community_details_use_case/agent/node.py
@@ -3,7 +3,6 @@ import os
 
 from langchain_openai import ChatOpenAI
 
-from app.modules.shared.application.services.llm_factory import extract_response_text
 
 from app.modules.topics.application.use_cases.get_community_details_use_case.agent.state import (
     CommunityAnalyzerState,


### PR DESCRIPTION
## Summary
- Fixed broken imports in `alembic/env.py` that prevented migrations from running
- Removed `audience_topic_analysis` import (class already lives in `audience_topic` module)
- Fixed `analysis_notification` → `notification`
- Fixed `topic_sentiment_analysis` → `topic_sentiment`
- Fixed `topic_pattern_analysis` → `topic_pattern`
- Removed `weekly_theme_analysis` import (module does not exist)
- Removed unused `extract_response_text` import from `node.py`

## Test plan
- [x] `make docker-migrate` runs successfully after changes