### PR TITLE
feat: add deep analysis for advice_request intent category

### DIFF
--- a/app/modules/intent_ask/application/use_cases/ask_intent_use_case/agent/prompts/intent_ask_prompts.py
+++ b/app/modules/intent_ask/application/use_cases/ask_intent_use_case/agent/prompts/intent_ask_prompts.py
@@ -33,8 +33,30 @@ def intent_ask_prompt(
     }
     category_label = category_labels.get(intent_category, intent_category)
 
+    category_focus = {
+        "pain_and_anger": {
+            "specialization": "understanding user frustrations, complaints, and emotional pain points",
+            "focus": "pain points, frustrations, anger patterns, and emotional signals",
+            "data_types": "emotions identified, behavioral patterns, specific examples from posts",
+            "goal": "help the user understand what causes pain in this audience",
+        },
+        "solution_request": {
+            "specialization": "understanding what solutions, tools, and resources people are actively seeking",
+            "focus": "solution types being sought, tools requested, automation needs, and recurring solution patterns",
+            "data_types": "solution types identified, seeking patterns, specific examples from posts",
+            "goal": "help the user understand what solutions this audience is looking for",
+        },
+        "advice_request": {
+            "specialization": "understanding what guidance, recommendations, and expert opinions people are seeking",
+            "focus": "advice types sought, guidance patterns, recommendation requests, and decision-making needs",
+            "data_types": "advice types identified, guidance patterns, specific examples from posts",
+            "goal": "help the user understand what advice and guidance this audience is seeking",
+        },
+    }
+    focus = category_focus.get(intent_category, category_focus["pain_and_anger"])
+
     prompt = f"""You are an expert analyst specialized in online community research,
-specifically in understanding user frustrations, complaints, and emotional pain points.
+specifically in {focus['specialization']}.
 
 Audience: "{audience_name}"
 Communities: {communities_str}
@@ -51,10 +73,10 @@ USER QUESTION:
 
 INSTRUCTIONS:
 - Answer EXCLUSIVELY based on the context data provided above
-- Focus on pain points, frustrations, anger patterns, and emotional signals
-- Cite concrete data: emotions identified, behavioral patterns, specific examples from posts
+- Focus on {focus['focus']}
+- Cite concrete data: {focus['data_types']}
 - If the information is not in the context, explicitly say there is not enough data
-- Be direct and actionable — help the user understand what causes pain in this audience
+- Be direct and actionable — {focus['goal']}
 - Use a maximum of 4 paragraphs
 - Do NOT invent data or make assumptions beyond what the context shows"""
 

--- a/app/modules/intent_ask/application/use_cases/ask_intent_use_case/ask_intent_use_case.py
+++ b/app/modules/intent_ask/application/use_cases/ask_intent_use_case/ask_intent_use_case.py
@@ -199,6 +199,13 @@ class AskIntentUseCase:
             "patterns": "SOLUTION REQUEST PATTERNS",
             "top_subreddits": "TOP SUBREDDITS FOR SOLUTION REQUESTS",
         },
+        "advice_request": {
+            "overview": "ADVICE REQUESTS OVERVIEW",
+            "subcategories": "ADVICE TYPE BREAKDOWN",
+            "topic_keywords": "ADVICE TOPIC KEYWORDS",
+            "patterns": "ADVICE REQUEST PATTERNS",
+            "top_subreddits": "TOP SUBREDDITS FOR ADVICE REQUESTS",
+        },
     }
 
     def _build_intent_context(

--- a/app/modules/intent_chat/application/use_cases/send_intent_message_use_case/agent/prompts/intent_chat_prompts.py
+++ b/app/modules/intent_chat/application/use_cases/send_intent_message_use_case/agent/prompts/intent_chat_prompts.py
@@ -45,6 +45,12 @@ def intent_chat_system_prompt(
             "data_types": "solution types identified, seeking patterns, specific examples from posts",
             "goal": "help the user understand what solutions this audience is looking for",
         },
+        "advice_request": {
+            "specialization": "understanding what guidance, recommendations, and expert opinions people are seeking",
+            "focus": "advice types sought, guidance patterns, recommendation requests, and decision-making needs",
+            "data_types": "advice types identified, guidance patterns, specific examples from posts",
+            "goal": "help the user understand what advice and guidance this audience is seeking",
+        },
     }
     focus = category_focus.get(intent_category, category_focus["pain_and_anger"])
 

--- a/app/modules/intent_chat/application/use_cases/send_intent_message_use_case/send_intent_message_use_case.py
+++ b/app/modules/intent_chat/application/use_cases/send_intent_message_use_case/send_intent_message_use_case.py
@@ -190,6 +190,13 @@ class SendIntentMessageUseCase:
             "patterns": "SOLUTION REQUEST PATTERNS",
             "top_subreddits": "TOP SUBREDDITS FOR SOLUTION REQUESTS",
         },
