### PR TITLE
feat: enrich intent patterns with Reddit thread comments

### DIFF
--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -32,6 +32,13 @@ logger = logging.getLogger(__name__)
 MAX_POSTS_CHARS = 80_000
 BATCH_SIZE = 50
 
+# Thread analysis configuration
+TOP_POSTS_FOR_COMMENTS = 15
+COMMENTS_PER_POST = 30
+TOP_COMMENTS_IN_PROMPT = 5
+MAX_COMMENT_LENGTH = 500
+THREAD_ANALYSIS_ENABLED = True
+
 VALID_INTENTS = {
     "advice_request",
     "pain_and_anger",
@@ -72,6 +79,95 @@ def _build_posts_batch_text(posts: list[dict], max_chars: int = MAX_POSTS_CHARS)
         )
         if selftext.strip():
             entry += f"Body: {selftext}\n"
+        entry += "---\n"
+
+        if total_chars + len(entry) > max_chars:
+            break
+        lines.append(entry)
+        total_chars += len(entry)
+
+    return "".join(lines)
+
+
+def _fetch_comments_for_posts(
+    posts: list[dict],
+    reddit_provider,
+    top_n: int = TOP_POSTS_FOR_COMMENTS,
+    comments_per_post: int = COMMENTS_PER_POST,
+    top_comments_in_prompt: int = TOP_COMMENTS_IN_PROMPT,
+) -> dict[str, list[dict]]:
+    """
+    Busca comentários dos top N posts por num_comments.
+
+    Returns:
+        Dict mapping post_id -> list of top comments sorted by score.
+    """
+    sorted_posts = sorted(
+        posts,
+        key=lambda p: p.get("num_comments", 0),
+        reverse=True,
+    )[:top_n]
+
+    comments_map: dict[str, list[dict]] = {}
+    for post in sorted_posts:
+        subreddit = post.get("subreddit", "")
+        post_id = post.get("id", "")
+        if not subreddit or not post_id:
+            continue
+
+        try:
+            raw_comments = reddit_provider.get_post_comments(
+                subreddit, post_id, limit=comments_per_post
+            )
+            sorted_comments = sorted(
+                raw_comments, key=lambda c: c.score, reverse=True
+            )[:top_comments_in_prompt]
+            comments_map[post_id] = [
+                {
+                    "body": c.body,
+                    "score": c.score,
+                    "author": c.author or "anonymous",
+                }
+                for c in sorted_comments
+            ]
+        except Exception:
+            logger.warning("Failed to fetch comments for post %s", post_id)
+            comments_map[post_id] = []
+
+    return comments_map
+
+
+def _build_posts_with_comments_text(
+    posts: list[dict],
+    comments_map: dict[str, list[dict]],
+    max_chars: int = MAX_POSTS_CHARS,
+) -> str:
+    """Formata batch de posts COM comentários para o prompt de patterns."""
+    lines: list[str] = []
+    total_chars = 0
+
+    for post in posts:
+        selftext = (post.get("selftext") or "")[:500]
+        entry = (
+            f"[POST_ID: {post['id']}] "
+            f"r/{post['subreddit']} | score: {post.get('score', 0)} | "
+            f"comments: {post.get('num_comments', 0)}\n"
+            f"Title: {post['title']}\n"
+        )
+        if selftext.strip():
+            entry += f"Body: {selftext}\n"
+
+        post_comments = comments_map.get(post["id"], [])
+        if post_comments:
+            entry += "--- Top Comments ---\n"
+            for comment in post_comments:
+                body = comment["body"].strip()
+                if len(body) > MAX_COMMENT_LENGTH:
+                    body = body[:MAX_COMMENT_LENGTH] + "..."
+                entry += (
+                    f"  [{comment['author']}, score:{comment['score']}] {body}\n"
+                )
+
         entry += "---\n"
 
         if total_chars + len(entry) > max_chars:
@@ -294,6 +390,7 @@ def analyze_pain_anger(state: IntentClassificationState) -> dict:
     para obter distribuições agregadas de sentimentos e topic keywords.
     Também computa top_subreddits (de quais comunidades vêm os posts pain_and_anger).
     Opcionalmente, agrupa posts em padrões de dor comportamentais (segunda chamada LLM).
