### PR TITLE
feat: YouTube Intelligence Module — cross-platform validation

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -45,6 +45,7 @@ from app.modules.topic_chat.domain.entities import topic_conversation  # noqa: E
 from app.modules.topic_chat.domain.entities import topic_conversation_message  # noqa: E402, F401
 from app.modules.intent_ask.domain.entities import intent_ask_log  # noqa: E402, F401
 from app.modules.content_suggestions.domain.entities import content_draft  # noqa: E402, F401
+from app.modules.youtube_validation.domain.entities import youtube_validation  # noqa: E402, F401
 
 target_metadata = [Base.metadata]
 

--- a/alembic/versions/b2c3d4e5f6a7_add_youtube_validation_tables.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_youtube_validation_tables.py
@@ -1,0 +1,152 @@
+"""add youtube validation tables
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f7
+Create Date: 2026-03-04 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "youtube_validations",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("audience_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="processing",
+        ),
+        sa.Column("fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("analysis_data", sa.JSON(), nullable=True),
+        sa.Column("summary", sa.JSON(), nullable=True),
+        sa.Column("total_videos", sa.Integer(), nullable=True, server_default="0"),
+        sa.Column("total_comments", sa.Integer(), nullable=True, server_default="0"),
+        sa.Column("model_used", sa.String(length=100), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["audience_id"], ["audiences.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_youtube_validations_audience_id"),
+        "youtube_validations",
+        ["audience_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_youtube_validations_user_id"),
+        "youtube_validations",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_youtube_validations_status"),
+        "youtube_validations",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_youtube_validations_fingerprint"),
+        "youtube_validations",
+        ["fingerprint"],
+        unique=False,
+    )
+
+    op.create_table(
+        "youtube_collected_videos",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("validation_id", sa.UUID(), nullable=False),
+        sa.Column("topic_name", sa.String(length=255), nullable=False),
+        sa.Column("video_id", sa.String(length=20), nullable=False),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("channel_name", sa.Text(), nullable=True),
+        sa.Column("views", sa.Integer(), nullable=True),
+        sa.Column("likes", sa.Integer(), nullable=True),
+        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("comments", sa.JSON(), nullable=True),
+        sa.Column("transcript", sa.Text(), nullable=True),
+        sa.Column("transcript_lang", sa.String(length=10), nullable=True),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("collected_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["validation_id"],
+            ["youtube_validations.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_youtube_collected_videos_validation_id"),
+        "youtube_collected_videos",
+        ["validation_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_yt_collected_validation_topic",
+        "youtube_collected_videos",
+        ["validation_id", "topic_name"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_yt_collected_unique",
+        "youtube_collected_videos",
+        ["validation_id", "video_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_yt_collected_unique",
+        table_name="youtube_collected_videos",
+    )
+    op.drop_index(
+        "ix_yt_collected_validation_topic",
+        table_name="youtube_collected_videos",
+    )
+    op.drop_index(
+        op.f("ix_youtube_collected_videos_validation_id"),
+        table_name="youtube_collected_videos",
+    )
+    op.drop_table("youtube_collected_videos")
+    op.drop_index(
+        op.f("ix_youtube_validations_fingerprint"),
+        table_name="youtube_validations",
+    )
+    op.drop_index(
+        op.f("ix_youtube_validations_status"),
+        table_name="youtube_validations",
+    )
+    op.drop_index(
+        op.f("ix_youtube_validations_user_id"),
+        table_name="youtube_validations",
+    )
+    op.drop_index(
+        op.f("ix_youtube_validations_audience_id"),
+        table_name="youtube_validations",
+    )
+    op.drop_table("youtube_validations")

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routes import (
     intent_ask_router,
     intent_chat_router,
     semantic_search_router,
+    youtube_validation_router,
 )
 
 logging.basicConfig(
@@ -101,6 +102,7 @@ app.include_router(content_suggestions_router)
 app.include_router(intent_ask_router)
 app.include_router(intent_chat_router)
 app.include_router(semantic_search_router)
+app.include_router(youtube_validation_router)
 
 
 @app.get("/")

--- a/app/modules/notifications/application/services/notification_event_service.py
+++ b/app/modules/notifications/application/services/notification_event_service.py
@@ -26,6 +26,7 @@ _TYPE_LABELS = {
     "theme_summary": "Theme Summary",
     "communities_changed": "Communities Update",
     "communities_validation_failed": "Community Validation",
+    "youtube_validation": "YouTube Validation",
 }
 
 

--- a/app/modules/topic_alerts/application/helpers/alert_rules.py
+++ b/app/modules/topic_alerts/application/helpers/alert_rules.py
@@ -44,3 +44,20 @@ def classify_new_theme_severity(engagement_score: float | None) -> str:
     if score >= NEW_THEME_WARNING_ENGAGEMENT:
         return "warning"
     return "info"
+
+
+# --- Thresholds de validação cross-platform YouTube ---
+CROSS_PLATFORM_WARNING_TRACTION = 7  # traction_score >= 7 = warning
+CROSS_PLATFORM_CRITICAL_TRACTION = 8  # traction_score > 8 + content_gap = critical
+
+
+def classify_cross_platform_severity(
+    traction_score: float,
+    has_content_gap: bool = False,
+) -> str | None:
+    """Retorna severity para validação cross-platform YouTube."""
+    if traction_score > CROSS_PLATFORM_CRITICAL_TRACTION and has_content_gap:
+        return "critical"
+    if traction_score >= CROSS_PLATFORM_WARNING_TRACTION:
+        return "warning"
+    return None

--- a/app/modules/topic_alerts/application/use_cases/evaluate_alerts_use_case.py
+++ b/app/modules/topic_alerts/application/use_cases/evaluate_alerts_use_case.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.modules.topic_alerts.application.helpers.alert_rules import (
+    classify_cross_platform_severity,
     classify_growth_severity,
     classify_new_theme_severity,
     classify_new_topic_severity,
@@ -305,6 +306,81 @@ class EvaluateAlertsUseCase:
         )
 
         return {t.name.strip().lower() for t in themes}
+
+    def evaluate_youtube_validation(
+        self,
+        audience_id: UUID,
+        validation_id: UUID,
+        user_id: UUID,
+        audience_name: str,
+        analysis_result: dict,
+    ) -> int:
+        """
+        Avalia resultado de validação YouTube e gera alertas cross-platform.
+
+        Args:
+            audience_id: ID da audiência
+            validation_id: ID da validação YouTube
+            user_id: ID do dono da audiência
+            audience_name: Nome da audiência
+            analysis_result: Resultado completo da análise LLM
+
+        Returns:
+            Número de alertas gerados
+        """
+        topics = analysis_result.get("topics", [])
+        if not topics:
+            return 0
+
+        alerts_data: list[dict] = []
+
+        for topic in topics:
+            topic_name = topic.get("topic_name", "")
+            traction_score = topic.get("traction_score", 0)
+            has_content_gap = bool(topic.get("content_gap"))
+
+            severity = classify_cross_platform_severity(
+                traction_score, has_content_gap
+            )
+            if not severity:
+                continue
+
+            gap_note = " (content gap detected)" if has_content_gap else ""
+            alerts_data.append(
+                {
+                    "audience_id": audience_id,
+                    "user_id": user_id,
+                    "alert_type": "cross_platform_validated",
+                    "severity": severity,
+                    "title": f"Cross-platform: {topic_name}",
+                    "message": (
+                        f"Topic '{topic_name}' in audience '{audience_name}' "
+                        f"has YouTube traction score {traction_score}/10"
+                        f"{gap_note}."
+                    ),
+                    "metadata_": {
+                        "topic_name": topic_name,
+                        "audience_id": str(audience_id),
+                        "audience_name": audience_name,
+                        "validation_id": str(validation_id),
+                        "traction_score": traction_score,
+                        "has_content_gap": has_content_gap,
+                    },
+                }
+            )
+
+        if not alerts_data:
+            return 0
+
+        count = self.alert_repo.create_batch(alerts_data)
+        self._send_notifications(user_id, audience_id, audience_name, alerts_data)
+
+        logger.info(
+            "Generated %d cross-platform alerts for audience '%s'",
+            count,
+            audience_name,
+        )
+        return count
 
     def _send_notifications(
         self,

--- a/app/modules/youtube_validation/application/helpers/youtube_context_limits.py
+++ b/app/modules/youtube_validation/application/helpers/youtube_context_limits.py
@@ -1,0 +1,55 @@
+"""YouTube-specific context limits per LLM provider.
+
+Gemini (2M tokens) allows aggressive collection and unified analysis.
+OpenAI (128K tokens) requires conservative collection and per-topic analysis.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from app.modules.shared.application.services.llm_factory import _detect_provider
+
+
+@dataclass(frozen=True)
+class YouTubeContextLimits:
+    """Limites de contexto específicos para coleta e análise YouTube."""
+
+    max_videos_per_topic: int
+    max_comments_per_video: int
+    max_transcript_chars: int
+    max_videos_with_transcript: int
+    max_total_analysis_chars: int
+    analysis_mode: str  # "unified" (1 call) or "per_topic" (N calls)
+
+
+_YOUTUBE_GEMINI_DEFAULTS = YouTubeContextLimits(
+    max_videos_per_topic=20,
+    max_comments_per_video=100,
+    max_transcript_chars=50_000,
+    max_videos_with_transcript=10,
+    max_total_analysis_chars=1_200_000,
+    analysis_mode="unified",
+)
+
+_YOUTUBE_OPENAI_DEFAULTS = YouTubeContextLimits(
+    max_videos_per_topic=5,
+    max_comments_per_video=30,
+    max_transcript_chars=10_000,
+    max_videos_with_transcript=3,
+    max_total_analysis_chars=80_000,
+    analysis_mode="per_topic",
+)
+
+
+def get_youtube_context_limits(
+    model_env_var: str = "YOUTUBE_VALIDATION_MODEL_NAME",
+    default_model: str = "gpt-5-nano-2025-08-07",
+) -> YouTubeContextLimits:
+    """Retorna limites de contexto YouTube baseados no provider do modelo configurado."""
+    model_name = os.getenv(model_env_var, os.getenv("MODEL_NAME", default_model))
+    provider = _detect_provider(model_name)
+    if provider == "gemini":
+        return _YOUTUBE_GEMINI_DEFAULTS
+    return _YOUTUBE_OPENAI_DEFAULTS

