### PR TITLE
feat: deep analysis with thread comments for ideas intent

### DIFF
--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -15,9 +15,11 @@ from app.modules.intent_classification.application.use_cases.classify_intents_us
     get_advice_patterns_prompt,
     get_aggregate_intents_prompt,
     get_analyze_advice_requests_prompt,
+    get_analyze_ideas_prompt,
     get_analyze_pain_anger_prompt,
     get_analyze_solution_requests_prompt,
     get_classify_intents_prompt,
+    get_ideas_patterns_prompt,
     get_pain_patterns_prompt,
     get_solution_patterns_prompt,
 )
@@ -938,6 +940,203 @@ def analyze_advice_requests(state: IntentClassificationState) -> dict:
     return {"intent_aggregations": updated}
 
 
+def analyze_ideas(state: IntentClassificationState) -> dict:
+    """
+    Nó 6: Analisa posts ideas para extrair tipos de ideia e tópicos.
+
+    Envia TODOS os posts classificados como ideas ao LLM em uma única chamada
+    para obter distribuições agregadas de tipos de ideia e topic keywords.
+    Também computa top_subreddits (de quais comunidades vêm os posts ideas).
+    Opcionalmente, agrupa posts em padrões de inovação (segunda chamada LLM).
+    Enriquece com comentários dos top posts quando reddit_provider disponível.
+    """
+    aggregations = state.get("intent_aggregations", [])
+    classified = state.get("classified_posts", [])
+
+    # Filtrar posts ideas
+    ideas_posts = [p for p in classified if p["primary_intent"] == "ideas"]
+    if not ideas_posts:
+        return {"intent_aggregations": aggregations}
+
+    # Computar top_subreddits a partir dos posts ideas
+    subreddit_counter = Counter(p["post_subreddit"] for p in ideas_posts)
+    top_subreddits = [
+        {"name": name, "count": count}
+        for name, count in subreddit_counter.most_common(10)
+    ]
+
+    # Construir texto de posts para o prompt
+    posts_text = _build_posts_batch_text(
+        [
+            {
+                "id": p["post_id"],
+                "subreddit": p["post_subreddit"],
+                "title": p["post_title"],
+                "score": 0,
+                "num_comments": 0,
+            }
+            for p in ideas_posts
+        ]
+    )
+
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    prompt = get_analyze_ideas_prompt(
+        audience_name=state["audience_name"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        posts_text=posts_text,
+        total_posts=len(ideas_posts),
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+    result = _parse_json_object_response(extract_response_text(response))
+
+    subcategories = result.get("subcategories")
+    topic_keywords = result.get("topic_keywords")
+
+    # Validar e limitar a 10 itens
+    if isinstance(subcategories, dict):
+        subcategories = dict(
+            sorted(subcategories.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        subcategories = None
+
+    if isinstance(topic_keywords, dict):
+        topic_keywords = dict(
+            sorted(topic_keywords.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        topic_keywords = None
+
+    # --- Ideas Patterns (segunda chamada LLM) ---
+    ideas_patterns = []
+    if len(ideas_posts) >= 3:
+        # Lookup de posts completos (com selftext, score, num_comments, permalink)
+        full_posts_map = {p["id"]: p for p in state.get("posts", [])}
+
+        # Montar texto rico para o prompt (inclui selftext)
+        rich_posts = [
+            full_posts_map[p["post_id"]]
+            for p in ideas_posts
+            if p["post_id"] in full_posts_map
+        ]
+
+        # Buscar comentários se reddit_provider disponível
+        reddit_provider = state.get("reddit_provider")
+        comments_map: dict[str, list[dict]] = {}
+        has_comments = False
+        if reddit_provider and THREAD_ANALYSIS_ENABLED:
+            logger.info(
+                "Fetching comments for top %d ideas posts",
+                TOP_POSTS_FOR_COMMENTS,
+            )
+            comments_map = _fetch_comments_for_posts(rich_posts, reddit_provider)
+            has_comments = bool(comments_map)
+            logger.info("Fetched comments for %d ideas posts", len(comments_map))
+
+        # Usar texto com ou sem comentários
+        if has_comments:
+            patterns_text = _build_posts_with_comments_text(rich_posts, comments_map)
+        else:
+            patterns_text = _build_posts_batch_text(rich_posts)
+
+        patterns_prompt = get_ideas_patterns_prompt(
+            audience_name=state["audience_name"],
+            period_start=state["period_start"],
+            period_end=state["period_end"],
+            posts_text=patterns_text,
+            total_posts=len(ideas_posts),
+            language_directive=language_directive,
+            has_comments=has_comments,
+        )
+
+        try:
+            patterns_response = llm.invoke(patterns_prompt)
+            raw_patterns = _parse_json_response(
+                extract_response_text(patterns_response)
+            )
+
+            # Enriquecer cada padrão com métricas e submissions
+            for pattern in raw_patterns:
+                submissions = []
+                total_upvotes = 0
+                total_comments = 0
+                for pid in pattern.get("post_ids", []):
+                    fp = full_posts_map.get(pid)
+                    if not fp:
+                        continue
+                    submission = {
+                        "title": fp["title"],
+                        "body": (fp.get("selftext") or "")[:500],
+                        "subreddit": f"r/{fp['subreddit']}",
+                        "score": fp.get("score", 0),
+                        "num_comments": fp.get("num_comments", 0),
+                        "permalink": fp.get("permalink", ""),
+                    }
+                    if has_comments and pid in comments_map:
+                        submission["top_comments"] = comments_map[pid]
+                    submissions.append(submission)
+                    total_upvotes += fp.get("score", 0)
+                    total_comments += fp.get("num_comments", 0)
+
+                if submissions:
+                    pattern_entry = {
+                        "name": pattern.get("name", ""),
+                        "emoji": pattern.get("emoji", ""),
+                        "post_count": len(submissions),
+                        "total_upvotes": total_upvotes,
+                        "total_comments": total_comments,
+                        "submissions": submissions,
+                    }
+                    if has_comments:
+                        pattern_entry["community_reception"] = pattern.get(
+                            "community_reception", "mixed"
+                        )
+                        pattern_entry["refinements"] = pattern.get(
+                            "refinements", []
+                        )
+                        pattern_entry["feasibility_notes"] = pattern.get(
+                            "feasibility_notes", []
+                        )
+                    ideas_patterns.append(pattern_entry)
+
+            ideas_patterns.sort(key=lambda x: x["post_count"], reverse=True)
+            logger.info(
+                "Ideas patterns: %d patterns identified from %d posts (comments: %s)",
+                len(ideas_patterns),
+                len(ideas_posts),
+                "yes" if has_comments else "no",
+            )
+        except Exception:
+            logger.exception("Failed to extract ideas patterns, continuing without them")
+            ideas_patterns = []
+
+    # Atualizar a agregação de ideas
+    updated = []
+    for agg in aggregations:
+        if agg["category"] == "ideas":
+            agg = {
+                **agg,
+                "subcategories": subcategories,
+                "topic_keywords": topic_keywords,
+                "top_subreddits": top_subreddits,
+                "pain_patterns": ideas_patterns,
+            }
+        updated.append(agg)
+
+    logger.info(
+        "Ideas analysis: %d subcategories, %d topic keywords, %d subreddits",
+        len(subcategories) if subcategories else 0,
+        len(topic_keywords) if topic_keywords else 0,
+        len(top_subreddits),
+    )
+    return {"intent_aggregations": updated}
+
+
 def create_intent_classification_agent():
     """Cria e compila o grafo LangGraph de classificação de intenção."""
     workflow = StateGraph(IntentClassificationState)
@@ -946,10 +1145,12 @@ def create_intent_classification_agent():
     workflow.add_node("analyze_pain_anger", analyze_pain_anger)
     workflow.add_node("analyze_solution_requests", analyze_solution_requests)
     workflow.add_node("analyze_advice_requests", analyze_advice_requests)
+    workflow.add_node("analyze_ideas", analyze_ideas)
     workflow.add_edge(START, "classify_intents")
     workflow.add_edge("classify_intents", "aggregate_intents")
     workflow.add_edge("aggregate_intents", "analyze_pain_anger")
     workflow.add_edge("analyze_pain_anger", "analyze_solution_requests")
     workflow.add_edge("analyze_solution_requests", "analyze_advice_requests")
-    workflow.add_edge("analyze_advice_requests", END)
+    workflow.add_edge("analyze_advice_requests", "analyze_ideas")
+    workflow.add_edge("analyze_ideas", END)
     return workflow.compile()

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -413,3 +413,113 @@ RULES:
 - post_ids must match exactly the POST_ID values from the input
 - Return ONLY the JSON array, no additional text
 {language_directive}"""
+
+
+def get_analyze_ideas_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+) -> str:
+    """Prompt para análise holística de tipos de ideias e tópicos em posts ideas."""
+    return f"""You are an expert community analyst specializing in understanding innovation signals, feature requests, product ideas, and creative suggestions shared in online communities.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total ideas posts: {total_posts}
+
+Below are ALL posts classified as "ideas" from this audience's communities.
+Your task is to analyze them holistically and identify:
+
+1. **Idea type subcategories**: What kinds of ideas are people proposing? (e.g., feature_request, product_idea, improvement, workflow_optimization, integration, new_concept, business_model, ux_redesign, automation, open_source, pricing_model, community_feature, etc.)
+2. **Topic keywords**: What specific subjects are the ideas about? Use single words. (e.g., automation, dashboard, analytics, pricing, onboarding, mobile, api, collaboration, templates, scheduling, etc.)
+
+POSTS:
+{posts_text}
+
+---
+
+Respond in JSON format:
+{{
+  "subcategories": {{
+    "idea_type": count,
+    "idea_type": count
+  }},
+  "topic_keywords": {{
+    "keyword": count,
+    "keyword": count
+  }}
+}}
+
+RULES:
+- subcategories: Return up to 10 idea types, sorted by count descending
+- topic_keywords: Return up to 10 single-word topics, sorted by count descending
+- Each count represents how many posts propose that type of idea or relate to that topic
+- A single post can contribute to multiple idea types or topics
+- Use lowercase for all keys
+- Idea types should be specific (use "feature_request" not "suggestion", use "ux_redesign" not "design")
+- Topics should be single words that capture the core subject (use "automation" not "automation tools")
+- The sum of subcategory counts may exceed total_posts (one post can propose multiple idea types)
+- Return ONLY the JSON object, no additional text
+{language_directive}"""
+
+
+def get_ideas_patterns_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+    has_comments: bool = False,
+) -> str:
+    """Prompt para agrupar posts ideas em padrões de inovação/sugestão."""
+    comments_instruction = ""
+    if has_comments:
+        comments_instruction = """
+
+IMPORTANT — THREAD COMMENTS ANALYSIS:
+Some posts include top community comments (marked with 💬 COMMENTS). Use them to:
+1. Assess **community_reception**: How the community reacted to the idea — "enthusiastic" (strong support, many want it), "positive" (general agreement), "mixed" (divided opinions), "skeptical" (doubts about feasibility/value)
+2. Extract **refinements**: Concrete improvements or variations suggested by commenters that make the idea better
+3. Extract **feasibility_notes**: Any technical or practical considerations mentioned by the community about implementing the idea
+- If comments are present, include "community_reception", "refinements", and "feasibility_notes" fields in each pattern"""
+
+    return f"""You are an expert community analyst. Your task is to group idea posts into innovation patterns — recurring themes that reveal what improvements, features, and creative concepts the audience is actively proposing and discussing.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total ideas posts: {total_posts}
+
+Below are posts classified as "ideas" from this audience's communities, including their body text for richer context.
+{comments_instruction}
+
+POSTS:
+{posts_text}
+
+---
+
+Group these posts into 3 to 8 innovation/idea patterns. Each pattern should represent a distinct, recurring type of idea or suggestion being proposed.
+
+Respond in JSON format:
+[
+  {{
+    "name": "Short descriptive name of the idea pattern (5-10 words)",
+    "emoji": "single emoji representing the type of idea",
+    "post_ids": ["id1", "id2", "id3"]{', "community_reception": "enthusiastic|positive|mixed|skeptical", "refinements": ["suggestion1", "suggestion2"], "feasibility_notes": ["note1", "note2"]' if has_comments else ''}
+  }}
+]
+
+RULES:
+- Create 3 to 8 patterns maximum
+- Each pattern must have at least 2 posts (if total posts < 6, patterns with 1 post are acceptable)
+- Each post_id must appear in EXACTLY ONE pattern — no duplicates across patterns
+- Every post_id from the input should be assigned to a pattern
+- Pattern names should be descriptive innovation phrases (5-10 words)
+- Use a single emoji that best represents the idea type (e.g., 💡 new concept, 🚀 feature request, 🔧 improvement, 🔄 workflow, 🤖 automation, 📊 analytics, 🎨 design, 🔌 integration)
+- Order patterns by number of posts (most posts first)
+- post_ids must match exactly the POST_ID values from the input
+- Return ONLY the JSON array, no additional text
+{language_directive}"""


### PR DESCRIPTION
## Summary

- Add `analyze_ideas` node (No 6) to the LangGraph intent classification pipeline
- Implement deep analysis for the `ideas` category: subcategories, topic keywords, top subreddits, and innovation patterns
- Enrich with Reddit thread comments: `community_reception`, `refinements`, `feasibility_notes`
- Add 2 new prompts: `get_analyze_ideas_prompt` and `get_ideas_patterns_prompt`

## Motivation

The `ideas` category was the poorest in the intent module — only basic classification and a generic description. This PR brings it to full parity with `solution_request` (deep analysis + thread comments).

## Test plan

- [ ] Trigger intent analysis refresh: `POST /audiences/{id}/themes/intents/refresh?window=week`
- [ ] Verify `ideas` category now has `subcategories`, `topic_keywords`, `top_subreddits`, and `pain_patterns`
- [ ] Verify patterns include `community_reception`, `refinements`, `feasibility_notes` when comments available
- [ ] Verify backward compatibility with existing analyses (no breaking changes)
- [ ] Verify feature flag `THREAD_ANALYSIS_ENABLED=False` skips comment fetching

Closes #111