+    Enriquece com comentários dos top posts quando reddit_provider disponível.
     """
     aggregations = state.get("intent_aggregations", [])
     classified = state.get("classified_posts", [])
@@ -369,7 +466,25 @@ def analyze_pain_anger(state: IntentClassificationState) -> dict:
             for p in pain_posts
             if p["post_id"] in full_posts_map
         ]
-        patterns_text = _build_posts_batch_text(rich_posts)
+
+        # Buscar comentários se reddit_provider disponível
+        reddit_provider = state.get("reddit_provider")
+        comments_map: dict[str, list[dict]] = {}
+        has_comments = False
+        if reddit_provider and THREAD_ANALYSIS_ENABLED:
+            logger.info(
+                "Fetching comments for top %d pain_and_anger posts",
+                TOP_POSTS_FOR_COMMENTS,
+            )
+            comments_map = _fetch_comments_for_posts(rich_posts, reddit_provider)
+            has_comments = bool(comments_map)
+            logger.info("Fetched comments for %d pain_and_anger posts", len(comments_map))
+
+        # Usar texto com ou sem comentários
+        if has_comments:
+            patterns_text = _build_posts_with_comments_text(rich_posts, comments_map)
+        else:
+            patterns_text = _build_posts_batch_text(rich_posts)
 
         patterns_prompt = get_pain_patterns_prompt(
             audience_name=state["audience_name"],
@@ -378,6 +493,7 @@ def analyze_pain_anger(state: IntentClassificationState) -> dict:
             posts_text=patterns_text,
             total_posts=len(pain_posts),
             language_directive=language_directive,
+            has_comments=has_comments,
         )
 
         try:
@@ -395,36 +511,44 @@ def analyze_pain_anger(state: IntentClassificationState) -> dict:
                     fp = full_posts_map.get(pid)
                     if not fp:
                         continue
-                    submissions.append(
-                        {
-                            "title": fp["title"],
-                            "body": (fp.get("selftext") or "")[:500],
-                            "subreddit": f"r/{fp['subreddit']}",
-                            "score": fp.get("score", 0),
-                            "num_comments": fp.get("num_comments", 0),
-                            "permalink": fp.get("permalink", ""),
-                        }
-                    )
+                    submission = {
+                        "title": fp["title"],
+                        "body": (fp.get("selftext") or "")[:500],
+                        "subreddit": f"r/{fp['subreddit']}",
+                        "score": fp.get("score", 0),
+                        "num_comments": fp.get("num_comments", 0),
+                        "permalink": fp.get("permalink", ""),
+                    }
+                    if has_comments and pid in comments_map:
+                        submission["top_comments"] = comments_map[pid]
+                    submissions.append(submission)
                     total_upvotes += fp.get("score", 0)
                     total_comments += fp.get("num_comments", 0)
 
                 if submissions:
-                    pain_patterns.append(
-                        {
-                            "name": pattern.get("name", ""),
-                            "emoji": pattern.get("emoji", ""),
-                            "post_count": len(submissions),
-                            "total_upvotes": total_upvotes,
-                            "total_comments": total_comments,
-                            "submissions": submissions,
-                        }
-                    )
+                    pattern_entry = {
+                        "name": pattern.get("name", ""),
+                        "emoji": pattern.get("emoji", ""),
+                        "post_count": len(submissions),
+                        "total_upvotes": total_upvotes,
+                        "total_comments": total_comments,
+                        "submissions": submissions,
+                    }
+                    if has_comments:
+                        pattern_entry["validation_score"] = pattern.get(
+                            "validation_score", "low"
+                        )
+                        pattern_entry["suggested_coping"] = pattern.get(
+                            "suggested_coping", []
+                        )
+                    pain_patterns.append(pattern_entry)
 
             pain_patterns.sort(key=lambda x: x["post_count"], reverse=True)
             logger.info(
-                "Pain patterns: %d patterns identified from %d posts",
+                "Pain patterns: %d patterns identified from %d posts (comments: %s)",
                 len(pain_patterns),
                 len(pain_posts),
+                "yes" if has_comments else "no",
             )
         except Exception:
             logger.exception("Failed to extract pain patterns, continuing without them")
@@ -460,6 +584,7 @@ def analyze_solution_requests(state: IntentClassificationState) -> dict:
     para obter distribuições agregadas de tipos de solução e topic keywords.
     Também computa top_subreddits (de quais comunidades vêm os posts solution_request).
     Opcionalmente, agrupa posts em padrões de busca de solução (segunda chamada LLM).
+    Enriquece com comentários dos top posts quando reddit_provider disponível.
     """
     aggregations = state.get("intent_aggregations", [])
     classified = state.get("classified_posts", [])
