### PR TITLE
feat: deep analysis with thread comments for news intent

### DIFF
--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/intent_agent.py
@@ -16,11 +16,13 @@ from app.modules.intent_classification.application.use_cases.classify_intents_us
     get_aggregate_intents_prompt,
     get_analyze_advice_requests_prompt,
     get_analyze_ideas_prompt,
+    get_analyze_news_prompt,
     get_analyze_pain_anger_prompt,
     get_analyze_self_promotion_prompt,
     get_analyze_solution_requests_prompt,
     get_classify_intents_prompt,
     get_ideas_patterns_prompt,
+    get_news_patterns_prompt,
     get_pain_patterns_prompt,
     get_self_promotion_patterns_prompt,
     get_solution_patterns_prompt,
@@ -1336,6 +1338,203 @@ def analyze_self_promotion(state: IntentClassificationState) -> dict:
     return {"intent_aggregations": updated}
 
 
+def analyze_news(state: IntentClassificationState) -> dict:
+    """
+    Nó 8: Analisa posts news para extrair tipos de notícia e tópicos.
+
+    Envia TODOS os posts classificados como news ao LLM em uma única chamada
+    para obter distribuições agregadas de tipos de notícia e topic keywords.
+    Também computa top_subreddits (de quais comunidades vêm os posts news).
+    Opcionalmente, agrupa posts em padrões de notícias (segunda chamada LLM).
+    Enriquece com comentários dos top posts quando reddit_provider disponível.
+    """
+    aggregations = state.get("intent_aggregations", [])
+    classified = state.get("classified_posts", [])
+
+    # Filtrar posts news
+    news_posts = [p for p in classified if p["primary_intent"] == "news"]
+    if not news_posts:
+        return {"intent_aggregations": aggregations}
+
+    # Computar top_subreddits a partir dos posts news
+    subreddit_counter = Counter(p["post_subreddit"] for p in news_posts)
+    top_subreddits = [
+        {"name": name, "count": count}
+        for name, count in subreddit_counter.most_common(10)
+    ]
+
+    # Construir texto de posts para o prompt
+    posts_text = _build_posts_batch_text(
+        [
+            {
+                "id": p["post_id"],
+                "subreddit": p["post_subreddit"],
+                "title": p["post_title"],
+                "score": 0,
+                "num_comments": 0,
+            }
+            for p in news_posts
+        ]
+    )
+
+    llm = _get_llm()
+    language_directive = get_language_directive(state.get("language", "en"))
+
+    prompt = get_analyze_news_prompt(
+        audience_name=state["audience_name"],
+        period_start=state["period_start"],
+        period_end=state["period_end"],
+        posts_text=posts_text,
+        total_posts=len(news_posts),
+        language_directive=language_directive,
+    )
+
+    response = llm.invoke(prompt)
+    result = _parse_json_object_response(extract_response_text(response))
+
+    subcategories = result.get("subcategories")
+    topic_keywords = result.get("topic_keywords")
+
+    # Validar e limitar a 10 itens
+    if isinstance(subcategories, dict):
+        subcategories = dict(
+            sorted(subcategories.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        subcategories = None
+
+    if isinstance(topic_keywords, dict):
+        topic_keywords = dict(
+            sorted(topic_keywords.items(), key=lambda x: x[1], reverse=True)[:10]
+        )
+    else:
+        topic_keywords = None
+
+    # --- News Patterns (segunda chamada LLM) ---
+    news_patterns = []
+    if len(news_posts) >= 3:
+        # Lookup de posts completos (com selftext, score, num_comments, permalink)
+        full_posts_map = {p["id"]: p for p in state.get("posts", [])}
+
+        # Montar texto rico para o prompt (inclui selftext)
+        rich_posts = [
+            full_posts_map[p["post_id"]]
+            for p in news_posts
+            if p["post_id"] in full_posts_map
+        ]
+
+        # Buscar comentários se reddit_provider disponível
+        reddit_provider = state.get("reddit_provider")
+        comments_map: dict[str, list[dict]] = {}
+        has_comments = False
+        if reddit_provider and THREAD_ANALYSIS_ENABLED:
+            logger.info(
+                "Fetching comments for top %d news posts",
+                TOP_POSTS_FOR_COMMENTS,
+            )
+            comments_map = _fetch_comments_for_posts(rich_posts, reddit_provider)
+            has_comments = bool(comments_map)
+            logger.info("Fetched comments for %d news posts", len(comments_map))
+
+        # Usar texto com ou sem comentários
+        if has_comments:
+            patterns_text = _build_posts_with_comments_text(rich_posts, comments_map)
+        else:
+            patterns_text = _build_posts_batch_text(rich_posts)
+
+        patterns_prompt = get_news_patterns_prompt(
+            audience_name=state["audience_name"],
+            period_start=state["period_start"],
+            period_end=state["period_end"],
+            posts_text=patterns_text,
+            total_posts=len(news_posts),
+            language_directive=language_directive,
+            has_comments=has_comments,
+        )
+
+        try:
+            patterns_response = llm.invoke(patterns_prompt)
+            raw_patterns = _parse_json_response(
+                extract_response_text(patterns_response)
+            )
+
+            # Enriquecer cada padrão com métricas e submissions
+            for pattern in raw_patterns:
+                submissions = []
+                total_upvotes = 0
+                total_comments = 0
+                for pid in pattern.get("post_ids", []):
+                    fp = full_posts_map.get(pid)
+                    if not fp:
+                        continue
+                    submission = {
+                        "title": fp["title"],
+                        "body": (fp.get("selftext") or "")[:500],
+                        "subreddit": f"r/{fp['subreddit']}",
+                        "score": fp.get("score", 0),
+                        "num_comments": fp.get("num_comments", 0),
+                        "permalink": fp.get("permalink", ""),
+                    }
+                    if has_comments and pid in comments_map:
+                        submission["top_comments"] = comments_map[pid]
+                    submissions.append(submission)
+                    total_upvotes += fp.get("score", 0)
+                    total_comments += fp.get("num_comments", 0)
+
+                if submissions:
+                    pattern_entry = {
+                        "name": pattern.get("name", ""),
+                        "emoji": pattern.get("emoji", ""),
+                        "post_count": len(submissions),
+                        "total_upvotes": total_upvotes,
+                        "total_comments": total_comments,
+                        "submissions": submissions,
+                    }
+                    if has_comments:
+                        pattern_entry["sentiment_shift"] = pattern.get(
+                            "sentiment_shift", "aligned"
+                        )
+                        pattern_entry["perceived_impact"] = pattern.get(
+                            "perceived_impact", "medium"
+                        )
+                        pattern_entry["actionability"] = pattern.get(
+                            "actionability", "informational"
+                        )
+                    news_patterns.append(pattern_entry)
+
+            news_patterns.sort(key=lambda x: x["post_count"], reverse=True)
+            logger.info(
+                "News patterns: %d patterns identified from %d posts (comments: %s)",
+                len(news_patterns),
+                len(news_posts),
+                "yes" if has_comments else "no",
+            )
+        except Exception:
+            logger.exception("Failed to extract news patterns, continuing without them")
+            news_patterns = []
+
+    # Atualizar a agregação de news
+    updated = []
+    for agg in aggregations:
+        if agg["category"] == "news":
+            agg = {
+                **agg,
+                "subcategories": subcategories,
+                "topic_keywords": topic_keywords,
+                "top_subreddits": top_subreddits,
+                "pain_patterns": news_patterns,
+            }
+        updated.append(agg)
+
+    logger.info(
+        "News analysis: %d subcategories, %d topic keywords, %d subreddits",
+        len(subcategories) if subcategories else 0,
+        len(topic_keywords) if topic_keywords else 0,
+        len(top_subreddits),
+    )
+    return {"intent_aggregations": updated}
+
+
 def create_intent_classification_agent():
     """Cria e compila o grafo LangGraph de classificação de intenção."""
     workflow = StateGraph(IntentClassificationState)
@@ -1346,6 +1545,7 @@ def create_intent_classification_agent():
     workflow.add_node("analyze_advice_requests", analyze_advice_requests)
     workflow.add_node("analyze_ideas", analyze_ideas)
     workflow.add_node("analyze_self_promotion", analyze_self_promotion)
+    workflow.add_node("analyze_news", analyze_news)
     workflow.add_edge(START, "classify_intents")
     workflow.add_edge("classify_intents", "aggregate_intents")
     workflow.add_edge("aggregate_intents", "analyze_pain_anger")
@@ -1353,5 +1553,6 @@ def create_intent_classification_agent():
     workflow.add_edge("analyze_solution_requests", "analyze_advice_requests")
     workflow.add_edge("analyze_advice_requests", "analyze_ideas")
     workflow.add_edge("analyze_ideas", "analyze_self_promotion")
-    workflow.add_edge("analyze_self_promotion", END)
+    workflow.add_edge("analyze_self_promotion", "analyze_news")
+    workflow.add_edge("analyze_news", END)
     return workflow.compile()

--- a/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
+++ b/app/modules/intent_classification/application/use_cases/classify_intents_use_case/agent/prompts/intent_prompts.py
@@ -633,3 +633,113 @@ RULES:
 - post_ids must match exactly the POST_ID values from the input
 - Return ONLY the JSON array, no additional text
 {language_directive}"""
+
+
+def get_analyze_news_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+) -> str:
+    """Prompt para análise holística de tipos de notícias e tópicos em posts news."""
+    return f"""You are an expert community analyst specializing in understanding news sharing patterns, industry trends, regulatory changes, and current events discussed in online communities.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total news posts: {total_posts}
+
+Below are ALL posts classified as "news" from this audience's communities.
+Your task is to analyze them holistically and identify:
+
+1. **News type subcategories**: What kinds of news are people sharing? (e.g., product_update, industry_trend, regulation, acquisition, funding, partnership, security_breach, algorithm_change, platform_update, market_report, layoffs, launch, shutdown, policy_change, research_finding, etc.)
+2. **Topic keywords**: What specific subjects are the news about? Use single words. (e.g., AI, pricing, privacy, Google, regulation, advertising, algorithm, layoffs, funding, security, etc.)
+
+POSTS:
+{posts_text}
+
+---
+
+Respond in JSON format:
+{{
+  "subcategories": {{
+    "news_type": count,
+    "news_type": count
+  }},
+  "topic_keywords": {{
+    "keyword": count,
+    "keyword": count
+  }}
+}}
+
+RULES:
+- subcategories: Return up to 10 news types, sorted by count descending
+- topic_keywords: Return up to 10 single-word topics, sorted by count descending
+- Each count represents how many posts share that type of news or relate to that topic
+- A single post can contribute to multiple news types or topics
+- Use lowercase for all keys
+- News types should be specific (use "algorithm_change" not "update", use "acquisition" not "business")
+- Topics should be single words that capture the core subject (use "privacy" not "data privacy")
+- The sum of subcategory counts may exceed total_posts (one post can cover multiple news types)
+- Return ONLY the JSON object, no additional text
+{language_directive}"""
+
+
+def get_news_patterns_prompt(
+    audience_name: str,
+    period_start: str,
+    period_end: str,
+    posts_text: str,
+    total_posts: int,
+    language_directive: str = "",
+    has_comments: bool = False,
+) -> str:
+    """Prompt para agrupar posts news em padrões de notícias/eventos."""
+    comments_instruction = ""
+    if has_comments:
+        comments_instruction = """
+
+IMPORTANT — THREAD COMMENTS ANALYSIS:
+Some posts include top community comments (marked with 💬 COMMENTS). Use them to:
+1. Assess **sentiment_shift**: Whether the community's reaction aligns with the news narrative — "aligned" (community agrees with the tone/framing), "divergent" (community disagrees or has opposite reaction), "polarized" (community is split with strong opinions on both sides)
+2. Assess **perceived_impact**: How significant the community considers this news — "high" (widespread concern/excitement, many affected), "medium" (notable but limited scope), "low" (minor or niche relevance)
+3. Assess **actionability**: Whether the news requires action from the audience — "requires_action" (people need to adapt, migrate, change strategy), "monitor" (worth watching but no immediate action needed), "informational" (purely informative, no action implied)
+- If comments are present, include "sentiment_shift", "perceived_impact", and "actionability" fields in each pattern"""
+
+    return f"""You are an expert community analyst. Your task is to group news posts into news patterns — recurring themes that reveal what events, changes, and developments the audience is actively discussing and reacting to.
+
+Audience: "{audience_name}"
+Period: {period_start} to {period_end}
+Total news posts: {total_posts}
+
+Below are posts classified as "news" from this audience's communities, including their body text for richer context.
+{comments_instruction}
+
+POSTS:
+{posts_text}
+
+---
+
+Group these posts into 3 to 8 news patterns. Each pattern should represent a distinct, recurring news theme or event being discussed.
+
+Respond in JSON format:
+[
+  {{
+    "name": "Short descriptive name of the news pattern (5-10 words)",
+    "emoji": "single emoji representing the type of news",
+    "post_ids": ["id1", "id2", "id3"]{', "sentiment_shift": "aligned|divergent|polarized", "perceived_impact": "high|medium|low", "actionability": "requires_action|monitor|informational"' if has_comments else ''}
+  }}
+]
+
+RULES:
+- Create 3 to 8 patterns maximum
+- Each pattern must have at least 2 posts (if total posts < 6, patterns with 1 post are acceptable)
+- Each post_id must appear in EXACTLY ONE pattern — no duplicates across patterns
+- Every post_id from the input should be assigned to a pattern
+- Pattern names should be descriptive news phrases (5-10 words)
+- Use a single emoji that best represents the news type (e.g., 📰 general news, 🔄 platform update, ⚖️ regulation, 💰 funding/acquisition, 🔒 security, 📉 market change, 🚀 launch, 🤖 AI/tech, ⚠️ breaking change)
+- Order patterns by number of posts (most posts first)
+- post_ids must match exactly the POST_ID values from the input
+- Return ONLY the JSON array, no additional text
+{language_directive}"""


### PR DESCRIPTION
## Summary

- Add `analyze_news` node (No 8) to the LangGraph intent classification pipeline
- Implement deep analysis for the `news` category: subcategories, topic keywords, top subreddits, and news patterns
- Enrich with Reddit thread comments: `sentiment_shift`, `perceived_impact`, `actionability`
- Add 2 new prompts: `get_analyze_news_prompt` and `get_news_patterns_prompt`

## Motivation

The `news` category was the last one without deep analysis — showing Subcategories 0, Topics 0, Subreddits 0. This PR completes **all 6 intent categories with full deep analysis and thread comments enrichment**.

News has unique fields that capture how the community reacts to industry events:
- `sentiment_shift`: Whether community agrees or diverges from the news narrative
- `perceived_impact`: How significant the community considers the news
- `actionability`: Whether the news requires action from the audience

## Test plan

- [ ] Trigger intent analysis refresh: `POST /audiences/{id}/themes/intents/refresh?window=week`
- [ ] Verify `news` category now has `subcategories`, `topic_keywords`, `top_subreddits`, and `pain_patterns`
- [ ] Verify patterns include `sentiment_shift`, `perceived_impact`, `actionability` when comments available
- [ ] Verify backward compatibility with existing analyses (no breaking changes)
- [ ] Verify feature flag `THREAD_ANALYSIS_ENABLED=False` skips comment fetching

Closes #115