--- a/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/agent/prompts/youtube_validation_prompts.py
+++ b/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/agent/prompts/youtube_validation_prompts.py
@@ -1,0 +1,145 @@
+from app.modules.shared.application.helpers.language_directive import (
+    get_language_directive,
+)
+
+
+def unified_validation_prompt(
+    audience_name: str,
+    topics_text: str,
+    total_topics: int,
+    total_videos: int,
+    total_comments: int,
+    language: str = "en",
+) -> str:
+    """Prompt para análise unificada cross-platform (Gemini — todos os tópicos em 1 chamada)."""
+    prompt = f"""You are an expert cross-platform analyst specializing in Reddit and YouTube audience intelligence.
+
+Audience: "{audience_name}"
+Total topics analyzed: {total_topics}
+Total YouTube videos collected: {total_videos}
+Total YouTube comments analyzed: {total_comments}
+
+Below is the cross-platform data for each topic. For each topic you have:
+- Reddit data: topic description, post count, community count, communities
+- YouTube data: videos with metadata (views, likes, duration), comments, and transcripts
+
+{topics_text}
+
+---
+
+TASK: Perform a comprehensive cross-platform validation comparing Reddit discussions with YouTube content for each topic. Produce a structured JSON with:
+
+1. **topics**: An array where each element analyzes one topic with:
+   - "topic_name": The topic name
+   - "traction_score": 0-10 scale measuring how well this Reddit topic performs on YouTube (0 = no presence, 10 = massive presence)
+   - "youtube_video_count": Number of YouTube videos found
+   - "avg_views": Average views across found videos
+   - "sentiment_reddit": Overall Reddit sentiment ("positive", "negative", "neutral", "mixed", "curious", "divided")
+   - "sentiment_youtube": Overall YouTube sentiment (from comments + video tone)
+   - "sentiment_divergence": 1-2 sentences explaining how/why sentiments differ between platforms (empty string if aligned)
+   - "content_gap": true if topic is discussed on Reddit but underrepresented on YouTube
+   - "content_gap_detail": Explanation of the gap (empty string if no gap)
+   - "content_saturated": true if YouTube already has extensive coverage
+   - "product_mentions": Array of products mentioned cross-platform, each with:
+     - "product": Product name
+     - "reddit_sentiment": Sentiment on Reddit
+     - "youtube_sentiment": Sentiment on YouTube
+     - "confidence": "high", "medium", or "low"
+   - "top_videos": Top 3-5 most relevant videos, each with:
+     - "title": Video title
+     - "video_id": YouTube video ID
+     - "views": View count
+     - "likes": Like count
+     - "comments_analyzed": Number of comments analyzed
+   - "audience_overlap_score": 0-10 scale (are Reddit and YouTube discussing this topic with similar perspectives?)
+   - "opportunity_insights": Array of 1-3 actionable insights specific to this topic
+
+2. **cross_platform_summary**: An object with:
+   - "total_topics_with_traction": Number of topics with traction_score >= 5
+   - "avg_traction_score": Average traction_score across all topics
+   - "content_gaps_found": Number of topics with content_gap = true
+   - "key_findings": Array of 3-5 high-level findings from the cross-platform comparison
+   - "best_opportunity": The single best cross-platform opportunity identified
+   - "biggest_divergence": The topic with the biggest sentiment divergence between platforms
+
+IMPORTANT:
+- Base ALL analysis on the actual data provided. Do NOT invent data.
+- If a topic has no YouTube data, set traction_score to 0 and note the absence.
+- Be specific — reference actual video titles, comment patterns, and Reddit discussions.
+- When comparing sentiments, explain WHY they differ (platform demographics, content format, etc).
+
+Respond ONLY with valid JSON. No markdown code blocks, no explanations outside the JSON.
+
+Example structure:
+{{"topics": [...], "cross_platform_summary": {{...}}}}"""
+
+    return prompt + get_language_directive(language)
+
+
+def per_topic_validation_prompt(
+    audience_name: str,
+    topic_name: str,
+    topic_text: str,
+    language: str = "en",
+) -> str:
+    """Prompt para análise por tópico (OpenAI — 1 tópico por chamada)."""
+    prompt = f"""You are an expert cross-platform analyst comparing Reddit and YouTube data for a specific topic.
+
+Audience: "{audience_name}"
+Topic: "{topic_name}"
+
+Below is the cross-platform data for this topic:
+{topic_text}
+
+---
+
+TASK: Analyze this topic's cross-platform presence. Return a JSON object with:
+- "topic_name": "{topic_name}"
+- "traction_score": 0-10 scale (YouTube presence for this Reddit topic)
+- "youtube_video_count": Number of YouTube videos found
+- "avg_views": Average views
+- "sentiment_reddit": Reddit sentiment
+- "sentiment_youtube": YouTube sentiment (from comments + transcripts)
+- "sentiment_divergence": How sentiments differ (empty string if aligned)
+- "content_gap": true/false
+- "content_gap_detail": Gap explanation (empty string if no gap)
+- "content_saturated": true/false
+- "product_mentions": [{{ "product": str, "reddit_sentiment": str, "youtube_sentiment": str, "confidence": str }}]
+- "top_videos": [{{ "title": str, "video_id": str, "views": int, "likes": int, "comments_analyzed": int }}]
+- "audience_overlap_score": 0-10
+- "opportunity_insights": [str]
+
+IMPORTANT: Base ALL analysis on actual data. Respond ONLY with valid JSON.
+
+Example: {{"topic_name": "...", "traction_score": 7.5, ...}}"""
+
+    return prompt + get_language_directive(language)
+
+
+def summary_prompt(
+    audience_name: str,
+    analysis_result_text: str,
+    language: str = "en",
+) -> str:
+    """Prompt para gerar resumo executivo da análise cross-platform."""
+    prompt = f"""You are summarizing a cross-platform Reddit vs YouTube validation for the audience "{audience_name}".
+
+Here is the full analysis result:
+{analysis_result_text}
+
+---
+
+TASK: Generate an executive summary JSON with:
+- "topics_analyzed": Total number of topics
+- "topics_with_youtube_traction": Number with traction_score >= 5
+- "content_gaps_found": Number of content gaps
+- "avg_traction_score": Average traction score (1 decimal)
+- "total_videos_analyzed": Total videos across all topics
+- "total_comments_analyzed": Total comments analyzed
+- "headline": A 1-sentence headline summarizing the key finding
+- "key_opportunities": Top 3 opportunities (array of strings)
+- "risk_factors": Top 2 risk factors or warnings (array of strings)
+
+Respond ONLY with valid JSON."""
+
+    return prompt + get_language_directive(language)

--- a/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/agent/state.py
+++ b/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/agent/state.py
@@ -1,0 +1,36 @@
+from typing import TypedDict
+
+
+class TopicVideoData(TypedDict):
+    """Dados coletados do YouTube para um tópico."""
+
+    topic_name: str
+    topic_description: str
+    videos: list[dict]
+    # Each video: {video_id, title, channel_name, views, likes, duration_seconds,
+    #              tags, description, comments, transcript, transcript_lang, published_at}
+
+
+class TopicRedditData(TypedDict):
+    """Dados do Reddit para um tópico (existentes no sistema)."""
+
+    topic_name: str
+    topic_description: str
+    post_count: int
+    avg_score: float
+    community_count: int
+    communities: list[str]
+
+
+class YouTubeValidationState(TypedDict):
+    """Estado do grafo LangGraph para validação cross-platform."""
+
+    # Input fields (set pelo caller em agent.invoke())
+    audience_name: str
+    language: str
+    topics_reddit_data: list[TopicRedditData]
+    topics_youtube_data: list[TopicVideoData]
+
+    # Output fields (populated by nodes)
+    analysis_result: dict | None  # Full cross-platform analysis
+    analysis_summary: dict | None  # Executive summary