@@ -535,7 +660,25 @@ def analyze_solution_requests(state: IntentClassificationState) -> dict:
             for p in solution_posts
             if p["post_id"] in full_posts_map
         ]
-        patterns_text = _build_posts_batch_text(rich_posts)
+
+        # Buscar comentários se reddit_provider disponível
+        reddit_provider = state.get("reddit_provider")
+        comments_map: dict[str, list[dict]] = {}
+        has_comments = False
+        if reddit_provider and THREAD_ANALYSIS_ENABLED:
+            logger.info(
+                "Fetching comments for top %d solution_request posts",
+                TOP_POSTS_FOR_COMMENTS,
+            )
+            comments_map = _fetch_comments_for_posts(rich_posts, reddit_provider)
+            has_comments = bool(comments_map)
+            logger.info("Fetched comments for %d solution_request posts", len(comments_map))
+
+        # Usar texto com ou sem comentários
+        if has_comments:
+            patterns_text = _build_posts_with_comments_text(rich_posts, comments_map)
+        else:
+            patterns_text = _build_posts_batch_text(rich_posts)
 
         patterns_prompt = get_solution_patterns_prompt(
             audience_name=state["audience_name"],
@@ -544,6 +687,7 @@ def analyze_solution_requests(state: IntentClassificationState) -> dict:
             posts_text=patterns_text,
             total_posts=len(solution_posts),
             language_directive=language_directive,
+            has_comments=has_comments,
         )
 
         try:
@@ -561,36 +705,44 @@ def analyze_solution_requests(state: IntentClassificationState) -> dict:
                     fp = full_posts_map.get(pid)
                     if not fp:
                         continue
-                    submissions.append(
-                        {
-                            "title": fp["title"],
-                            "body": (fp.get("selftext") or "")[:500],
-                            "subreddit": f"r/{fp['subreddit']}",
-                            "score": fp.get("score", 0),
-                            "num_comments": fp.get("num_comments", 0),
-                            "permalink": fp.get("permalink", ""),
-                        }
-                    )
+                    submission = {
+                        "title": fp["title"],
+                        "body": (fp.get("selftext") or "")[:500],
+                        "subreddit": f"r/{fp['subreddit']}",
+                        "score": fp.get("score", 0),
+                        "num_comments": fp.get("num_comments", 0),
+                        "permalink": fp.get("permalink", ""),
+                    }
+                    if has_comments and pid in comments_map:
+                        submission["top_comments"] = comments_map[pid]
+                    submissions.append(submission)
                     total_upvotes += fp.get("score", 0)
                     total_comments += fp.get("num_comments", 0)
 
                 if submissions:
-                    solution_patterns.append(
-                        {
-                            "name": pattern.get("name", ""),
-                            "emoji": pattern.get("emoji", ""),
-                            "post_count": len(submissions),
-                            "total_upvotes": total_upvotes,
-                            "total_comments": total_comments,
-                            "submissions": submissions,
-                        }
-                    )
+                    pattern_entry = {
+                        "name": pattern.get("name", ""),
+                        "emoji": pattern.get("emoji", ""),
+                        "post_count": len(submissions),
+                        "total_upvotes": total_upvotes,
+                        "total_comments": total_comments,
+                        "submissions": submissions,
+                    }
+                    if has_comments:
+                        pattern_entry["recommended_solutions"] = pattern.get(
+                            "recommended_solutions", []
+                        )
+                        pattern_entry["community_consensus"] = pattern.get(
+                            "community_consensus", "weak"
+                        )
+                    solution_patterns.append(pattern_entry)
 
             solution_patterns.sort(key=lambda x: x["post_count"], reverse=True)
             logger.info(
-                "Solution patterns: %d patterns identified from %d posts",
+                "Solution patterns: %d patterns identified from %d posts (comments: %s)",
                 len(solution_patterns),
                 len(solution_posts),
+                "yes" if has_comments else "no",
             )
         except Exception:
             logger.exception("Failed to extract solution patterns, continuing without them")

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -145,15 +145,33 @@ def get_pain_patterns_prompt(
     posts_text: str,
     total_posts: int,
     language_directive: str = "",
+    has_comments: bool = False,
 ) -> str:
     """Prompt para agrupar posts pain_and_anger em padrões de dor comportamentais."""
