### PR TITLE
feat: deep analysis with thread comments for self_promotion intent

### DIFF
--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -17,10 +17,12 @@ from app.modules.intent_classification.application.use_cases.classify_intents_us
     get_analyze_advice_requests_prompt,
     get_analyze_ideas_prompt,
     get_analyze_pain_anger_prompt,
+    get_analyze_self_promotion_prompt,
     get_analyze_solution_requests_prompt,
     get_classify_intents_prompt,
     get_ideas_patterns_prompt,
     get_pain_patterns_prompt,
+    get_self_promotion_patterns_prompt,
     get_solution_patterns_prompt,
 )
 from app.modules.intent_classification.application.use_cases.classify_intents_use_case.agent.state import (
@@ -1137,6 +1139,203 @@ def analyze_ideas(state: IntentClassificationState) -> dict:
     return {"intent_aggregations": updated}
 
 
+def analyze_self_promotion(state: IntentClassificationState) -> dict:
+    """
+    Nó 7: Analisa posts self_promotion para extrair tipos de promoção e tópicos.
+
+    Envia TODOS os posts classificados como self_promotion ao LLM em uma única chamada
+    para obter distribuições agregadas de tipos de promoção e topic keywords.
+    Também computa top_subreddits (de quais comunidades vêm os posts self_promotion).
+    Opcionalmente, agrupa posts em padrões de promoção (segunda chamada LLM).
+    Enriquece com comentários dos top posts quando reddit_provider disponível.
+    """
+    aggregations = state.get("intent_aggregations", [])
+    classified = state.get("classified_posts", [])
+
+    # Filtrar posts self_promotion
+    promo_posts = [p for p in classified if p["primary_intent"] == "self_promotion"]
+    if not promo_posts:
+        return {"intent_aggregations": aggregations}
+
+    # Computar top_subreddits a partir dos posts self_promotion
+    subreddit_counter = Counter(p["post_subreddit"] for p in promo_posts)
+    top_subreddits = [
+        {"name": name, "count": count}
+        for name, count in subreddit_counter.most_common(10)
+    ]
+
+    # Construir texto de posts para o prompt
+    posts_text = _build_posts_batch_text(
+        [
+            {
+                "id": p["post_id"],
+                "subreddit": p["post_subreddit"],
+                "title": p["post_title"],
+                "score": 0,
+                "num_comments": 0,
+            }
+            for p in promo_posts
+        ]
+    )
+
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    prompt = get_analyze_self_promotion_prompt(
+        audience_name=state["audience_name"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        posts_text=posts_text,
+        total_posts=len(promo_posts),
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+    result = _parse_json_object_response(extract_response_text(response))
+
+    subcategories = result.get("subcategories")
+    topic_keywords = result.get("topic_keywords")
+
+    # Validar e limitar a 10 itens
+    if isinstance(subcategories, dict):
+        subcategories = dict(
+            sorted(subcategories.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        subcategories = None
+
+    if isinstance(topic_keywords, dict):
+        topic_keywords = dict(
+            sorted(topic_keywords.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        topic_keywords = None
+
+    # --- Self-Promotion Patterns (segunda chamada LLM) ---
+    promo_patterns = []
+    if len(promo_posts) >= 3:
+        # Lookup de posts completos (com selftext, score, num_comments, permalink)
+        full_posts_map = {p["id"]: p for p in state.get("posts", [])}
+
+        # Montar texto rico para o prompt (inclui selftext)
+        rich_posts = [
+            full_posts_map[p["post_id"]]
+            for p in promo_posts
+            if p["post_id"] in full_posts_map
+        ]
+
+        # Buscar comentários se reddit_provider disponível
+        reddit_provider = state.get("reddit_provider")
+        comments_map: dict[str, list[dict]] = {}
+        has_comments = False
+        if reddit_provider and THREAD_ANALYSIS_ENABLED:
+            logger.info(
+                "Fetching comments for top %d self_promotion posts",
+                TOP_POSTS_FOR_COMMENTS,
+            )
+            comments_map = _fetch_comments_for_posts(rich_posts, reddit_provider)
+            has_comments = bool(comments_map)
+            logger.info("Fetched comments for %d self_promotion posts", len(comments_map))
+
+        # Usar texto com ou sem comentários
+        if has_comments:
+            patterns_text = _build_posts_with_comments_text(rich_posts, comments_map)
+        else:
+            patterns_text = _build_posts_batch_text(rich_posts)
+
+        patterns_prompt = get_self_promotion_patterns_prompt(
+            audience_name=state["audience_name"],
+            period_start=state["period_start"],
+            period_end=state["period_end"],
+            posts_text=patterns_text,
+            total_posts=len(promo_posts),
+            language_directive=language_directive,
+            has_comments=has_comments,
+        )
+
+        try:
+            patterns_response = llm.invoke(patterns_prompt)
+            raw_patterns = _parse_json_response(
+                extract_response_text(patterns_response)
+            )
+
+            # Enriquecer cada padrão com métricas e submissions
+            for pattern in raw_patterns:
+                submissions = []
+                total_upvotes = 0
+                total_comments = 0
+                for pid in pattern.get("post_ids", []):
+                    fp = full_posts_map.get(pid)
+                    if not fp:
+                        continue
+                    submission = {
+                        "title": fp["title"],
+                        "body": (fp.get("selftext") or "")[:500],
+                        "subreddit": f"r/{fp['subreddit']}",
+                        "score": fp.get("score", 0),
+                        "num_comments": fp.get("num_comments", 0),
+                        "permalink": fp.get("permalink", ""),
+                    }
+                    if has_comments and pid in comments_map:
+                        submission["top_comments"] = comments_map[pid]
+                    submissions.append(submission)
+                    total_upvotes += fp.get("score", 0)
+                    total_comments += fp.get("num_comments", 0)
+
+                if submissions:
+                    pattern_entry = {
+                        "name": pattern.get("name", ""),
+                        "emoji": pattern.get("emoji", ""),
+                        "post_count": len(submissions),
+                        "total_upvotes": total_upvotes,
+                        "total_comments": total_comments,
+                        "submissions": submissions,
+                    }
+                    if has_comments:
+                        pattern_entry["community_sentiment"] = pattern.get(
+                            "community_sentiment", "neutral"
+                        )
+                        pattern_entry["feedback_highlights"] = pattern.get(
+                            "feedback_highlights", []
+                        )
+                        pattern_entry["market_signals"] = pattern.get(
+                            "market_signals", []
+                        )
+                    promo_patterns.append(pattern_entry)
+
+            promo_patterns.sort(key=lambda x: x["post_count"], reverse=True)
+            logger.info(
+                "Self-Promotion patterns: %d patterns identified from %d posts (comments: %s)",
+                len(promo_patterns),
+                len(promo_posts),
+                "yes" if has_comments else "no",
+            )
+        except Exception:
+            logger.exception("Failed to extract self-promotion patterns, continuing without them")
+            promo_patterns = []
+
+    # Atualizar a agregação de self_promotion
+    updated = []
+    for agg in aggregations:
+        if agg["category"] == "self_promotion":
+            agg = {
+                **agg,
+                "subcategories": subcategories,
+                "topic_keywords": topic_keywords,
+                "top_subreddits": top_subreddits,
+                "pain_patterns": promo_patterns,
+            }
+        updated.append(agg)
+
+    logger.info(
+        "Self-Promotion analysis: %d subcategories, %d topic keywords, %d subreddits",
+        len(subcategories) if subcategories else 0,
+        len(topic_keywords) if topic_keywords else 0,
+        len(top_subreddits),
+    )
+    return {"intent_aggregations": updated}
+
+
 def create_intent_classification_agent():
     """Cria e compila o grafo LangGraph de classificação de intenção."""
     workflow = StateGraph(IntentClassificationState)
@@ -1146,11 +1345,13 @@ def create_intent_classification_agent():
     workflow.add_node("analyze_solution_requests", analyze_solution_requests)
     workflow.add_node("analyze_advice_requests", analyze_advice_requests)
     workflow.add_node("analyze_ideas", analyze_ideas)
+    workflow.add_node("analyze_self_promotion", analyze_self_promotion)
     workflow.add_edge(START, "classify_intents")
     workflow.add_edge("classify_intents", "aggregate_intents")
     workflow.add_edge("aggregate_intents", "analyze_pain_anger")
     workflow.add_edge("analyze_pain_anger", "analyze_solution_requests")
     workflow.add_edge("analyze_solution_requests", "analyze_advice_requests")
     workflow.add_edge("analyze_advice_requests", "analyze_ideas")
-    workflow.add_edge("analyze_ideas", END)
+    workflow.add_edge("analyze_ideas", "analyze_self_promotion")
+    workflow.add_edge("analyze_self_promotion", END)
     return workflow.compile()

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -523,3 +523,113 @@ RULES:
 - post_ids must match exactly the POST_ID values from the input
 - Return ONLY the JSON array, no additional text
 {language_directive}"""
+
+
+def get_analyze_self_promotion_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+) -> str:
+    """Prompt para análise holística de tipos de autopromoção e tópicos em posts self_promotion."""
+    return f"""You are an expert community analyst specializing in understanding self-promotion patterns, product launches, content marketing, and entrepreneurial signals shared in online communities.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total self_promotion posts: {total_posts}
+
+Below are ALL posts classified as "self_promotion" from this audience's communities.
+Your task is to analyze them holistically and identify:
+
+1. **Promotion type subcategories**: What kinds of self-promotion are people doing? (e.g., product_launch, service_offer, content_marketing, portfolio_showcase, tool_showcase, course, tutorial, open_source, newsletter, podcast, ebook, template, saas_launch, freelance_offer, case_study, etc.)
+2. **Topic keywords**: What specific subjects are being promoted? Use single words. (e.g., SaaS, freelancing, design, writing, analytics, marketing, automation, AI, SEO, development, etc.)
+
+POSTS:
+{posts_text}
+
+---
+
+Respond in JSON format:
+{{
+  "subcategories": {{
+    "promotion_type": count,
+    "promotion_type": count
+  }},
+  "topic_keywords": {{
+    "keyword": count,
+    "keyword": count
+  }}
+}}
+
+RULES:
+- subcategories: Return up to 10 promotion types, sorted by count descending
+- topic_keywords: Return up to 10 single-word topics, sorted by count descending
+- Each count represents how many posts do that type of promotion or relate to that topic
+- A single post can contribute to multiple promotion types or topics
+- Use lowercase for all keys
+- Promotion types should be specific (use "product_launch" not "promotion", use "tutorial" not "content")
+- Topics should be single words that capture the core subject (use "SaaS" not "SaaS product")
+- The sum of subcategory counts may exceed total_posts (one post can involve multiple promotion types)
+- Return ONLY the JSON object, no additional text
+{language_directive}"""
+
+
+def get_self_promotion_patterns_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+    has_comments: bool = False,
+) -> str:
+    """Prompt para agrupar posts self_promotion em padrões de autopromoção."""
+    comments_instruction = ""
+    if has_comments:
+        comments_instruction = """
+
+IMPORTANT — THREAD COMMENTS ANALYSIS:
+Some posts include top community comments (marked with 💬 COMMENTS). Use them to:
+1. Assess **community_sentiment**: How the community reacted to the promotion — "supportive" (positive feedback, interest shown), "neutral" (acknowledged but not enthusiastic), "skeptical" (doubts about value/legitimacy), "hostile" (negative reception, seen as spam)
+2. Extract **feedback_highlights**: Direct feedback, suggestions, or questions from the community about the promoted product/service/content
+3. Extract **market_signals**: Competitive insights — competitors mentioned, market gaps identified, unmet needs revealed by community responses
+- If comments are present, include "community_sentiment", "feedback_highlights", and "market_signals" fields in each pattern"""
+
+    return f"""You are an expert community analyst. Your task is to group self-promotion posts into promotion patterns — recurring themes that reveal what products, services, and content the audience is actively building and promoting.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total self_promotion posts: {total_posts}
+
+Below are posts classified as "self_promotion" from this audience's communities, including their body text for richer context.
+{comments_instruction}
+
+POSTS:
+{posts_text}
+
+---
+
+Group these posts into 3 to 8 promotion patterns. Each pattern should represent a distinct, recurring type of product, service, or content being promoted.
+
+Respond in JSON format:
+[
+  {{
+    "name": "Short descriptive name of the promotion pattern (5-10 words)",
+    "emoji": "single emoji representing the type of promotion",
+    "post_ids": ["id1", "id2", "id3"]{', "community_sentiment": "supportive|neutral|skeptical|hostile", "feedback_highlights": ["feedback1", "feedback2"], "market_signals": ["signal1", "signal2"]' if has_comments else ''}
+  }}
+]
+
+RULES:
+- Create 3 to 8 patterns maximum
+- Each pattern must have at least 2 posts (if total posts < 6, patterns with 1 post are acceptable)
+- Each post_id must appear in EXACTLY ONE pattern — no duplicates across patterns
+- Every post_id from the input should be assigned to a pattern
+- Pattern names should be descriptive promotion phrases (5-10 words)
+- Use a single emoji that best represents the promotion type (e.g., 🚀 product launch, 📝 content/blog, 🎓 course/tutorial, 🔧 tool/plugin, 💼 service/freelance, 📊 SaaS, 🎨 design/creative, 📰 newsletter)
+- Order patterns by number of posts (most posts first)
+- post_ids must match exactly the POST_ID values from the input
+- Return ONLY the JSON array, no additional text
+{language_directive}"""


### PR DESCRIPTION
## Summary

- Add `analyze_self_promotion` node (No 7) to the LangGraph intent classification pipeline
- Implement deep analysis for the `self_promotion` category: subcategories, topic keywords, top subreddits, and promotion patterns
- Enrich with Reddit thread comments: `community_sentiment`, `feedback_highlights`, `market_signals`
- Add 2 new prompts: `get_analyze_self_promotion_prompt` and `get_self_promotion_patterns_prompt`

## Motivation

The `self_promotion` category was the last one without deep analysis. This PR brings **all 6 intent categories to full parity** — every category now has subcategories, topic keywords, top subreddits, patterns, and thread comments enrichment.

## Test plan

- [ ] Trigger intent analysis refresh: `POST /audiences/{id}/themes/intents/refresh?window=week`
- [ ] Verify `self_promotion` category now has `subcategories`, `topic_keywords`, `top_subreddits`, and `pain_patterns`
- [ ] Verify patterns include `community_sentiment`, `feedback_highlights`, `market_signals` when comments available
- [ ] Verify backward compatibility with existing analyses (no breaking changes)
- [ ] Verify feature flag `THREAD_ANALYSIS_ENABLED=False` skips comment fetching

Closes #113