### PR TITLE
fix: use llm_factory in content agents and serve S3 images via presigned URLs

### DIFF
--- a/app/modules/content_suggestions/application/use_cases/generate_suggestions_use_case/agent/content_suggestion_agent.py
+++ b/app/modules/content_suggestions/application/use_cases/generate_suggestions_use_case/agent/content_suggestion_agent.py
@@ -4,13 +4,12 @@ import json
 import logging
 import os
 
-from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.shared.application.helpers.language_directive import (
     get_language_directive,
 )
-from app.modules.shared.application.services.llm_factory import extract_response_text
+from app.modules.shared.application.services.llm_factory import create_llm, extract_response_text
 from app.modules.content_suggestions.application.use_cases.generate_suggestions_use_case.agent.prompts.accuracy_prompts import (
     get_accuracy_review_prompt,
 )
@@ -30,9 +29,10 @@ from app.modules.content_suggestions.application.use_cases.generate_suggestions_
 logger = logging.getLogger(__name__)
 
 
-def _get_llm() -> ChatOpenAI:
-    return ChatOpenAI(
-        model=os.getenv("CONTENT_SUGGESTION_MODEL", os.getenv("MODEL_NAME", "gpt-5-nano-2025-08-07")),
+def _get_llm():
+    return create_llm(
+        model_env_var="CONTENT_SUGGESTION_MODEL",
+        default_model=os.getenv("MODEL_NAME", "gpt-5-nano-2025-08-07"),
         temperature=0.3,
     )
 

--- a/app/modules/content_suggestions/application/use_cases/produce_content_use_case/agent/content_production_agent.py
+++ b/app/modules/content_suggestions/application/use_cases/produce_content_use_case/agent/content_production_agent.py
@@ -4,13 +4,12 @@ import json
 import logging
 import os
 
-from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.shared.application.helpers.language_directive import (
     get_language_directive,
 )
-from app.modules.shared.application.services.llm_factory import extract_response_text
+from app.modules.shared.application.services.llm_factory import create_llm, extract_response_text
 
 from .prompts.draft_prompts import get_draft_content_prompt
 from .prompts.hooks_prompts import get_refine_hooks_prompt
@@ -19,13 +18,13 @@ from .state import ContentProductionState
 logger = logging.getLogger(__name__)
 
 
-def _get_llm() -> ChatOpenAI:
+def _get_llm():
     """Retorna instancia do LLM para producao de conteudo."""
-    model_name = os.getenv(
-        "CONTENT_PRODUCTION_MODEL",
-        os.getenv("MODEL_NAME", "gpt-5-nano-2025-08-07"),
+    return create_llm(
+        model_env_var="CONTENT_PRODUCTION_MODEL",
+        default_model=os.getenv("MODEL_NAME", "gpt-5-nano-2025-08-07"),
+        temperature=0.5,
     )
-    return ChatOpenAI(model=model_name, temperature=0.5)
 
 
 def _parse_json_response(text: str) -> list[dict]:

--- a/app/modules/content_suggestions/application/use_cases/produce_content_use_case/produce_content_use_case.py
+++ b/app/modules/content_suggestions/application/use_cases/produce_content_use_case/produce_content_use_case.py
@@ -210,7 +210,12 @@ class ProduceContentUseCase:
         platforms: list[str],
         user_id: UUID | None = None,
     ) -> str | None:
-        """Gera imagem via Imagen e faz upload para S3."""
+        """Gera imagem via Imagen e faz upload para S3.
+
+        Returns:
+            A S3 key do arquivo enviado (usada para gerar presigned URLs)
+            ou None se a geracao falhar.
+        """
         if not image_prompt:
             logger.info("No image_prompt, skipping image generation")
             return None
@@ -241,13 +246,13 @@ class ProduceContentUseCase:
             key = storage.generate_key(
                 prefix=f"content-images/{suggestion_id}"
             )
-            url = storage.upload(data=image_bytes, key=key)
+            storage.upload(data=image_bytes, key=key)
 
             # Registrar arquivo na tabela uploaded_files
             try:
                 file_record = UploadedFile(
                     key=key,
-                    url=url,
+                    url=key,
                     content_type="image/png",
                     size_bytes=len(image_bytes),
                     uploaded_by=user_id,
@@ -255,10 +260,10 @@ class ProduceContentUseCase:
                 UploadedFileRepository(self.db).save(file_record)
                 logger.info("Image registered in uploaded_files: %s", key)
             except Exception:
-                logger.exception("Failed to register image in uploaded_files, URL still valid")
+                logger.exception("Failed to register image in uploaded_files")
 
-            logger.info("Image uploaded: %s", url)
-            return url
+            logger.info("Image uploaded with key: %s", key)
+            return key
 
         except Exception:
             logger.exception("Image generation/upload failed, continuing without image")

--- a/app/routes/content_suggestions.py
+++ b/app/routes/content_suggestions.py
@@ -23,6 +23,7 @@ from app.modules.content_suggestions.infra.repositories.content_suggestion_repos
 )
 from app.modules.identity.dependencies import get_current_user
 from app.modules.identity.domain.entities.user import User
+from app.modules.shared.application.services.storage_service import StorageService
 from app.modules.shared.infra.database.database import get_db
 
 router = APIRouter(
@@ -303,6 +304,25 @@ def get_draft(
     return _serialize_draft(draft)
 
 
+def _resolve_image_url(image_value: str | None) -> str | None:
+    """Gera presigned URL a partir da key do S3.
+
+    Compativel com registros antigos que armazenam a URL publica completa:
+    detecta pelo prefixo ``https://`` e extrai a key automaticamente.
+    """
+    if not image_value:
+        return None
+    try:
+        key = image_value
+        if image_value.startswith("https://"):
+            # URL antiga: https://<bucket>.s3.<region>.amazonaws.com/<key>
+            key = image_value.split(".amazonaws.com/", 1)[-1]
+        storage = StorageService()
+        return storage.get_presigned_url(key)
+    except Exception:
+        return None
+
+
 def _serialize_suggestion(s) -> dict:
     """Serializa uma sugestao para resposta JSON."""
     return {
@@ -321,7 +341,7 @@ def _serialize_suggestion(s) -> dict:
         "keywords": s.keywords,
         "research_notes": s.research_notes,
         "image_prompt": s.image_prompt,
-        "image_url": s.image_url,
+        "image_url": _resolve_image_url(s.image_url),
         "differentiation_notes": s.differentiation_notes,
         "accuracy_notes": s.accuracy_notes,
         "source_topics": s.source_topics,
@@ -345,7 +365,7 @@ def _serialize_draft(d) -> dict:
         "cta": d.cta,
         "platform_notes": d.platform_notes,
         "hashtags": d.hashtags or [],
-        "image_url": d.image_url,
+        "image_url": _resolve_image_url(d.image_url),
         "image_aspect_ratio": d.image_aspect_ratio,
         "model_used": d.model_used,
         "created_at": d.created_at.isoformat() if d.created_at else None,


### PR DESCRIPTION
## Summary
- **Content agents using wrong LLM client**: `content_suggestion_agent` and `content_production_agent` were hardcoded to `ChatOpenAI`, causing 404 errors when `CONTENT_SUGGESTION_MODEL` / `CONTENT_PRODUCTION_MODEL` are set to Gemini models. Now both use `create_llm()` from `llm_factory` which auto-detects the provider.
- **S3 images returning AccessDenied**: Images were uploaded without public ACL but served via public URLs. Now the S3 key is stored in the database and presigned URLs (1h expiry) are generated at read time. Backward-compatible with existing records that store full URLs.

## Test plan
- [ ] Trigger content production with `CONTENT_PRODUCTION_MODEL=gemini-3.1-pro-preview` and verify no 404 error
- [ ] Trigger content suggestions with `CONTENT_SUGGESTION_MODEL=gemini-3.1-pro-preview` and verify no 404 error
- [ ] Verify existing images (old URL format) still load correctly in the frontend
- [ ] Verify newly generated images use presigned URLs and load without AccessDenied