+    comments_context = ""
+    comments_json_fields = ""
+    comments_rules = ""
+
+    if has_comments:
+        comments_context = """
+Note: Some posts include their top community comments (sorted by score). Use these comments to better understand the true severity and breadth of each pain pattern."""
+
+        comments_json_fields = """,
+    "validation_score": "high|medium|low — based on how many commenters validate/echo the same pain",
+    "suggested_coping": ["solution or coping strategy mentioned in comments"]"""
+
+        comments_rules = """
+- validation_score: Analyze comments to determine if other users validate the same pain. "high" = multiple commenters agree/echo ("same here", "I deal with this too"), "medium" = some agreement, "low" = little or no agreement in comments
+- suggested_coping: Extract any solutions, workarounds, or coping strategies mentioned by commenters. Return empty array if none found
+- Use comments to better judge which patterns represent widespread community pain vs isolated complaints"""
+
     return f"""You are an expert psychologist and community analyst. Your task is to group pain & anger posts into behavioral pain patterns — recurring themes that reveal what the audience is truly struggling with.
 
 Audience: "{audience_name}"
 Period: {period_start} to {period_end}
 Total pain_and_anger posts: {total_posts}
 
-Below are posts classified as "pain_and_anger" from this audience's communities, including their body text for richer context.
+Below are posts classified as "pain_and_anger" from this audience's communities, including their body text for richer context.{comments_context}
 
 POSTS:
 {posts_text}
@@ -167,7 +185,7 @@ Respond in JSON format:
   {{
     "name": "Short descriptive name of the pain pattern (5-10 words)",
     "emoji": "single emoji representing the emotional tone",
-    "post_ids": ["id1", "id2", "id3"]
+    "post_ids": ["id1", "id2", "id3"]{comments_json_fields}
   }}
 ]
 
@@ -180,7 +198,7 @@ RULES:
 - Use a single emoji that best represents the emotional tone of the pattern
 - Order patterns by number of posts (most posts first)
 - post_ids must match exactly the POST_ID values from the input
-- Return ONLY the JSON array, no additional text
+- Return ONLY the JSON array, no additional text{comments_rules}
 {language_directive}"""
 
 
@@ -242,15 +260,34 @@ def get_solution_patterns_prompt(
     posts_text: str,
     total_posts: int,
     language_directive: str = "",
+    has_comments: bool = False,
 ) -> str:
     """Prompt para agrupar posts solution_request em padrões de busca de solução."""
+    comments_context = ""
+    comments_json_fields = ""
+    comments_rules = ""
+
+    if has_comments:
+        comments_context = """
+Note: Some posts include their top community comments (sorted by score). Use these comments to identify which tools, services, and products the community actually recommends — not just what the OP is asking for."""
+
+        comments_json_fields = """,
+    "recommended_solutions": ["specific tool, service, or product recommended in comments"],
+    "community_consensus": "strong|moderate|weak|divided — level of agreement on best solution"
+"""
+
+        comments_rules = """
+- recommended_solutions: Extract specific tools, libraries, services, or products recommended by commenters. Return empty array if none found
+- community_consensus: Based on comment agreement — "strong" = most commenters agree on a solution, "moderate" = some agreement, "weak" = few recommendations, "divided" = conflicting opinions
+- Use comments to distinguish between what people ask for and what the community actually recommends"""
+
     return f"""You are an expert product strategist and community analyst. Your task is to group solution request posts into solution-seeking patterns — recurring themes that reveal what the audience is actively trying to solve or build.
 
 Audience: "{audience_name}"
 Period: {period_start} to {period_end}
 Total solution_request posts: {total_posts}
 
-Below are posts classified as "solution_request" from this audience's communities, including their body text for richer context.
+Below are posts classified as "solution_request" from this audience's communities, including their body text for richer context.{comments_context}
 
 POSTS:
 {posts_text}
@@ -264,7 +301,7 @@ Respond in JSON format:
   {{
     "name": "Short descriptive name of the solution pattern (5-10 words)",
     "emoji": "single emoji representing the type of solution sought",
-    "post_ids": ["id1", "id2", "id3"]
+    "post_ids": ["id1", "id2", "id3"]{comments_json_fields}
   }}
 ]
 
@@ -277,5 +314,5 @@ RULES:
 - Use a single emoji that best represents the type of solution (e.g., 🔧 tools, 📊 analytics, 🤖 automation, 📋 templates)
 - Order patterns by number of posts (most posts first)
 - post_ids must match exactly the POST_ID values from the input
-- Return ONLY the JSON array, no additional text
+- Return ONLY the JSON array, no additional text{comments_rules}
 {language_directive}"""

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/state.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/state.py
@@ -1,6 +1,6 @@
 """Estado do agente de classificação de intenção."""
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 class PostForClassification(TypedDict):
@@ -53,6 +53,7 @@ class IntentClassificationState(TypedDict):
     period_start: str
     period_end: str
     language: str