--- a/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/agent/youtube_validation_agent.py
+++ b/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/agent/youtube_validation_agent.py
@@ -1,0 +1,349 @@
+"""LangGraph agent for cross-platform YouTube validation.
+
+Graph: START → analyze_cross_platform → generate_summary → END
+
+Routes to unified (Gemini) or per-topic (OpenAI) analysis based on
+the configured model's provider.
+"""
+
+import json
+import logging
+import os
+
+from langgraph.graph import END, START, StateGraph
+
+from app.modules.shared.application.services.llm_factory import (
+    create_llm,
+    extract_response_text,
+)
+from app.modules.youtube_validation.application.helpers.youtube_context_limits import (
+    get_youtube_context_limits,
+)
+from app.modules.youtube_validation.application.use_cases.extract_youtube_validation_use_case.agent.prompts.youtube_validation_prompts import (
+    per_topic_validation_prompt,
+    summary_prompt,
+    unified_validation_prompt,
+)
+from app.modules.youtube_validation.application.use_cases.extract_youtube_validation_use_case.agent.state import (
+    YouTubeValidationState,
+)
+
+logger = logging.getLogger(__name__)
+
+_MODEL_ENV = "YOUTUBE_VALIDATION_MODEL_NAME"
+_MODEL_FALLBACK_ENV = "MODEL_NAME"
+_DEFAULT_MODEL = "gpt-5-nano-2025-08-07"
+
+
+def _resolve_model_env() -> str:
+    """Return the model name using the dedicated env var with fallback."""
+    return os.getenv(_MODEL_ENV) or os.getenv(_MODEL_FALLBACK_ENV, _DEFAULT_MODEL)
+
+
+def _get_llm():
+    model = _resolve_model_env()
+    return create_llm(model_env_var=_MODEL_ENV, default_model=model, temperature=0)
+
+
+def _parse_json_response(content: str) -> dict | None:
+    """Parse JSON from LLM response, cleaning markdown code blocks."""
+    text = content.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+    if text.endswith("```"):
+        text = text[:-3].strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        logger.error("Failed to parse JSON response: %s", text[:500])
+        return None
+
+
+# ── Text builders ──────────────────────────────────────────────────────────
+
+
+def _build_topic_text(
+    reddit_data: dict,
+    youtube_data: dict,
+    max_comments: int = 100,
+    max_transcript_chars: int = 50_000,
+) -> str:
+    """Constrói texto de um tópico com dados Reddit + YouTube."""
+    lines = []
+    topic_name = reddit_data.get("topic_name", youtube_data.get("topic_name", ""))
+
+    lines.append(f"=== TOPIC: {topic_name} ===")
+
+    # Reddit section
+    lines.append("\n--- REDDIT DATA ---")
+    lines.append(f"Description: {reddit_data.get('topic_description', 'N/A')}")
+    lines.append(f"Post count: {reddit_data.get('post_count', 0)}")
+    lines.append(f"Average score: {reddit_data.get('avg_score', 0)}")
+    lines.append(
+        f"Communities ({reddit_data.get('community_count', 0)}): "
+        f"{', '.join(reddit_data.get('communities', []))}"
+    )
+
+    # YouTube section
+    videos = youtube_data.get("videos", [])
+    lines.append(f"\n--- YOUTUBE DATA ({len(videos)} videos) ---")
+
+    total_transcript_chars = 0
+    for v in videos:
+        title = v.get("title", "")
+        views = v.get("views", "N/A")
+        likes = v.get("likes", "N/A")
+        duration = v.get("duration_seconds", "N/A")
+        channel = v.get("channel_name", "N/A")
+
+        lines.append(
+            f"\n[VIDEO] {title}\n"
+            f"  Channel: {channel} | Views: {views} | Likes: {likes} | Duration: {duration}s"
+        )
+
+        # Video description (truncate)
+        desc = v.get("description", "")
+        if desc:
+            if len(desc) > 500:
+                desc = desc[:500] + "..."
+            lines.append(f"  Description: {desc}")
+
+        # Comments
+        comments = v.get("comments", [])
+        if comments:
+            lines.append(f"  Comments ({len(comments)}):")
+            for c in comments[:max_comments]:
+                text = c.get("text", "")
+                if len(text) > 300:
+                    text = text[:300] + "..."
+                lines.append(
+                    f"    [{c.get('author', '?')}, likes:{c.get('likes', 0)}] {text}"
+                )
+
+        # Transcript
+        transcript = v.get("transcript", "")
+        if transcript and total_transcript_chars < max_transcript_chars:
+            remaining = max_transcript_chars - total_transcript_chars
+            if len(transcript) > remaining:
+                transcript = transcript[:remaining] + "..."
+            lines.append(
+                f"  Transcript ({v.get('transcript_lang', '?')}): {transcript}"
+            )
+            total_transcript_chars += len(transcript)
+
+    return "\n".join(lines)
+
+
+def _build_all_topics_text(
+    reddit_data_list: list[dict],
+    youtube_data_list: list[dict],
+    limits,
+) -> str:
+    """Constrói texto completo de todos os tópicos para análise unificada."""
+    sections = []
+    total_chars = 0
+
+    # Cria mapa de youtube_data por topic_name
+    yt_map = {d["topic_name"]: d for d in youtube_data_list}
+
+    for reddit in reddit_data_list:
+        topic_name = reddit.get("topic_name", "")
+        yt = yt_map.get(topic_name, {"topic_name": topic_name, "videos": []})
+
+        section = _build_topic_text(
+            reddit,
+            yt,
+            max_comments=limits.max_comments_per_video,
+            max_transcript_chars=limits.max_transcript_chars,
+        )
+
+        if total_chars + len(section) > limits.max_total_analysis_chars:
+            logger.warning("Truncating topics text at %d chars", total_chars)
+            break
+
+        sections.append(section)
+        total_chars += len(section)
+
+    return "\n\n" + "=" * 60 + "\n\n".join(sections)
+
+
+# ── Node 1: Cross-platform analysis ───────────────────────────────────────
+
+
+def analyze_cross_platform(state: YouTubeValidationState) -> dict:
+    """Nó principal: roteia para unified ou per_topic baseado no provider."""
+    limits = get_youtube_context_limits()
+
+    reddit_data = state.get("topics_reddit_data", [])
+    youtube_data = state.get("topics_youtube_data", [])
+
+    if not reddit_data and not youtube_data:
+        return {"analysis_result": None}
+
+    if limits.analysis_mode == "unified":
+        return _unified_analysis(state, limits)
+    else:
+        return _per_topic_analysis(state, limits)
+
+
+def _unified_analysis(state: YouTubeValidationState, limits) -> dict:
+    """Gemini path: todos os tópicos em 1 chamada LLM."""
+    reddit_data = state.get("topics_reddit_data", [])
+    youtube_data = state.get("topics_youtube_data", [])
+
+    topics_text = _build_all_topics_text(reddit_data, youtube_data, limits)
+    total_videos = sum(len(d.get("videos", [])) for d in youtube_data)
+    total_comments = sum(
+        sum(len(v.get("comments", [])) for v in d.get("videos", []))
+        for d in youtube_data
+    )
+
+    llm = _get_llm()
+    prompt = unified_validation_prompt(
+        audience_name=state["audience_name"],
+        topics_text=topics_text,
+        total_topics=len(reddit_data),
+        total_videos=total_videos,
+        total_comments=total_comments,
+        language=state.get("language", "en"),
+    )
+
+    response = llm.invoke(prompt)
+    content = extract_response_text(response)
+    result = _parse_json_response(content)
+
+    if not result:
+        return {"analysis_result": None}
+
+    logger.info(
+        "Unified cross-platform analysis complete for %d topics", len(reddit_data)
+    )
+    return {"analysis_result": result}
+
+
+def _per_topic_analysis(state: YouTubeValidationState, limits) -> dict:
+    """OpenAI path: 1 chamada LLM por tópico, depois agrega."""
+    reddit_data = state.get("topics_reddit_data", [])
+    youtube_data = state.get("topics_youtube_data", [])
+
+    yt_map = {d["topic_name"]: d for d in youtube_data}
+    llm = _get_llm()
+    topics_results = []
+
+    for reddit in reddit_data:
+        topic_name = reddit.get("topic_name", "")
+        yt = yt_map.get(topic_name, {"topic_name": topic_name, "videos": []})
+
+        topic_text = _build_topic_text(
+            reddit,
+            yt,
+            max_comments=limits.max_comments_per_video,
+            max_transcript_chars=limits.max_transcript_chars,
+        )
+
+        prompt = per_topic_validation_prompt(
+            audience_name=state["audience_name"],
+            topic_name=topic_name,
+            topic_text=topic_text,
+            language=state.get("language", "en"),
+        )
+
+        response = llm.invoke(prompt)
+        content = extract_response_text(response)
+        result = _parse_json_response(content)
+
+        if result:
+            topics_results.append(result)
+        else:
+            logger.warning("Per-topic analysis failed for '%s'", topic_name)
+
+    if not topics_results:
+        return {"analysis_result": None}
+
+    # Aggregate per-topic results
+    traction_scores = [t.get("traction_score", 0) for t in topics_results]
+    avg_traction = sum(traction_scores) / len(traction_scores) if traction_scores else 0
+
+    aggregated = {
+        "topics": topics_results,
+        "cross_platform_summary": {
+            "total_topics_with_traction": sum(1 for s in traction_scores if s >= 5),
+            "avg_traction_score": round(avg_traction, 1),
+            "content_gaps_found": sum(
+                1 for t in topics_results if t.get("content_gap")
+            ),
+            "key_findings": [],
+            "best_opportunity": "",
+            "biggest_divergence": "",
+        },
+    }
+
+    logger.info(
+        "Per-topic cross-platform analysis complete for %d topics",
+        len(topics_results),
+    )
+    return {"analysis_result": aggregated}
+
+
+# ── Node 2: Generate summary ──────────────────────────────────────────────
+
+
+def generate_summary(state: YouTubeValidationState) -> dict:
+    """Gera resumo executivo a partir do resultado completo."""
+    result = state.get("analysis_result")
+    if not result:
+        return {"analysis_summary": None}
+
+    llm = _get_llm()
+    result_text = json.dumps(result, indent=2, ensure_ascii=False)
+
+    # Truncate if too large for summary prompt
+    if len(result_text) > 80_000:
+        result_text = result_text[:80_000] + "\n... (truncated)"
+
+    prompt = summary_prompt(
+        audience_name=state["audience_name"],
+        analysis_result_text=result_text,
+        language=state.get("language", "en"),
+    )
+
+    response = llm.invoke(prompt)
+    content = extract_response_text(response)
+    summary = _parse_json_response(content)
+
+    if not summary:
+        # Fallback: build summary from analysis_result
+        topics = result.get("topics", [])
+        total_videos = sum(t.get("youtube_video_count", 0) for t in topics)
+        traction_scores = [t.get("traction_score", 0) for t in topics]
+        summary = {
+            "topics_analyzed": len(topics),
+            "topics_with_youtube_traction": sum(1 for s in traction_scores if s >= 5),
+            "content_gaps_found": sum(1 for t in topics if t.get("content_gap")),
+            "avg_traction_score": round(sum(traction_scores) / len(traction_scores), 1)
+            if traction_scores
+            else 0,
+            "total_videos_analyzed": total_videos,
+            "total_comments_analyzed": 0,
+        }
+
+    logger.info("Summary generated for cross-platform analysis")
+    return {"analysis_summary": summary}
+
+
+# ── Graph assembly ──────────────────────────────────────────────────────────
+
+
+def create_youtube_validation_agent():
+    """Create the LangGraph agent for YouTube cross-platform validation."""
+    workflow = StateGraph(YouTubeValidationState)
+
+    workflow.add_node("analyze_cross_platform", analyze_cross_platform)
+    workflow.add_node("generate_summary", generate_summary)
+
+    workflow.add_edge(START, "analyze_cross_platform")
+    workflow.add_edge("analyze_cross_platform", "generate_summary")
+    workflow.add_edge("generate_summary", END)
+
+    return workflow.compile()