+        "advice_request": {
+            "overview": "ADVICE REQUESTS OVERVIEW",
+            "subcategories": "ADVICE TYPE BREAKDOWN",
+            "topic_keywords": "ADVICE TOPIC KEYWORDS",
+            "patterns": "ADVICE REQUEST PATTERNS",
+            "top_subreddits": "TOP SUBREDDITS FOR ADVICE REQUESTS",
+        },
     }
 
     def _build_intent_context(

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -12,7 +12,9 @@ from app.modules.shared.application.services.llm_factory import extract_response
 from langgraph.graph import END, START, StateGraph
 
 from app.modules.intent_classification.application.use_cases.classify_intents_use_case.agent.prompts.intent_prompts import (
+    get_advice_patterns_prompt,
     get_aggregate_intents_prompt,
+    get_analyze_advice_requests_prompt,
     get_analyze_pain_anger_prompt,
     get_analyze_solution_requests_prompt,
     get_classify_intents_prompt,
@@ -618,6 +620,172 @@ def analyze_solution_requests(state: IntentClassificationState) -> dict:
     return {"intent_aggregations": updated}
 
 
+def analyze_advice_requests(state: IntentClassificationState) -> dict:
+    """
+    Nó 5: Analisa posts advice_request para extrair tipos de conselho e tópicos.
+
+    Envia TODOS os posts classificados como advice_request ao LLM em uma única chamada
+    para obter distribuições agregadas de tipos de conselho e topic keywords.
+    Também computa top_subreddits (de quais comunidades vêm os posts advice_request).
+    Opcionalmente, agrupa posts em padrões de busca de conselho (segunda chamada LLM).
+    """
+    aggregations = state.get("intent_aggregations", [])
+    classified = state.get("classified_posts", [])
+
+    # Filtrar posts advice_request
+    advice_posts = [p for p in classified if p["primary_intent"] == "advice_request"]
+    if not advice_posts:
+        return {"intent_aggregations": aggregations}
+
+    # Computar top_subreddits a partir dos posts advice_request
+    subreddit_counter = Counter(p["post_subreddit"] for p in advice_posts)
+    top_subreddits = [
+        {"name": name, "count": count}
+        for name, count in subreddit_counter.most_common(10)
+    ]
+
+    # Construir texto de posts para o prompt
+    posts_text = _build_posts_batch_text(
+        [
+            {
+                "id": p["post_id"],
+                "subreddit": p["post_subreddit"],
+                "title": p["post_title"],
+                "score": 0,
+                "num_comments": 0,
+            }
+            for p in advice_posts
+        ]
+    )
+
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    prompt = get_analyze_advice_requests_prompt(
+        audience_name=state["audience_name"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        posts_text=posts_text,
+        total_posts=len(advice_posts),
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+    result = _parse_json_object_response(extract_response_text(response))
+
+    subcategories = result.get("subcategories")
+    topic_keywords = result.get("topic_keywords")
+
+    # Validar e limitar a 10 itens
+    if isinstance(subcategories, dict):
+        subcategories = dict(
+            sorted(subcategories.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        subcategories = None
+
+    if isinstance(topic_keywords, dict):
+        topic_keywords = dict(
+            sorted(topic_keywords.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        topic_keywords = None
+
+    # --- Advice Patterns (segunda chamada LLM) ---
+    advice_patterns = []
+    if len(advice_posts) >= 3:
+        # Lookup de posts completos (com selftext, score, num_comments, permalink)
+        full_posts_map = {p["id"]: p for p in state.get("posts", [])}
+
+        # Montar texto rico para o prompt (inclui selftext)
+        rich_posts = [
+            full_posts_map[p["post_id"]]
+            for p in advice_posts
+            if p["post_id"] in full_posts_map
+        ]
+        patterns_text = _build_posts_batch_text(rich_posts)
+
+        patterns_prompt = get_advice_patterns_prompt(
+            audience_name=state["audience_name"],
+            period_start=state["period_start"],
+            period_end=state["period_end"],
+            posts_text=patterns_text,
+            total_posts=len(advice_posts),
+            language_directive=language_directive,
+        )
+
+        try:
+            patterns_response = llm.invoke(patterns_prompt)
+            raw_patterns = _parse_json_response(
+                extract_response_text(patterns_response)
+            )
+
+            # Enriquecer cada padrão com métricas e submissions
+            for pattern in raw_patterns:
+                submissions = []
+                total_upvotes = 0
+                total_comments = 0
+                for pid in pattern.get("post_ids", []):
+                    fp = full_posts_map.get(pid)
+                    if not fp:
+                        continue
+                    submissions.append(
+                        {
+                            "title": fp["title"],
+                            "body": (fp.get("selftext") or "")[:500],
+                            "subreddit": f"r/{fp['subreddit']}",
+                            "score": fp.get("score", 0),
+                            "num_comments": fp.get("num_comments", 0),
+                            "permalink": fp.get("permalink", ""),
+                        }
+                    )
+                    total_upvotes += fp.get("score", 0)
+                    total_comments += fp.get("num_comments", 0)
+
+                if submissions:
+                    advice_patterns.append(
+                        {
+                            "name": pattern.get("name", ""),
+                            "emoji": pattern.get("emoji", ""),
+                            "post_count": len(submissions),
+                            "total_upvotes": total_upvotes,
+                            "total_comments": total_comments,
+                            "submissions": submissions,
+                        }
+                    )
+
+            advice_patterns.sort(key=lambda x: x["post_count"], reverse=True)
+            logger.info(
+                "Advice patterns: %d patterns identified from %d posts",
+                len(advice_patterns),
+                len(advice_posts),
+            )
+        except Exception:
+            logger.exception("Failed to extract advice patterns, continuing without them")
+            advice_patterns = []
+
+    # Atualizar a agregação de advice_request
+    updated = []
+    for agg in aggregations:
+        if agg["category"] == "advice_request":
+            agg = {
+                **agg,
+                "subcategories": subcategories,
+                "topic_keywords": topic_keywords,
+                "top_subreddits": top_subreddits,
+                "pain_patterns": advice_patterns,
+            }
+        updated.append(agg)
+
+    logger.info(
+        "Advice Requests analysis: %d subcategories, %d topic keywords, %d subreddits",
+        len(subcategories) if subcategories else 0,
+        len(topic_keywords) if topic_keywords else 0,
+        len(top_subreddits),
+    )
+    return {"intent_aggregations": updated}
+
+
 def create_intent_classification_agent():
     """Cria e compila o grafo LangGraph de classificação de intenção."""
     workflow = StateGraph(IntentClassificationState)
@@ -625,9 +793,11 @@ def create_intent_classification_agent():
     workflow.add_node("aggregate_intents", aggregate_intents)
     workflow.add_node("analyze_pain_anger", analyze_pain_anger)
     workflow.add_node("analyze_solution_requests", analyze_solution_requests)
+    workflow.add_node("analyze_advice_requests", analyze_advice_requests)
     workflow.add_edge(START, "classify_intents")
     workflow.add_edge("classify_intents", "aggregate_intents")
     workflow.add_edge("aggregate_intents", "analyze_pain_anger")
     workflow.add_edge("analyze_pain_anger", "analyze_solution_requests")
-    workflow.add_edge("analyze_solution_requests", END)
+    workflow.add_edge("analyze_solution_requests", "analyze_advice_requests")
+    workflow.add_edge("analyze_advice_requests", END)
     return workflow.compile()

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -279,3 +279,100 @@ RULES:
 - post_ids must match exactly the POST_ID values from the input
 - Return ONLY the JSON array, no additional text
 {language_directive}"""
+
+
+def get_analyze_advice_requests_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+) -> str:
+    """Prompt para análise holística de tipos de conselho e tópicos em posts advice_request."""
+    return f"""You are an expert community analyst specializing in understanding what guidance, recommendations, and expert opinions people seek in online communities.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total advice_request posts: {total_posts}
+
+Below are ALL posts classified as "advice_request" from this audience's communities.
+Your task is to analyze them holistically and identify:
+
+1. **Advice type subcategories**: What kinds of advice are people looking for? (e.g., career, strategy, beginner, comparison, best_practices, recommendation, troubleshooting, scaling, optimization, workflow, budgeting, hiring, etc.)
+2. **Topic keywords**: What specific subjects are people seeking advice about? Use single words. (e.g., marketing, pricing, hiring, SEO, content, branding, analytics, freelancing, etc.)
+
+POSTS:
+{posts_text}
+
+---
+
+Respond in JSON format:
+{{
+  "subcategories": {{
+    "advice_type": count,
+    "advice_type": count
+  }},
+  "topic_keywords": {{
+    "keyword": count,
+    "keyword": count
+  }}
+}}
+
+RULES:
+- subcategories: Return up to 10 advice types, sorted by count descending
+- topic_keywords: Return up to 10 single-word topics, sorted by count descending
+- Each count represents how many posts seek that type of advice or relate to that topic
+- A single post can contribute to multiple advice types or topics
+- Use lowercase for all keys
+- Advice types should be specific (use "career" not "life", use "comparison" not "questions")
+- Topics should be single words that capture the core subject (use "pricing" not "pricing strategy")
+- The sum of subcategory counts may exceed total_posts (one post can seek multiple advice types)
+- Return ONLY the JSON object, no additional text
+{language_directive}"""
+
+
+def get_advice_patterns_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+) -> str:
+    """Prompt para agrupar posts advice_request em padrões de busca de conselho."""
+    return f"""You are an expert community analyst. Your task is to group advice request posts into advice-seeking patterns — recurring themes that reveal what guidance and recommendations the audience is actively looking for.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total advice_request posts: {total_posts}
+
+Below are posts classified as "advice_request" from this audience's communities, including their body text for richer context.
+
+POSTS:
+{posts_text}
+
+---
+
+Group these posts into 3 to 8 advice-seeking patterns. Each pattern should represent a distinct, recurring type of guidance or recommendation being sought.
+
+Respond in JSON format:
+[
+  {{
+    "name": "Short descriptive name of the advice pattern (5-10 words)",
+    "emoji": "single emoji representing the type of advice sought",
+    "post_ids": ["id1", "id2", "id3"]
+  }}
+]
+
+RULES:
+- Create 3 to 8 patterns maximum
+- Each pattern must have at least 2 posts (if total posts < 6, patterns with 1 post are acceptable)
+- Each post_id must appear in EXACTLY ONE pattern — no duplicates across patterns
+- Every post_id from the input should be assigned to a pattern
+- Pattern names should be descriptive advice-seeking phrases (5-10 words)
+- Use a single emoji that best represents the advice type (e.g., 🎯 strategy, 📈 growth, 💼 career, 🤔 comparison, 📚 learning, 💡 best practices)
+- Order patterns by number of posts (most posts first)
+- post_ids must match exactly the POST_ID values from the input
+- Return ONLY the JSON array, no additional text
+{language_directive}"""

--- a/app/routes/intent_ask.py
+++ b/app/routes/intent_ask.py
@@ -23,7 +23,7 @@ router = APIRouter(
 
 AUDIENCE_NOT_FOUND = "Audiência não encontrada"
 VALID_WINDOWS = ("week", "month")
-SUPPORTED_ASK_CATEGORIES = ("pain_and_anger", "solution_request")
+SUPPORTED_ASK_CATEGORIES = ("pain_and_anger", "solution_request", "advice_request")
 
 
 class IntentAskRequest(BaseModel):

--- a/app/routes/intent_chat.py
+++ b/app/routes/intent_chat.py
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/audiences", tags=["Intent Chat"])
 AUDIENCE_NOT_FOUND = "Audiência não encontrada"
 CONVERSATION_NOT_FOUND = "Conversa não encontrada"
 VALID_WINDOWS = ("week", "month")
-SUPPORTED_CHAT_CATEGORIES = ("pain_and_anger", "solution_request")
+SUPPORTED_CHAT_CATEGORIES = ("pain_and_anger", "solution_request", "advice_request")
 
 
 class SendMessageRequest(BaseModel):


### PR DESCRIPTION
## Summary

- Adiciona analise profunda para a categoria `advice_request` (pedido de conselho) com subcategorias, topic keywords, top subreddits e padroes
- Novo no `analyze_advice_requests` no grafo LangGraph (No 5)
- Habilita Ask e Chat para `advice_request` com prompts semanticamente distintos
- Generaliza prompt do Ask (antes hardcoded para pain) com `category_focus` dict

## Arquivos modificados

| Arquivo | Mudanca |
|---------|---------|
| `agent/prompts/intent_prompts.py` | 2 novas funcoes de prompt |
| `agent/intent_agent.py` | `analyze_advice_requests()` + grafo 5 nos |
| `app/routes/intent_ask.py` | `advice_request` em `SUPPORTED_ASK_CATEGORIES` |
| `app/routes/intent_chat.py` | `advice_request` em `SUPPORTED_CHAT_CATEGORIES` |
| `ask_intent_use_case.py` | `_CATEGORY_LABELS["advice_request"]` |
| `send_intent_message_use_case.py` | `_CATEGORY_LABELS["advice_request"]` |
| `intent_ask_prompts.py` | Generalizado com `category_focus` dict |
| `intent_chat_prompts.py` | `category_focus["advice_request"]` |

Nenhuma migration. Nenhuma nova tabela. Nenhum novo endpoint.

## Test plan

- [ ] Disparar refresh de intencoes e verificar que `advice_request` retorna subcategories, topic_keywords, top_subreddits e pain_patterns
- [ ] Testar Ask: `POST /audiences/{id}/themes/intents/advice_request/ask`
- [ ] Testar Chat: `POST /audiences/{id}/themes/intents/advice_request/chat`
- [ ] Verificar backward compatibility: pain_and_anger e solution_request continuam funcionando

Closes #108