+    reddit_provider: Any  # GenericRedditProvider para buscar comentários
 
     # Populated by nodes
     classified_posts: list[ClassifiedPost]

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/classify_intents_use_case.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/classify_intents_use_case.py
@@ -17,6 +17,9 @@ from app.modules.intent_classification.infra.repositories.intent_classification_
 from app.modules.theme_analysis.infra.repositories.theme_analysis_repository import (
     ThemeAnalysisRepository,
 )
+from app.modules.topics.infra.providers.reddit_provider.generic_reddit_provider import (
+    GenericRedditProvider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +35,7 @@ class ClassifyIntentsUseCase:
         self.audience_repo = AudienceRepository(db)
         self.theme_repo = ThemeAnalysisRepository(db)
         self.intent_repo = IntentClassificationRepository(db)
+        self.reddit_provider = GenericRedditProvider()
 
     def execute(
         self,
@@ -121,6 +125,7 @@ class ClassifyIntentsUseCase:
                     "period_start": period_start,
                     "period_end": period_end,
                     "language": language,
+                    "reddit_provider": self.reddit_provider,
                     "classified_posts": [],
                     "intent_aggregations": [],
                 }


### PR DESCRIPTION
## Summary

- Enrich `pain_and_anger` and `solution_request` pattern analysis with Reddit comment data from top posts by engagement
- Fetch top 15 posts per category (sorted by `num_comments`), retrieve 30 comments each, and include the top 5 (by score) in LLM prompts
- Pain patterns now extract `validation_score` (community agreement level) and `suggested_coping` (workarounds from comments)
- Solution patterns now extract `recommended_solutions` (tools/services mentioned) and `community_consensus` (agreement level)
- Each submission includes `top_comments` array with author, score, and body
- Feature flag `THREAD_ANALYSIS_ENABLED` for cost control; graceful fallback if disabled or on failure

## Files changed (4)

| File | Change |
|------|--------|
| `agent/state.py` | Add `reddit_provider: Any` to `IntentClassificationState` |
| `classify_intents_use_case.py` | Inject `GenericRedditProvider` and pass through agent state |
| `agent/intent_agent.py` | Add constants, `_fetch_comments_for_posts()` and `_build_posts_with_comments_text()` helpers, modify `analyze_pain_anger()` and `analyze_solution_requests()` |
| `agent/prompts/intent_prompts.py` | Add `has_comments` parameter to `get_pain_patterns_prompt()` and `get_solution_patterns_prompt()` with extended JSON schema |

## Test plan

- [ ] Trigger intent classification for an existing audience (`POST /audiences/{id}/themes/intents/refresh?window=week`)
- [ ] Verify logs show "Fetching comments for top X pain_and_anger/solution_request posts"
- [ ] Check `IntentSummary.pain_patterns` JSON includes `validation_score`, `suggested_coping` for pain patterns
- [ ] Check `IntentSummary.pain_patterns` JSON includes `recommended_solutions`, `community_consensus` for solution patterns
- [ ] Verify submissions include `top_comments` arrays
- [ ] Set `THREAD_ANALYSIS_ENABLED = False` and verify identical behavior to previous version

Closes #107