--- a/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/extract_youtube_validation_use_case.py
+++ b/app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/extract_youtube_validation_use_case.py
@@ -1,0 +1,322 @@
+"""Orchestrates YouTube cross-platform validation: collect, analyze, persist."""
+
+import logging
+import os
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.youtube_validation.application.helpers.youtube_context_limits import (
+    get_youtube_context_limits,
+)
+from app.modules.youtube_validation.application.use_cases.extract_youtube_validation_use_case.agent.youtube_validation_agent import (
+    create_youtube_validation_agent,
+)
+from app.modules.youtube_validation.infra.providers.youtube_provider import (
+    YouTubeProvider,
+)
+from app.modules.youtube_validation.infra.repositories.youtube_validation_repository import (
+    YouTubeValidationRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+_MODEL_ENV = "YOUTUBE_VALIDATION_MODEL_NAME"
+_MODEL_FALLBACK_ENV = "MODEL_NAME"
+_DEFAULT_MODEL = "gpt-5-nano-2025-08-07"
+
+
+class ExtractYouTubeValidationUseCase:
+    """
+    Coleta vídeos YouTube, cruza com dados Reddit e roda análise LLM.
+    Pensado para rodar em background thread.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.validation_repo = YouTubeValidationRepository(db)
+        self.youtube_provider = YouTubeProvider()
+
+    def execute(
+        self,
+        audience_id: UUID,
+        validation_id: UUID,
+        user_id: UUID,
+        language: str = "en",
+    ) -> bool:
+        """
+        Executa a validação cross-platform completa.
+
+        Args:
+            audience_id: ID da audiência
+            validation_id: ID da validação já criada (status: processing)
+            user_id: ID do usuário que disparou
+            language: Idioma preferido do usuário
+
+        Returns:
+            True se concluiu com sucesso
+        """
+        audience = None
+        try:
+            # 1. Buscar audiência e tópicos
+            audience = self.audience_repo.find_by_id(audience_id)
+            if not audience:
+                self.validation_repo.mark_failed(validation_id, "Audience not found")
+                return False
+
+            latest_analysis = self.topic_repo.find_latest_ready(audience_id)
+            if not latest_analysis:
+                self.validation_repo.mark_failed(
+                    validation_id,
+                    "No ready topic analysis found",
+                )
+                return False
+
+            topics = self.topic_repo.get_topics(latest_analysis.id)
+            if not topics:
+                self.validation_repo.mark_failed(validation_id, "No topics found")
+                return False
+
+            limits = get_youtube_context_limits()
+
+            # 2. Coletar dados YouTube por tópico
+            logger.info(
+                "Collecting YouTube data for %d topics (audience %s)",
+                len(topics),
+                audience_id,
+            )
+
+            topics_youtube_data = []
+            all_collected_videos = []
+
+            for topic in topics:
+                videos = self.youtube_provider.collect_for_topic(
+                    topic_name=topic.name,
+                    max_videos=limits.max_videos_per_topic,
+                    max_comments_per_video=limits.max_comments_per_video,
+                    max_videos_with_transcript=limits.max_videos_with_transcript,
+                    max_transcript_chars=limits.max_transcript_chars,
+                )
+
+                topics_youtube_data.append(
+                    {
+                        "topic_name": topic.name,
+                        "videos": videos,
+                    }
+                )
+
+                for v in videos:
+                    all_collected_videos.append(
+                        {
+                            "topic_name": topic.name,
+                            "video_id": v.get("video_id", ""),
+                            "title": v.get("title"),
+                            "channel_name": v.get("channel_name"),
+                            "views": v.get("views"),
+                            "likes": v.get("likes"),
+                            "duration_seconds": v.get("duration_seconds"),
+                            "tags": v.get("tags"),
+                            "description": v.get("description"),
+                            "comments": v.get("comments"),
+                            "transcript": v.get("transcript"),
+                            "transcript_lang": v.get("transcript_lang"),
+                            "published_at": v.get("published_at"),
+                        }
+                    )
+
+            # 3. Persistir vídeos coletados
+            if all_collected_videos:
+                self.validation_repo.save_collected_videos(
+                    validation_id, all_collected_videos
+                )
+
+            total_videos = len(all_collected_videos)
+            total_comments = sum(
+                len(v.get("comments") or []) for v in all_collected_videos
+            )
+
+            logger.info(
+                "Collected %d videos with %d comments for audience %s",
+                total_videos,
+                total_comments,
+                audience_id,
+            )
+
+            # 4. Preparar dados Reddit dos tópicos
+            topics_reddit_data = []
+            for topic in topics:
+                communities = topic.communities or []
+                community_names = [c.get("name", "") for c in communities]
+
+                topics_reddit_data.append(
+                    {
+                        "topic_name": topic.name,
+                        "topic_description": topic.description or "",
+                        "post_count": topic.post_count or 0,
+                        "avg_score": 0,
+                        "community_count": len(communities),
+                        "communities": community_names,
+                    }
+                )
+
+            # 5. Rodar agente LangGraph
+            agent = create_youtube_validation_agent()
+            result = agent.invoke(
+                {
+                    "audience_id": str(audience_id),
+                    "audience_name": audience.name,
+                    "language": language,
+                    "topics_reddit_data": topics_reddit_data,
+                    "topics_youtube_data": topics_youtube_data,
+                    "analysis_result": None,
+                    "analysis_summary": None,
+                }
+            )
+
+            analysis_result = result.get("analysis_result")
+            analysis_summary = result.get("analysis_summary")
+
+            if not analysis_result:
+                self.validation_repo.mark_failed(
+                    validation_id,
+                    "LLM analysis returned no results",
+                )
+                return False
+
+            # 6. Salvar resultado
+            model_used = os.getenv(_MODEL_ENV) or os.getenv(
+                _MODEL_FALLBACK_ENV, _DEFAULT_MODEL
+            )
+            self.validation_repo.mark_ready(
+                validation_id=validation_id,
+                analysis_data=analysis_result,
+                summary=analysis_summary or {},
+                total_videos=total_videos,
+                total_comments=total_comments,
+                model_used=model_used,
+            )
+
+            # 7. Limpar validações antigas
+            self.validation_repo.delete_old_validations(audience_id, keep_latest=2)
+
+            logger.info(
+                "YouTube validation complete for audience %s: "
+                "%d videos, %d comments analyzed",
+                audience_id,
+                total_videos,
+                total_comments,
+            )
+
+            # 8. Avaliar alertas cross-platform
+            self._evaluate_alerts(
+                audience_id=audience_id,
+                validation_id=validation_id,
+                user_id=user_id,
+                audience_name=audience.name,
+                analysis_result=analysis_result,
+            )
+
+            # 9. Notificar usuário
+            self._notify_complete(
+                user_id=user_id,
+                audience_id=audience_id,
+                audience_name=audience.name,
+                validation_id=validation_id,
+            )
+
+            return True
+
+        except Exception as e:
+            logger.exception("YouTube validation failed for audience %s", audience_id)
+            try:
+                self.validation_repo.mark_failed(validation_id, str(e))
+            except Exception:
+                pass
+            try:
+                self._notify_failed(
+                    user_id=user_id,
+                    audience_id=audience_id,
+                    audience_name=audience.name if audience else "",
+                    validation_id=validation_id,
+                    error_message=str(e),
+                )
+            except Exception:
+                pass
+            return False
+
+    def _notify_complete(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        audience_name: str,
+        validation_id: UUID,
+    ) -> None:
+        try:
+            from app.modules.notifications.application.services.notification_event_service import (
+                NotificationEventService,
+            )
+
+            NotificationEventService(self.db).notify_analysis_complete(
+                user_id=user_id,
+                analysis_type="youtube_validation",
+                analysis_id=validation_id,
+                audience_id=audience_id,
+                audience_name=audience_name,
+            )
+        except Exception:
+            logger.debug("Failed to send YouTube validation complete notification")
+
+    def _notify_failed(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        audience_name: str,
+        validation_id: UUID,
+        error_message: str,
+    ) -> None:
+        try:
+            from app.modules.notifications.application.services.notification_event_service import (
+                NotificationEventService,
+            )
+
+            NotificationEventService(self.db).notify_analysis_failed(
+                user_id=user_id,
+                analysis_type="youtube_validation",
+                analysis_id=validation_id,
+                audience_id=audience_id,
+                audience_name=audience_name,
+                error_message=error_message,
+            )
+        except Exception:
+            logger.debug("Failed to send YouTube validation failed notification")
+
+    def _evaluate_alerts(
+        self,
+        audience_id: UUID,
+        validation_id: UUID,
+        user_id: UUID,
+        audience_name: str,
+        analysis_result: dict,
+    ) -> None:
+        try:
+            from app.modules.topic_alerts.application.use_cases.evaluate_alerts_use_case import (
+                EvaluateAlertsUseCase,
+            )
+
+            EvaluateAlertsUseCase(self.db).evaluate_youtube_validation(
+                audience_id=audience_id,
+                validation_id=validation_id,
+                user_id=user_id,
+                audience_name=audience_name,
+                analysis_result=analysis_result,
+            )
+        except Exception:
+            logger.debug("Failed to evaluate cross-platform alerts")

--- a/app/modules/youtube_validation/application/use_cases/trigger_youtube_validation_use_case.py
+++ b/app/modules/youtube_validation/application/use_cases/trigger_youtube_validation_use_case.py
@@ -1,0 +1,148 @@
+"""Triggers YouTube cross-platform validation in background when user requests it."""
+
+import logging
+import threading
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.audience_topics.infra.repositories.audience_topic_repository import (
+    AudienceTopicRepository,
+)
+from app.modules.youtube_validation.infra.repositories.youtube_validation_repository import (
+    YouTubeValidationRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerYouTubeValidationUseCase:
+    """
+    Verifica se a validação YouTube precisa ser processada
+    e dispara em background thread se necessário.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.audience_repo = AudienceRepository(db)
+        self.topic_repo = AudienceTopicRepository(db)
+        self.validation_repo = YouTubeValidationRepository(db)
+
+    def execute(
+        self,
+        audience_id: UUID,
+        user_id: UUID,
+        force: bool = False,
+        language: str = "en",
+    ) -> dict:
+        """
+        Verifica e dispara validação YouTube se necessário.
+
+        Args:
+            audience_id: ID da audiência
+            user_id: ID do usuário
+            force: Se True, ignora fingerprint e força reprocessamento
+            language: Idioma preferido do usuário
+
+        Returns:
+            dict com status e informações
+        """
+        # Verificar se a audiência existe
+        audience = self.audience_repo.find_by_id(audience_id)
+        if not audience:
+            return {"status": "error", "message": "Audience not found"}
+
+        # Verificar se já há validação em processamento
+        latest = self.validation_repo.find_latest_by_audience(audience_id)
+        if latest and latest.status == "processing" and not force:
+            return {
+                "status": "processing",
+                "message": "YouTube validation already in progress.",
+                "validation_id": str(latest.id),
+            }
+
+        # Obter tópicos da audiência para fingerprint
+        latest_analysis = self.topic_repo.find_latest_by_audience(audience_id)
+        if not latest_analysis or latest_analysis.status != "ready":
+            return {
+                "status": "error",
+                "message": "No topic analysis available. Run topic analysis first.",
+            }
+
+        topics = self.topic_repo.get_topics(latest_analysis.id)
+        if not topics:
+            return {
+                "status": "error",
+                "message": "No topics found for this audience.",
+            }
+
+        # Gerar fingerprint
+        topic_names = [t.name for t in topics]
+        fingerprint = YouTubeValidationRepository.generate_fingerprint(
+            audience_id, topic_names
+        )
+
+        # Se não forçar, verificar se já existe validação com mesmo fingerprint
+        if not force:
+            existing = self.validation_repo.find_by_fingerprint(
+                audience_id, fingerprint
+            )
+            if existing:
+                return {
+                    "status": existing.status,
+                    "message": f"Existing validation (status={existing.status}).",
+                    "validation_id": str(existing.id),
+                }
+
+        # Criar registro de validação com status "processing"
+        validation = self.validation_repo.create_validation(
+            audience_id, user_id, fingerprint
+        )
+        logger.info(
+            "Triggering YouTube validation for audience %s (validation %s)",
+            audience_id,
+            validation.id,
+        )
+
+        # Disparar em background
+        self._run_in_background(audience_id, validation.id, user_id, language)
+
+        return {
+            "status": "processing",
+            "message": "YouTube validation started. Check back in a few minutes.",
+            "validation_id": str(validation.id),
+            "topics_count": len(topics),
+        }
+
+    def _run_in_background(
+        self,
+        audience_id: UUID,
+        validation_id: UUID,
+        user_id: UUID,
+        language: str = "en",
+    ) -> None:
+        """Dispara validação YouTube em background thread."""
+        from app.modules.shared.infra.database.database import SessionLocal
+
+        def background_task():
+            db = SessionLocal()
+            try:
+                from app.modules.youtube_validation.application.use_cases.extract_youtube_validation_use_case.extract_youtube_validation_use_case import (
+                    ExtractYouTubeValidationUseCase,
+                )
+
+                use_case = ExtractYouTubeValidationUseCase(db)
+                use_case.execute(audience_id, validation_id, user_id, language=language)
+            except Exception:
+                logger.exception(
+                    "Background YouTube validation failed for audience %s",
+                    audience_id,
+                )
+            finally:
+                db.close()
+
+        thread = threading.Thread(target=background_task, daemon=True)
+        thread.start()

--- a/app/modules/youtube_validation/domain/entities/youtube_validation.py
+++ b/app/modules/youtube_validation/domain/entities/youtube_validation.py
@@ -1,0 +1,109 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import relationship
+
+from app.modules.shared.infra.database.orm.metadata import Base
+
+
+class YouTubeValidation(Base):
+    """
+    Registro de uma validação cross-platform YouTube para uma audiência.
+    Criado quando o usuário dispara a análise YouTube Validation.
+    """
+
+    __tablename__ = "youtube_validations"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    audience_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audiences.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(
+        String(20), nullable=False, default="processing", index=True
+    )  # processing, ready, failed
+    fingerprint = Column(String(64), nullable=False, index=True)
+    analysis_data = Column(JSON, nullable=True)  # resultado completo da análise LLM
+    summary = Column(JSON, nullable=True)  # resumo executivo
+    total_videos = Column(Integer, nullable=True, default=0)
+    total_comments = Column(Integer, nullable=True, default=0)
+    model_used = Column(String(100), nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    collected_videos = relationship(
+        "YouTubeCollectedVideo",
+        back_populates="validation",
+        cascade="all, delete-orphan",
+    )
+
+
+class YouTubeCollectedVideo(Base):
+    """
+    Vídeo coletado do YouTube durante a validação cross-platform.
+    Persiste metadados, comentários e transcrições para re-análise futura.
+    """
+
+    __tablename__ = "youtube_collected_videos"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    validation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("youtube_validations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    topic_name = Column(String(255), nullable=False)
+    video_id = Column(String(20), nullable=False)
+    title = Column(Text, nullable=True)
+    channel_name = Column(Text, nullable=True)
+    views = Column(Integer, nullable=True)
+    likes = Column(Integer, nullable=True)
+    duration_seconds = Column(Integer, nullable=True)
+    tags = Column(JSON, nullable=True)
+    description = Column(Text, nullable=True)
+    comments = Column(JSON, nullable=True)  # [{author, text, likes, published_at}]
+    transcript = Column(Text, nullable=True)
+    transcript_lang = Column(String(10), nullable=True)
+    published_at = Column(DateTime(timezone=True), nullable=True)
+    collected_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    validation = relationship("YouTubeValidation", back_populates="collected_videos")
+
+    __table_args__ = (
+        Index("ix_yt_collected_validation_topic", "validation_id", "topic_name"),
+        Index(
+            "ix_yt_collected_unique",
+            "validation_id",
+            "video_id",
+            unique=True,
+        ),
+    )

--- a/app/modules/youtube_validation/infra/providers/youtube_provider.py
+++ b/app/modules/youtube_validation/infra/providers/youtube_provider.py
@@ -1,0 +1,381 @@
+"""YouTube data collection provider.
+
+Combines three sources:
+- YouTube Data API v3: ONLY for search (100 quota units/request)
+- yt-dlp: metadata + comments (free, no quota)
+- youtube-transcript-api: transcripts (free, no quota)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+TRANSCRIPT_LANG_PRIORITY = ["pt-BR", "pt", "en"]
+_RATE_LIMIT_DELAY = 1.5  # seconds between yt-dlp requests
+
+
+class YouTubeProvider:
+    """Facade unificada para coleta de dados do YouTube."""
+
+    def __init__(self):
+        self._api_key = settings.youtube_api_key
+        self._last_request_time: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Rate limiting
+    # ------------------------------------------------------------------
+
+    def _respect_rate_limit(self) -> None:
+        """Respeita rate limit entre requests yt-dlp (1.5s)."""
+        elapsed = time.time() - self._last_request_time
+        if elapsed < _RATE_LIMIT_DELAY:
+            time.sleep(_RATE_LIMIT_DELAY - elapsed)
+        self._last_request_time = time.time()
+
+    # ------------------------------------------------------------------
+    # YouTube Data API v3 (search only — 100 units/request)
+    # ------------------------------------------------------------------
+
+    def search_videos(
+        self,
+        query: str,
+        max_results: int = 20,
+        published_after_days: int = 30,
+        region_code: str = "US",
+    ) -> list[dict]:
+        """Busca vídeos no YouTube via API v3.
+
+        Retorna lista de {video_id, title, channel_name, published_at}.
+        Usa apenas o endpoint search/list (100 units por request).
+        """
+        if not self._api_key:
+            logger.warning("YouTube API key not configured, skipping search")
+            return []
+
+        try:
+            published_after = (
+                datetime.now(timezone.utc) - timedelta(days=published_after_days)
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            response = requests.get(
+                "https://www.googleapis.com/youtube/v3/search",
+                params={
+                    "part": "snippet",
+                    "q": query,
+                    "type": "video",
+                    "order": "relevance",
+                    "maxResults": min(max_results, 50),
+                    "publishedAfter": published_after,
+                    "regionCode": region_code,
+                    "key": self._api_key,
+                },
+                timeout=15,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            results = []
+            for item in data.get("items", []):
+                snippet = item.get("snippet", {})
+                results.append(
+                    {
+                        "video_id": item["id"]["videoId"],
+                        "title": snippet.get("title", ""),
+                        "channel_name": snippet.get("channelTitle", ""),
+                        "published_at": snippet.get("publishedAt", ""),
+                    }
+                )
+            return results
+
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 403:
+                logger.warning("YouTube API quota exceeded or forbidden: %s", e)
+            else:
+                logger.error("YouTube API search error: %s", e)
+            return []
+        except Exception as e:
+            logger.error("YouTube API search failed: %s", e)
+            return []
+
+    # ------------------------------------------------------------------
+    # yt-dlp — metadata (free, no quota)
+    # ------------------------------------------------------------------
+
+    def get_video_metadata(self, video_id: str) -> dict | None:
+        """Extrai metadados do vídeo via yt-dlp.
+
+        Retorna dict com: video_id, title, channel_name, views, likes,
+        duration_seconds, tags, description, published_at.
+        """
+        try:
+            import yt_dlp
+
+            self._respect_rate_limit()
+
+            ydl_opts = {
+                "quiet": True,
+                "no_warnings": True,
+                "skip_download": True,
+                "extract_flat": False,
+            }
+
+            url = f"https://www.youtube.com/watch?v={video_id}"
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=False)
+
+            if not info:
+                return None
+
+            published_at = info.get("upload_date")
+            if published_at and len(published_at) == 8:
+                published_at = (
+                    f"{published_at[:4]}-{published_at[4:6]}-{published_at[6:8]}"
+                    "T00:00:00Z"
+                )
+
+            return {
+                "video_id": video_id,
+                "title": info.get("title", ""),
+                "channel_name": info.get("uploader", "") or info.get("channel", ""),
+                "views": info.get("view_count"),
+                "likes": info.get("like_count"),
+                "duration_seconds": info.get("duration"),
+                "tags": info.get("tags") or [],
+                "description": info.get("description", ""),
+                "published_at": published_at,
+            }
+        except Exception as e:
+            logger.debug("yt-dlp metadata extraction failed for %s: %s", video_id, e)
+            return None
+
+    # ------------------------------------------------------------------
+    # yt-dlp — comments (free, no quota, with fallbacks)
+    # ------------------------------------------------------------------
+
+    def get_video_comments(self, video_id: str, max_comments: int = 100) -> list[dict]:
+        """Extrai comentários do vídeo via yt-dlp com fallbacks.
+
+        Strategy 1: yt-dlp com getcomments + extractor_args
+        Strategy 2: yt-dlp simplificado (sem extractor_args)
+
+        Retorna lista de {author, text, likes}.
+        """
+        comments = self._get_comments_strategy_1(video_id, max_comments)
+        if comments:
+            return comments
+
+        comments = self._get_comments_strategy_2(video_id, max_comments)
+        if comments:
+            return comments
+
+        logger.debug("All comment strategies failed for %s", video_id)
+        return []
+
+    def _get_comments_strategy_1(self, video_id: str, max_comments: int) -> list[dict]:
+        """yt-dlp com getcomments e extractor_args."""
+        try:
+            import yt_dlp
+
+            self._respect_rate_limit()
+
+            ydl_opts = {
+                "quiet": True,
+                "no_warnings": True,
+                "skip_download": True,
+                "getcomments": True,
+                "extractor_args": {"youtube": {"max_comments": [str(max_comments)]}},
+            }
+
+            url = f"https://www.youtube.com/watch?v={video_id}"
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=False)
+
+            if not info:
+                return []
+
+            return self._parse_yt_dlp_comments(info.get("comments") or [], max_comments)
+        except Exception as e:
+            logger.debug("Comment strategy 1 failed for %s: %s", video_id, e)
+            return []
+
+    def _get_comments_strategy_2(self, video_id: str, max_comments: int) -> list[dict]:
+        """yt-dlp simplificado sem extractor_args."""
+        try:
+            import yt_dlp
+
+            self._respect_rate_limit()
+
+            ydl_opts = {
+                "quiet": True,
+                "no_warnings": True,
+                "skip_download": True,
+                "getcomments": True,
+            }
+
+            url = f"https://www.youtube.com/watch?v={video_id}"
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=False)
+
+            if not info:
+                return []
+
+            return self._parse_yt_dlp_comments(info.get("comments") or [], max_comments)
+        except Exception as e:
+            logger.debug("Comment strategy 2 failed for %s: %s", video_id, e)
+            return []
+
+    @staticmethod
+    def _parse_yt_dlp_comments(
+        raw_comments: list[dict], max_comments: int
+    ) -> list[dict]:
+        """Normaliza comentários do yt-dlp para formato padrão."""
+        parsed = []
+        for c in raw_comments[:max_comments]:
+            parsed.append(
+                {
+                    "author": c.get("author", ""),
+                    "text": c.get("text", ""),
+                    "likes": c.get("like_count", 0) or 0,
+                }
+            )
+        return parsed
+
+    # ------------------------------------------------------------------
+    # youtube-transcript-api — transcripts (free, no quota)
+    # ------------------------------------------------------------------
+
+    def get_transcript(
+        self,
+        video_id: str,
+        preferred_langs: list[str] | None = None,
+    ) -> tuple[str, str] | None:
+        """Obtém transcrição do vídeo com fallback de idioma.
+
+        Tenta: pt-BR -> pt -> en -> qualquer disponível.
+        Retorna (transcript_text, language_code) ou None.
+        """
+        langs = preferred_langs or TRANSCRIPT_LANG_PRIORITY
+
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+
+            # Tenta idiomas na ordem de prioridade
+            for lang in langs:
+                try:
+                    transcript = transcript_list.find_transcript([lang])
+                    segments = transcript.fetch()
+                    text = " ".join(s.get("text", "") for s in segments)
+                    return (text.strip(), lang)
+                except Exception:
+                    continue
+
+            # Fallback: qualquer idioma disponível
+            try:
+                for transcript in transcript_list:
+                    segments = transcript.fetch()
+                    text = " ".join(s.get("text", "") for s in segments)
+                    return (text.strip(), transcript.language_code)
+            except Exception:
+                pass
+
+            return None
+
+        except Exception as e:
+            logger.debug("Transcript extraction failed for %s: %s", video_id, e)
+            return None
+
+    # ------------------------------------------------------------------
+    # High-level: collect all data for a topic
+    # ------------------------------------------------------------------
+
+    def collect_for_topic(
+        self,
+        topic_name: str,
+        max_videos: int = 20,
+        max_comments_per_video: int = 100,
+        max_videos_with_transcript: int = 10,
+        max_transcript_chars: int = 50_000,
+    ) -> list[dict]:
+        """Pipeline completa de coleta para um tópico.
+
+        1. Busca vídeos via API v3
+        2. Para cada vídeo: metadata + comments + transcript
+        3. Retorna lista de dicts com dados completos
+
+        Args:
+            topic_name: Nome do tópico para buscar no YouTube.
+            max_videos: Máximo de vídeos a buscar.
+            max_comments_per_video: Máximo de comentários por vídeo.
+            max_videos_with_transcript: Quantos vídeos terão transcrição coletada.
+            max_transcript_chars: Máximo de caracteres de transcrição por vídeo.
+
+        Returns:
+            Lista de dicts com dados completos do vídeo.
+        """
+        search_results = self.search_videos(topic_name, max_results=max_videos)
+
+        if not search_results:
+            logger.info("No YouTube videos found for topic '%s'", topic_name)
+            return []
+
+        collected = []
+        videos_with_transcript = 0
+
+        for i, search_item in enumerate(search_results):
+            video_id = search_item["video_id"]
+
+            # Metadata via yt-dlp (enriches search results)
+            metadata = self.get_video_metadata(video_id)
+            if metadata:
+                video_data = metadata
+            else:
+                # Fallback: use search snippet data
+                video_data = {
+                    "video_id": video_id,
+                    "title": search_item.get("title", ""),
+                    "channel_name": search_item.get("channel_name", ""),
+                    "views": None,
+                    "likes": None,
+                    "duration_seconds": None,
+                    "tags": [],
+                    "description": "",
+                    "published_at": search_item.get("published_at", ""),
+                }
+
+            # Comments
+            comments = self.get_video_comments(video_id, max_comments_per_video)
+            video_data["comments"] = comments
+
+            # Transcript (only for top N videos by position)
+            transcript = None
+            transcript_lang = None
+            if videos_with_transcript < max_videos_with_transcript:
+                result = self.get_transcript(video_id)
+                if result:
+                    transcript, transcript_lang = result
+                    if len(transcript) > max_transcript_chars:
+                        transcript = transcript[:max_transcript_chars]
+                    videos_with_transcript += 1
+
+            video_data["transcript"] = transcript
+            video_data["transcript_lang"] = transcript_lang
+
+            collected.append(video_data)
+
+        logger.info(
+            "Collected %d videos for topic '%s' (%d with transcripts)",
+            len(collected),
+            topic_name,
+            videos_with_transcript,
+        )
+        return collected

--- a/app/modules/youtube_validation/infra/repositories/youtube_validation_repository.py
+++ b/app/modules/youtube_validation/infra/repositories/youtube_validation_repository.py
@@ -1,0 +1,196 @@
+import hashlib
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.modules.youtube_validation.domain.entities.youtube_validation import (
+    YouTubeCollectedVideo,
+    YouTubeValidation,
+)
+
+
+class YouTubeValidationRepository:
+    """Repositório para operações com validações YouTube cross-platform."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    @staticmethod
+    def generate_fingerprint(audience_id: UUID, topic_names: list[str]) -> str:
+        """Gera fingerprint SHA256 da audiência + tópicos."""
+        sorted_names = sorted(n.lower() for n in topic_names)
+        content = f"{audience_id}:" + ":".join(sorted_names)
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def find_latest_by_audience(self, audience_id: UUID) -> YouTubeValidation | None:
+        """Busca a validação mais recente (qualquer status) para a audiência."""
+        return (
+            self.db.query(YouTubeValidation)
+            .filter(YouTubeValidation.audience_id == audience_id)
+            .order_by(YouTubeValidation.created_at.desc())
+            .first()
+        )
+
+    def find_by_fingerprint(
+        self, audience_id: UUID, fingerprint: str
+    ) -> YouTubeValidation | None:
+        """Busca validação por fingerprint (mesma composição de tópicos)."""
+        return (
+            self.db.query(YouTubeValidation)
+            .filter(
+                YouTubeValidation.audience_id == audience_id,
+                YouTubeValidation.fingerprint == fingerprint,
+                YouTubeValidation.status.in_(["ready", "processing"]),
+            )
+            .order_by(YouTubeValidation.created_at.desc())
+            .first()
+        )
+
+    def create_validation(
+        self, audience_id: UUID, user_id: UUID, fingerprint: str
+    ) -> YouTubeValidation:
+        """Cria um novo registro de validação com status 'processing'."""
+        validation = YouTubeValidation(
+            audience_id=audience_id,
+            user_id=user_id,
+            fingerprint=fingerprint,
+            status="processing",
+        )
+        self.db.add(validation)
+        self.db.commit()
+        self.db.refresh(validation)
+        return validation
+
+    def mark_ready(
+        self,
+        validation_id: UUID,
+        analysis_data: dict,
+        summary: dict,
+        total_videos: int,
+        total_comments: int,
+        model_used: str,
+    ) -> YouTubeValidation | None:
+        """Marca validação como pronta e salva resultados."""
+        validation = (
+            self.db.query(YouTubeValidation)
+            .filter(YouTubeValidation.id == validation_id)
+            .first()
+        )
+        if not validation:
+            return None
+
+        validation.status = "ready"
+        validation.analysis_data = analysis_data
+        validation.summary = summary
+        validation.total_videos = total_videos
+        validation.total_comments = total_comments
+        validation.model_used = model_used
+        validation.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(validation)
+        return validation
+
+    def mark_failed(
+        self, validation_id: UUID, error_message: str
+    ) -> YouTubeValidation | None:
+        """Marca validação como falha."""
+        validation = (
+            self.db.query(YouTubeValidation)
+            .filter(YouTubeValidation.id == validation_id)
+            .first()
+        )
+        if not validation:
+            return None
+
+        validation.status = "failed"
+        validation.error_message = error_message
+        validation.completed_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(validation)
+        return validation
+
+    def save_collected_videos(self, validation_id: UUID, videos: list[dict]) -> int:
+        """Salva vídeos coletados em batch. Retorna quantidade inserida."""
+        objects = []
+        seen_video_ids: set[str] = set()
+
+        for v in videos:
+            vid = v.get("video_id", "")
+            if vid in seen_video_ids:
+                continue
+            seen_video_ids.add(vid)
+
+            published_at = v.get("published_at")
+            if isinstance(published_at, str) and published_at:
+                try:
+                    published_at = datetime.fromisoformat(
+                        published_at.replace("Z", "+00:00")
+                    )
+                except (ValueError, TypeError):
+                    published_at = None
+            elif not isinstance(published_at, datetime):
+                published_at = None
+
+            objects.append(
+                YouTubeCollectedVideo(
+                    validation_id=validation_id,
+                    topic_name=v.get("topic_name", ""),
+                    video_id=vid,
+                    title=v.get("title"),
+                    channel_name=v.get("channel_name"),
+                    views=v.get("views"),
+                    likes=v.get("likes"),
+                    duration_seconds=v.get("duration_seconds"),
+                    tags=v.get("tags"),
+                    description=v.get("description"),
+                    comments=v.get("comments"),
+                    transcript=v.get("transcript"),
+                    transcript_lang=v.get("transcript_lang"),
+                    published_at=published_at,
+                )
+            )
+
+        if objects:
+            self.db.add_all(objects)
+            self.db.commit()
+        return len(objects)
+
+    def get_collected_videos_by_topic(
+        self, validation_id: UUID, topic_name: str
+    ) -> list[YouTubeCollectedVideo]:
+        """Busca vídeos coletados de um tópico específico."""
+        return (
+            self.db.query(YouTubeCollectedVideo)
+            .filter(
+                YouTubeCollectedVideo.validation_id == validation_id,
+                YouTubeCollectedVideo.topic_name == topic_name,
+            )
+            .order_by(YouTubeCollectedVideo.views.desc().nullslast())
+            .all()
+        )
+
+    def delete_old_validations(self, audience_id: UUID, keep_latest: int = 2) -> int:
+        """Remove validações antigas, mantendo as N mais recentes."""
+        latest_ids = (
+            self.db.query(YouTubeValidation.id)
+            .filter(YouTubeValidation.audience_id == audience_id)
+            .order_by(YouTubeValidation.created_at.desc())
+            .limit(keep_latest)
+            .all()
+        )
+        keep_ids = [row[0] for row in latest_ids]
+
+        if not keep_ids:
+            return 0
+
+        deleted = (
+            self.db.query(YouTubeValidation)
+            .filter(
+                YouTubeValidation.audience_id == audience_id,
+                YouTubeValidation.id.notin_(keep_ids),
+            )
+            .delete(synchronize_session="fetch")
+        )
+        self.db.commit()
+        return deleted

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -25,6 +25,7 @@ from app.routes.content_suggestions import router as content_suggestions_router
 from app.routes.intent_ask import router as intent_ask_router
 from app.routes.intent_chat import router as intent_chat_router
 from app.routes.semantic_search import router as semantic_search_router
+from app.routes.youtube_validation import router as youtube_validation_router
 
 __all__ = [
     "auth_router",
@@ -50,4 +51,5 @@ __all__ = [
     "intent_ask_router",
     "intent_chat_router",
     "semantic_search_router",
+    "youtube_validation_router",
 ]

--- a/app/routes/youtube_validation.py
+++ b/app/routes/youtube_validation.py
@@ -1,0 +1,182 @@
+"""Routes for YouTube cross-platform validation."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.modules.youtube_validation.application.use_cases.trigger_youtube_validation_use_case import (
+    TriggerYouTubeValidationUseCase,
+)
+from app.modules.youtube_validation.infra.repositories.youtube_validation_repository import (
+    YouTubeValidationRepository,
+)
+from app.modules.audiences.infra.repositories.audience_repository import (
+    AudienceRepository,
+)
+from app.modules.identity.dependencies import get_current_user
+from app.modules.identity.domain.entities.user import User
+from app.modules.shared.infra.database.database import get_db
+
+router = APIRouter(prefix="/audiences", tags=["YouTube Validation"])
+
+AUDIENCE_NOT_FOUND = "Audience not found"
+
+
+def _check_ownership(audience, current_user: User) -> None:
+    """Valida que o usuário é dono da audiência ou superuser."""
+    if current_user.is_superuser:
+        return
+    if audience.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Acesso negado")
+
+
+@router.post("/{audience_id}/youtube-validation", status_code=202)
+def trigger_youtube_validation(
+    audience_id: UUID,
+    force: bool = False,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Dispara validação cross-platform YouTube para a audiência.
+
+    Coleta vídeos, comentários e transcrições do YouTube para cada tópico
+    e cruza com dados Reddit existentes. Retorna 202 indicando que o
+    processamento está em andamento.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    trigger = TriggerYouTubeValidationUseCase(db)
+    result = trigger.execute(
+        audience_id=audience_id,
+        user_id=current_user.id,
+        force=force,
+        language=current_user.preferred_language,
+    )
+
+    return result
+
+
+@router.get("/{audience_id}/youtube-validation")
+def get_youtube_validation(
+    audience_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Retorna o resultado mais recente da validação YouTube.
+
+    Retorna status: no_analysis | processing | failed | ready.
+    Quando ready, inclui analysis_data e summary.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    validation_repo = YouTubeValidationRepository(db)
+    latest = validation_repo.find_latest_by_audience(audience_id)
+
+    if not latest:
+        return {
+            "status": "no_analysis",
+            "message": "No YouTube validation found. Trigger one first.",
+            "audience_id": str(audience_id),
+        }
+
+    if latest.status == "processing":
+        return {
+            "status": "processing",
+            "message": "YouTube validation in progress. Check back in a few minutes.",
+            "validation_id": str(latest.id),
+            "audience_id": str(audience_id),
+        }
+
+    if latest.status == "failed":
+        return {
+            "status": "failed",
+            "message": f"Validation failed: {latest.error_message or 'unknown error'}",
+            "validation_id": str(latest.id),
+            "audience_id": str(audience_id),
+        }
+
+    return {
+        "status": "ready",
+        "validation_id": str(latest.id),
+        "audience_id": str(audience_id),
+        "completed_at": (
+            latest.completed_at.isoformat() if latest.completed_at else None
+        ),
+        "model_used": latest.model_used,
+        "total_videos": latest.total_videos,
+        "total_comments": latest.total_comments,
+        "analysis_data": latest.analysis_data,
+        "summary": latest.summary,
+    }
+
+
+@router.get("/{audience_id}/youtube-validation/{topic_name}/videos")
+def get_youtube_validation_videos(
+    audience_id: UUID,
+    topic_name: str,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Retorna vídeos coletados para um tópico específico da validação mais recente.
+
+    Útil para browse detalhado dos vídeos por tópico.
+    """
+    audience_repo = AudienceRepository(db)
+    audience = audience_repo.find_by_id(audience_id)
+    if not audience:
+        raise HTTPException(status_code=404, detail=AUDIENCE_NOT_FOUND)
+
+    _check_ownership(audience, current_user)
+
+    validation_repo = YouTubeValidationRepository(db)
+    latest = validation_repo.find_latest_by_audience(audience_id)
+
+    if not latest or latest.status != "ready":
+        return {
+            "status": "no_data",
+            "message": "No ready YouTube validation found.",
+            "topic_name": topic_name,
+            "videos": [],
+        }
+
+    videos = validation_repo.get_collected_videos_by_topic(latest.id, topic_name)
+
+    return {
+        "status": "ready",
+        "validation_id": str(latest.id),
+        "topic_name": topic_name,
+        "videos_count": len(videos),
+        "videos": [
+            {
+                "id": str(v.id),
+                "video_id": v.video_id,
+                "title": v.title,
+                "channel_name": v.channel_name,
+                "views": v.views,
+                "likes": v.likes,
+                "duration_seconds": v.duration_seconds,
+                "tags": v.tags,
+                "description": v.description,
+                "comments_count": len(v.comments) if v.comments else 0,
+                "has_transcript": v.transcript is not None,
+                "transcript_lang": v.transcript_lang,
+                "published_at": (
+                    v.published_at.isoformat() if v.published_at else None
+                ),
+            }
+            for v in videos
+        ],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,6 @@ dependencies = [
     "ruff>=0.15.1",
     "sqlalchemy>=2.0.46",
     "uvicorn>=0.34.0",
+    "yt-dlp>=2024.12.0",
+    "youtube-transcript-api>=0.6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -346,6 +346,8 @@ dependencies = [
     { name = "ruff" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
+    { name = "youtube-transcript-api" },
+    { name = "yt-dlp" },
 ]
 
 [package.metadata]
@@ -374,6 +376,8 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.15.1" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
     { name = "uvicorn", specifier = ">=0.34.0" },
+    { name = "youtube-transcript-api", specifier = ">=0.6.0" },
+    { name = "yt-dlp", specifier = ">=2024.12.0" },
 ]
 
 [[package]]
@@ -427,6 +431,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
     { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
     { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1955,6 +1968,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
     { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
     { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/6f/7427d23609353e5ef3470ff43ef551b8bd7b166dd4fef48957f0d0e040fe/yt_dlp-2026.3.3.tar.gz", hash = "sha256:3db7969e3a8964dc786bdebcffa2653f31123bf2a630f04a17bdafb7bbd39952", size = 3118658, upload-time = "2026-03-03T16:54:53.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/a4/8b5cd28ab87aef48ef15e74241befec3445496327db028f34147a9e0f14f/yt_dlp-2026.3.3-py3-none-any.whl", hash = "sha256:166c6e68c49ba526474bd400e0129f58aa522c2896204aa73be669c3d2f15e63", size = 3315599, upload-time = "2026-03-03T16:54:51.899Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add complete YouTube Intelligence Module that cross-validates audience topics against YouTube data (videos, comments, transcripts)
- YouTube Provider facade: API v3 search (100 units/req) + yt-dlp for metadata/comments (free) + youtube-transcript-api for transcripts (free)
- LangGraph agent with dual analysis mode: unified (Gemini 2M context) or per-topic (OpenAI 128K context)
- Dual-table persistence (youtube_validations + youtube_collected_videos) with fingerprint deduplication
- 3 API endpoints: POST trigger, GET result, GET videos by topic
- Integration with SSE notifications (complete/failed events) and Topic Alerts (cross-platform severity classification)

## New Files (11)
- `app/modules/youtube_validation/domain/entities/youtube_validation.py` — YouTubeValidation + YouTubeCollectedVideo entities
- `app/modules/youtube_validation/infra/providers/youtube_provider.py` — YouTube data collection facade
- `app/modules/youtube_validation/infra/repositories/youtube_validation_repository.py` — CRUD repository
- `app/modules/youtube_validation/application/helpers/youtube_context_limits.py` — Provider-specific context limits
- `app/modules/youtube_validation/application/use_cases/trigger_youtube_validation_use_case.py` — Trigger with background thread
- `app/modules/youtube_validation/application/use_cases/extract_youtube_validation_use_case/` — Main orchestrator + LangGraph agent
- `app/routes/youtube_validation.py` — 3 endpoints under /audiences prefix
- `alembic/versions/b2c3d4e5f6a7_add_youtube_validation_tables.py` — Migration for 2 tables

## Modified Files (8)
- `pyproject.toml` — Added yt-dlp, youtube-transcript-api dependencies
- `alembic/env.py` — Registered new entities
- `app/routes/__init__.py` + `app/main.py` — Registered youtube_validation_router
- `notification_event_service.py` — Added "youtube_validation" to _TYPE_LABELS
- `alert_rules.py` — Added classify_cross_platform_severity()
- `evaluate_alerts_use_case.py` — Added evaluate_youtube_validation() method

## Test plan
- [ ] Run `make migrate` to create youtube_validations + youtube_collected_videos tables
- [ ] Verify `make migrate-down` + `make migrate` (up/down/up cycle)
- [ ] POST `/{audience_id}/youtube-validation` — verify status=processing returned
- [ ] GET `/{audience_id}/youtube-validation` — verify result with analysis_data + summary
- [ ] GET `/{audience_id}/youtube-validation/{topic_name}/videos` — verify collected videos
- [ ] Verify SSE notification received on completion (youtube_validation_complete)
- [ ] Verify cross-platform alerts generated for topics with traction >= 7
- [ ] Test without YOUTUBE_API_KEY — should degrade gracefully (no search results, no crash)
- [ ] Run `make lint` — all checks pass
- [ ] Run `make format` — no formatting issues in new files

Closes #77