### PR TITLE
feat: i18n support for notification messages (pt-BR)

### DIFF
--- a/app/modules/audiences/application/use_cases/manage_audience_use_case.py
+++ b/app/modules/audiences/application/use_cases/manage_audience_use_case.py
@@ -155,19 +155,11 @@ class UpdateAudienceUseCase:
             self.trigger_topics.execute(audience_id)
             self.trigger_keywords.execute(audience_id)
 
-            self.notification_service.notify(
+            self.notification_service.notify_communities_updated(
                 user_id=user_id,
-                type_="communities_changed",
-                title="Communities Updated",
-                message=(
-                    f"Audience communities updated: "
-                    f"{len(to_add)} added, {len(to_remove)} removed."
-                ),
-                metadata={
-                    "audience_id": str(audience_id),
-                    "added": sorted(to_add),
-                    "removed": sorted(to_remove),
-                },
+                audience_id=audience_id,
+                added=list(to_add),
+                removed=list(to_remove),
             )
 
             for name in to_remove:

--- a/app/modules/audiences/application/use_cases/validate_communities_use_case.py
+++ b/app/modules/audiences/application/use_cases/validate_communities_use_case.py
@@ -48,16 +48,8 @@ class ValidateCommunitiesUseCase:
 
         self.audience_repo.remove_communities_by_names(audience_id, invalid_names)
 
-        self.notification_service.notify(
+        self.notification_service.notify_communities_invalid(
             user_id=user_id,
-            type_="communities_validation_failed",
-            title="Invalid Communities Removed",
-            message=(
-                f"The following communities were not found on Reddit and have been "
-                f"removed: {', '.join(invalid_names)}"
-            ),
-            metadata={
-                "audience_id": str(audience_id),
-                "invalid_names": invalid_names,
-            },
+            audience_id=audience_id,
+            invalid_names=invalid_names,
         )

--- a/app/modules/content_suggestions/application/use_cases/generate_suggestions_use_case/generate_suggestions_use_case.py
+++ b/app/modules/content_suggestions/application/use_cases/generate_suggestions_use_case/generate_suggestions_use_case.py
@@ -61,7 +61,9 @@ class GenerateSuggestionsUseCase:
             community_names = [c.subreddit_name for c in communities]
 
             if not community_names:
-                self.suggestion_repo.mark_failed(analysis_id, "No communities in audience")
+                self.suggestion_repo.mark_failed(
+                    analysis_id, "No communities in audience"
+                )
                 return False
 
             # 2. Montar contexto de todos os módulos
@@ -89,20 +91,22 @@ class GenerateSuggestionsUseCase:
                 os.getenv("MODEL_NAME", "gpt-5-nano-2025-08-07"),
             )
 
-            result = agent.invoke({
-                "audience_id": str(audience_id),
-                "audience_name": audience.name,
-                "audience_description": audience.description,
-                "community_names": community_names,
-                "language": language,
-                "assembled_context": assembled_context,
-                "modules_available": modules_available,
-                "topic_contexts": topic_contexts,
-                "ranked_opportunities": [],
-                "content_suggestions": [],
-                "differentiated_suggestions": [],
-                "verified_suggestions": [],
-            })
+            result = agent.invoke(
+                {
+                    "audience_id": str(audience_id),
+                    "audience_name": audience.name,
+                    "audience_description": audience.description,
+                    "community_names": community_names,
+                    "language": language,
+                    "assembled_context": assembled_context,
+                    "modules_available": modules_available,
+                    "topic_contexts": topic_contexts,
+                    "ranked_opportunities": [],
+                    "content_suggestions": [],
+                    "differentiated_suggestions": [],
+                    "verified_suggestions": [],
+                }
+            )
 
             verified = result.get("verified_suggestions", [])
 
@@ -138,15 +142,13 @@ class GenerateSuggestionsUseCase:
                 )
 
                 top_title = verified[0].get("title", "N/A") if verified else "N/A"
-                NotificationEventService(self.db).notify(
+                NotificationEventService(self.db).notify_content_suggestions_ready(
                     user_id=audience.user_id,
-                    type_="content_suggestions_ready",
-                    title="Content Suggestions Ready",
-                    message=f"Generated {len(verified)} content suggestions for audience '{audience.name}'.",
-                    metadata={
-                        "audience_id": str(audience_id),
-                        "analysis_id": str(analysis_id),
-                        "suggestion_count": len(verified),
+                    audience_id=audience_id,
+                    audience_name=audience.name,
+                    analysis_id=analysis_id,
+                    suggestion_count=len(verified),
+                    metadata_extra={
                         "top_suggestion_title": top_title,
                         "modules_used": modules_available,
                     },
@@ -171,16 +173,12 @@ class GenerateSuggestionsUseCase:
                         NotificationEventService,
                     )
 
-                    NotificationEventService(self.db).notify(
+                    NotificationEventService(self.db).notify_content_suggestions_failed(
                         user_id=audience.user_id,
-                        type_="content_suggestions_failed",
-                        title="Content Suggestions Failed",
-                        message=f"Failed to generate suggestions for audience '{audience.name}': {e}",
-                        metadata={
-                            "audience_id": str(audience_id),
-                            "analysis_id": str(analysis_id),
-                            "error": str(e),
-                        },
+                        audience_id=audience_id,
+                        audience_name=audience.name,
+                        analysis_id=analysis_id,
+                        error=str(e),
                     )
             except Exception:
                 pass

--- a/app/modules/content_suggestions/application/use_cases/produce_content_use_case/produce_content_use_case.py
+++ b/app/modules/content_suggestions/application/use_cases/produce_content_use_case/produce_content_use_case.py
@@ -105,16 +105,18 @@ class ProduceContentUseCase:
                 os.getenv("MODEL_NAME", "gpt-5-nano-2025-08-07"),
             )
 
-            result = agent.invoke({
-                "suggestion": suggestion_dict,
-                "target_platforms": target_platforms,
-                "audience_name": audience.name,
-                "audience_description": audience.description,
-                "community_names": community_names,
-                "language": language,
-                "platform_drafts": [],
-                "refined_drafts": [],
-            })
+            result = agent.invoke(
+                {
+                    "suggestion": suggestion_dict,
+                    "target_platforms": target_platforms,
+                    "audience_name": audience.name,
+                    "audience_description": audience.description,
+                    "community_names": community_names,
+                    "language": language,
+                    "platform_drafts": [],
+                    "refined_drafts": [],
+                }
+            )
 
             refined = result.get("refined_drafts", [])
             if not refined:
@@ -153,19 +155,14 @@ class ProduceContentUseCase:
                     NotificationEventService,
                 )
 
-                platforms_str = ", ".join(target_platforms)
-                NotificationEventService(self.db).notify(
+                NotificationEventService(self.db).notify_content_production_ready(
                     user_id=audience.user_id,
-                    type_="content_production_ready",
-                    title="Content Ready",
-                    message=f"Content for '{suggestion.title[:80]}' ready on {platforms_str}.",
-                    metadata={
-                        "audience_id": str(analysis.audience_id),
-                        "suggestion_id": str(suggestion_id),
-                        "platforms": target_platforms,
-                        "draft_count": len(refined),
-                        "has_image": bool(image_url),
-                    },
+                    audience_id=analysis.audience_id,
+                    suggestion_id=suggestion_id,
+                    suggestion_title=suggestion.title,
+                    platforms=target_platforms,
+                    draft_count=len(refined),
+                    has_image=bool(image_url),
                 )
             except Exception:
                 logger.debug("Failed to send notification for content production")
@@ -187,18 +184,19 @@ class ProduceContentUseCase:
                         NotificationEventService,
                     )
 
-                    NotificationEventService(self.db).notify(
-                        user_id=suggestion.analysis.audience.user_id
+                    user_id = (
+                        suggestion.analysis.audience.user_id
                         if hasattr(suggestion.analysis, "audience")
-                        else None,
-                        type_="content_production_failed",
-                        title="Content Production Failed",
-                        message=f"Failed to produce content: {e}",
-                        metadata={
-                            "suggestion_id": str(suggestion_id),
-                            "error": str(e),
-                        },
+                        else None
                     )
+                    if user_id:
+                        NotificationEventService(
+                            self.db
+                        ).notify_content_production_failed(
+                            user_id=user_id,
+                            suggestion_id=suggestion_id,
+                            error=str(e),
+                        )
             except Exception:
                 pass
             return False
@@ -243,9 +241,7 @@ class ProduceContentUseCase:
             )
 
             storage = StorageService()
-            key = storage.generate_key(
-                prefix=f"content-images/{suggestion_id}"
-            )
+            key = storage.generate_key(prefix=f"content-images/{suggestion_id}")
             storage.upload(data=image_bytes, key=key)
 
             # Registrar arquivo na tabela uploaded_files

--- a/app/modules/notifications/application/services/notification_event_service.py
+++ b/app/modules/notifications/application/services/notification_event_service.py
@@ -8,27 +8,13 @@ from uuid import UUID
 from redis import Redis
 from sqlalchemy.orm import Session
 
+from app.modules.identity.domain.entities.user import User
+from app.modules.notifications.application.services.notification_messages import t
 from app.modules.notifications.infra.repositories.notification_repository import (
     NotificationRepository,
 )
 
 logger = logging.getLogger(__name__)
-
-# Labels legíveis para cada tipo de análise
-_TYPE_LABELS = {
-    "topic_analysis": "Topic Analysis",
-    "keyword_analysis": "Keyword Analysis",
-    "deep_dive": "Deep Dive",
-    "pattern_analysis": "Pattern Analysis",
-    "behavioral_pattern": "Behavioral Patterns",
-    "theme_analysis": "Theme Analysis",
-    "intent_classification": "Intent Classification",
-    "theme_summary": "Theme Summary",
-    "communities_changed": "Communities Update",
-    "communities_validation_failed": "Community Validation",
-    "youtube_validation": "YouTube Validation",
-    "product_intelligence": "Product Intelligence",
-}
 
 
 class NotificationEventService:
@@ -39,6 +25,21 @@ class NotificationEventService:
         self.repo = NotificationRepository(db)
         redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
         self._redis = Redis.from_url(redis_url, decode_responses=True)
+
+    # ── helpers ──────────────────────────────────────────────
+
+    def _get_user_language(self, user_id: UUID) -> str:
+        """Retorna o idioma preferido do usuário ou 'en' como fallback."""
+        try:
+            user = self.db.query(User.preferred_language).filter_by(id=user_id).first()
+            return user[0] if user and user[0] else "en"
+        except Exception:
+            logger.debug(
+                "Could not fetch language for user %s, defaulting to en", user_id
+            )
+            return "en"
+
+    # ── core ─────────────────────────────────────────────────
 
     def notify(
         self,
@@ -76,6 +77,8 @@ class NotificationEventService:
                 "Failed to publish notification to Redis for user %s", user_id
             )
 
+    # ── analysis complete / failed ───────────────────────────
+
     def notify_analysis_complete(
         self,
         user_id: UUID,
@@ -87,12 +90,16 @@ class NotificationEventService:
         topic_name: str | None = None,
     ) -> None:
         """Notificação de análise concluída com sucesso."""
-        label = _TYPE_LABELS.get(analysis_type, analysis_type)
-        context = (
-            f" for topic '{topic_name}'"
-            if topic_name
-            else f" for audience '{audience_name}'"
-        )
+        lang = self._get_user_language(user_id)
+
+        if topic_name:
+            msg_key = f"{analysis_type}_complete_msg_topic"
+            msg = t(msg_key, lang, topic_name=topic_name)
+        else:
+            msg_key = f"{analysis_type}_complete_msg_audience"
+            msg = t(msg_key, lang, audience_name=audience_name)
+
+        title = t(f"{analysis_type}_complete_title", lang)
 
         metadata = {
             "audience_id": str(audience_id),
@@ -106,8 +113,8 @@ class NotificationEventService:
         self.notify(
             user_id=user_id,
             type_=f"{analysis_type}_complete",
-            title=f"{label} Ready",
-            message=f"{label} analysis{context} is complete.",
+            title=title,
+            message=msg,
             metadata=metadata,
         )
 
@@ -123,12 +130,16 @@ class NotificationEventService:
         topic_name: str | None = None,
     ) -> None:
         """Notificação de análise que falhou."""
-        label = _TYPE_LABELS.get(analysis_type, analysis_type)
-        context = (
-            f" for topic '{topic_name}'"
-            if topic_name
-            else f" for audience '{audience_name}'"
-        )
+        lang = self._get_user_language(user_id)
+
+        if topic_name:
+            msg_key = f"{analysis_type}_failed_msg_topic"
+            msg = t(msg_key, lang, topic_name=topic_name)
+        else:
+            msg_key = f"{analysis_type}_failed_msg_audience"
+            msg = t(msg_key, lang, audience_name=audience_name)
+
+        title = t(f"{analysis_type}_failed_title", lang)
 
         metadata = {
             "audience_id": str(audience_id),
@@ -143,7 +154,176 @@ class NotificationEventService:
         self.notify(
             user_id=user_id,
             type_=f"{analysis_type}_failed",
-            title=f"{label} Failed",
-            message=f"{label} analysis{context} failed: {error_message}",
+            title=title,
+            message=msg,
             metadata=metadata,
+        )
+
+    # ── communities ──────────────────────────────────────────
+
+    def notify_communities_updated(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        added: list[str],
+        removed: list[str],
+    ) -> None:
+        """Notificação de comunidades atualizadas na audiência."""
+        lang = self._get_user_language(user_id)
+
+        self.notify(
+            user_id=user_id,
+            type_="communities_changed",
+            title=t("communities_updated_title", lang),
+            message=t(
+                "communities_updated_msg",
+                lang,
+                added=len(added),
+                removed=len(removed),
+            ),
+            metadata={
+                "audience_id": str(audience_id),
+                "added": sorted(added),
+                "removed": sorted(removed),
+            },
+        )
+
+    def notify_communities_invalid(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        invalid_names: list[str],
+    ) -> None:
+        """Notificação de comunidades inválidas removidas."""
+        lang = self._get_user_language(user_id)
+
+        self.notify(
+            user_id=user_id,
+            type_="communities_validation_failed",
+            title=t("communities_invalid_title", lang),
+            message=t(
+                "communities_invalid_msg",
+                lang,
+                names=", ".join(invalid_names),
+            ),
+            metadata={
+                "audience_id": str(audience_id),
+                "invalid_names": invalid_names,
+            },
+        )
+
+    # ── content suggestions ──────────────────────────────────
+
+    def notify_content_suggestions_ready(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        audience_name: str,
+        analysis_id: UUID,
+        suggestion_count: int,
+        metadata_extra: dict | None = None,
+    ) -> None:
+        """Notificação de sugestões de conteúdo prontas."""
+        lang = self._get_user_language(user_id)
+
+        meta = {
+            "audience_id": str(audience_id),
+            "analysis_id": str(analysis_id),
+            "suggestion_count": suggestion_count,
+        }
+        if metadata_extra:
+            meta.update(metadata_extra)
+
+        self.notify(
+            user_id=user_id,
+            type_="content_suggestions_ready",
+            title=t("content_suggestions_ready_title", lang),
+            message=t(
+                "content_suggestions_ready_msg",
+                lang,
+                count=suggestion_count,
+                audience_name=audience_name,
+            ),
+            metadata=meta,
+        )
+
+    def notify_content_suggestions_failed(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        audience_name: str,
+        analysis_id: UUID,
+        error: str,
+    ) -> None:
+        """Notificação de falha nas sugestões de conteúdo."""
+        lang = self._get_user_language(user_id)
+
+        self.notify(
+            user_id=user_id,
+            type_="content_suggestions_failed",
+            title=t("content_suggestions_failed_title", lang),
+            message=t(
+                "content_suggestions_failed_msg",
+                lang,
+                audience_name=audience_name,
+            ),
+            metadata={
+                "audience_id": str(audience_id),
+                "analysis_id": str(analysis_id),
+                "error": error,
+            },
+        )
+
+    # ── content production ───────────────────────────────────
+
+    def notify_content_production_ready(
+        self,
+        user_id: UUID,
+        audience_id: UUID,
+        suggestion_id: UUID,
+        suggestion_title: str,
+        platforms: list[str],
+        draft_count: int,
+        has_image: bool = False,
+    ) -> None:
+        """Notificação de conteúdo produzido com sucesso."""
+        lang = self._get_user_language(user_id)
+
+        self.notify(
+            user_id=user_id,
+            type_="content_production_ready",
+            title=t("content_production_ready_title", lang),
+            message=t(
+                "content_production_ready_msg",
+                lang,
+                title=suggestion_title[:80],
+                platforms=", ".join(platforms),
+            ),
+            metadata={
+                "audience_id": str(audience_id),
+                "suggestion_id": str(suggestion_id),
+                "platforms": platforms,
+                "draft_count": draft_count,
+                "has_image": has_image,
+            },
+        )
+
+    def notify_content_production_failed(
+        self,
+        user_id: UUID,
+        suggestion_id: UUID,
+        error: str,
+    ) -> None:
+        """Notificação de falha na produção de conteúdo."""
+        lang = self._get_user_language(user_id)
+
+        self.notify(
+            user_id=user_id,
+            type_="content_production_failed",
+            title=t("content_production_failed_title", lang),
+            message=t("content_production_failed_msg", lang),
+            metadata={
+                "suggestion_id": str(suggestion_id),
+                "error": error,
+            },
         )

--- a/app/modules/notifications/application/services/notification_messages.py
+++ b/app/modules/notifications/application/services/notification_messages.py
@@ -1,0 +1,403 @@
+"""Catálogo de traduções para mensagens de notificação do sistema.
+
+Organizado por idioma → chave de mensagem → template com placeholders.
+Fallback automático para inglês quando a tradução não existe.
+"""
+
+_CATALOG: dict[str, dict[str, str]] = {
+    # ──────────────────────────────────────────────────────────
+    # English (default / fallback)
+    # ──────────────────────────────────────────────────────────
+    "en": {
+        # --- Analysis complete ---
+        "topic_analysis_complete_title": "Topic Analysis Complete",
+        "topic_analysis_complete_msg_audience": (
+            "Topic analysis for audience '{audience_name}' is ready for viewing."
+        ),
+        "topic_analysis_complete_msg_topic": (
+            "Topic analysis for topic '{topic_name}' is ready for viewing."
+        ),
+        "keyword_analysis_complete_title": "Keyword Analysis Complete",
+        "keyword_analysis_complete_msg_audience": (
+            "Keyword analysis for audience '{audience_name}' is ready for viewing."
+        ),
+        "keyword_analysis_complete_msg_topic": (
+            "Keyword analysis for topic '{topic_name}' is ready for viewing."
+        ),
+        "deep_dive_complete_title": "Deep Dive Complete",
+        "deep_dive_complete_msg_audience": (
+            "Deep dive for audience '{audience_name}' is ready for viewing."
+        ),
+        "deep_dive_complete_msg_topic": (
+            "Deep dive for topic '{topic_name}' is ready for viewing."
+        ),
+        "pattern_analysis_complete_title": "Pattern Analysis Complete",
+        "pattern_analysis_complete_msg_audience": (
+            "Pattern analysis for audience '{audience_name}' is ready for viewing."
+        ),
+        "pattern_analysis_complete_msg_topic": (
+            "Pattern analysis for topic '{topic_name}' is ready for viewing."
+        ),
+        "behavioral_pattern_complete_title": "Behavioral Patterns Complete",
+        "behavioral_pattern_complete_msg_audience": (
+            "Behavioral pattern analysis for audience '{audience_name}' is ready for viewing."
+        ),
+        "behavioral_pattern_complete_msg_topic": (
+            "Behavioral pattern analysis for topic '{topic_name}' is ready for viewing."
+        ),
+        "theme_analysis_complete_title": "Theme Analysis Complete",
+        "theme_analysis_complete_msg_audience": (
+            "Theme analysis for audience '{audience_name}' is ready for viewing."
+        ),
+        "theme_analysis_complete_msg_topic": (
+            "Theme analysis for topic '{topic_name}' is ready for viewing."
+        ),
+        "intent_classification_complete_title": "Intent Classification Complete",
+        "intent_classification_complete_msg_audience": (
+            "Intent classification for audience '{audience_name}' is ready for viewing."
+        ),
+        "intent_classification_complete_msg_topic": (
+            "Intent classification for topic '{topic_name}' is ready for viewing."
+        ),
+        "theme_summary_complete_title": "Theme Summary Complete",
+        "theme_summary_complete_msg_audience": (
+            "Theme summary for audience '{audience_name}' is ready for viewing."
+        ),
+        "theme_summary_complete_msg_topic": (
+            "Theme summary for topic '{topic_name}' is ready for viewing."
+        ),
+        "youtube_validation_complete_title": "YouTube Validation Complete",
+        "youtube_validation_complete_msg_audience": (
+            "YouTube validation for audience '{audience_name}' is ready for viewing."
+        ),
+        "youtube_validation_complete_msg_topic": (
+            "YouTube validation for topic '{topic_name}' is ready for viewing."
+        ),
+        "product_intelligence_complete_title": "Product Intelligence Complete",
+        "product_intelligence_complete_msg_audience": (
+            "Product intelligence for audience '{audience_name}' is ready for viewing."
+        ),
+        "product_intelligence_complete_msg_topic": (
+            "Product intelligence for topic '{topic_name}' is ready for viewing."
+        ),
+        # --- Analysis failed ---
+        "topic_analysis_failed_title": "Topic Analysis Failed",
+        "topic_analysis_failed_msg_audience": (
+            "Topic analysis for audience '{audience_name}' failed. Please try again."
+        ),
+        "topic_analysis_failed_msg_topic": (
+            "Topic analysis for topic '{topic_name}' failed. Please try again."
+        ),
+        "keyword_analysis_failed_title": "Keyword Analysis Failed",
+        "keyword_analysis_failed_msg_audience": (
+            "Keyword analysis for audience '{audience_name}' failed. Please try again."
+        ),
+        "keyword_analysis_failed_msg_topic": (
+            "Keyword analysis for topic '{topic_name}' failed. Please try again."
+        ),
+        "deep_dive_failed_title": "Deep Dive Failed",
+        "deep_dive_failed_msg_audience": (
+            "Deep dive for audience '{audience_name}' failed. Please try again."
+        ),
+        "deep_dive_failed_msg_topic": (
+            "Deep dive for topic '{topic_name}' failed. Please try again."
+        ),
+        "pattern_analysis_failed_title": "Pattern Analysis Failed",
+        "pattern_analysis_failed_msg_audience": (
+            "Pattern analysis for audience '{audience_name}' failed. Please try again."
+        ),
+        "pattern_analysis_failed_msg_topic": (
+            "Pattern analysis for topic '{topic_name}' failed. Please try again."
+        ),
+        "behavioral_pattern_failed_title": "Behavioral Patterns Failed",
+        "behavioral_pattern_failed_msg_audience": (
+            "Behavioral pattern analysis for audience '{audience_name}' failed. Please try again."
+        ),
+        "behavioral_pattern_failed_msg_topic": (
+            "Behavioral pattern analysis for topic '{topic_name}' failed. Please try again."
+        ),
+        "theme_analysis_failed_title": "Theme Analysis Failed",
+        "theme_analysis_failed_msg_audience": (
+            "Theme analysis for audience '{audience_name}' failed. Please try again."
+        ),
+        "theme_analysis_failed_msg_topic": (
+            "Theme analysis for topic '{topic_name}' failed. Please try again."
+        ),
+        "intent_classification_failed_title": "Intent Classification Failed",
+        "intent_classification_failed_msg_audience": (
+            "Intent classification for audience '{audience_name}' failed. Please try again."
+        ),
+        "intent_classification_failed_msg_topic": (
+            "Intent classification for topic '{topic_name}' failed. Please try again."
+        ),
+        "theme_summary_failed_title": "Theme Summary Failed",
+        "theme_summary_failed_msg_audience": (
+            "Theme summary for audience '{audience_name}' failed. Please try again."
+        ),
+        "theme_summary_failed_msg_topic": (
+            "Theme summary for topic '{topic_name}' failed. Please try again."
+        ),
+        "youtube_validation_failed_title": "YouTube Validation Failed",
+        "youtube_validation_failed_msg_audience": (
+            "YouTube validation for audience '{audience_name}' failed. Please try again."
+        ),
+        "youtube_validation_failed_msg_topic": (
+            "YouTube validation for topic '{topic_name}' failed. Please try again."
+        ),
+        "product_intelligence_failed_title": "Product Intelligence Failed",
+        "product_intelligence_failed_msg_audience": (
+            "Product intelligence for audience '{audience_name}' failed. Please try again."
+        ),
+        "product_intelligence_failed_msg_topic": (
+            "Product intelligence for topic '{topic_name}' failed. Please try again."
+        ),
+        # --- Communities ---
+        "communities_updated_title": "Communities Updated",
+        "communities_updated_msg": (
+            "Audience communities updated: {added} added, {removed} removed."
+        ),
+        "communities_invalid_title": "Invalid Communities Removed",
+        "communities_invalid_msg": (
+            "The following communities were not found on Reddit "
+            "and have been removed: {names}"
+        ),
+        # --- Content suggestions ---
+        "content_suggestions_ready_title": "Content Suggestions Ready",
+        "content_suggestions_ready_msg": (
+            "{count} content suggestions generated for audience '{audience_name}'."
+        ),
+        "content_suggestions_failed_title": "Content Suggestions Failed",
+        "content_suggestions_failed_msg": (
+            "Failed to generate suggestions for audience '{audience_name}'. "
+            "Please try again."
+        ),
+        # --- Content production ---
+        "content_production_ready_title": "Content Ready",
+        "content_production_ready_msg": ("Content '{title}' is ready for {platforms}."),
+        "content_production_failed_title": "Content Production Failed",
+        "content_production_failed_msg": (
+            "Failed to produce content. Please try again."
+        ),
+    },
+    # ──────────────────────────────────────────────────────────
+    # Brazilian Portuguese
+    # ──────────────────────────────────────────────────────────
+    "pt-BR": {
+        # --- Analysis complete ---
+        "topic_analysis_complete_title": "Análise de Tópicos Concluída",
+        "topic_analysis_complete_msg_audience": (
+            "A análise de tópicos da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "topic_analysis_complete_msg_topic": (
+            "A análise de tópicos do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        "keyword_analysis_complete_title": "Análise de Keywords Concluída",
+        "keyword_analysis_complete_msg_audience": (
+            "A análise de keywords da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "keyword_analysis_complete_msg_topic": (
+            "A análise de keywords do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        "deep_dive_complete_title": "Deep Dive Concluído",
+        "deep_dive_complete_msg_audience": (
+            "O deep dive da audiência '{audience_name}' está pronto para visualização."
+        ),
+        "deep_dive_complete_msg_topic": (
+            "O deep dive do tópico '{topic_name}' está pronto para visualização."
+        ),
+        "pattern_analysis_complete_title": "Análise de Padrões Concluída",
+        "pattern_analysis_complete_msg_audience": (
+            "A análise de padrões da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "pattern_analysis_complete_msg_topic": (
+            "A análise de padrões do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        "behavioral_pattern_complete_title": "Padrões Comportamentais Concluídos",
+        "behavioral_pattern_complete_msg_audience": (
+            "A análise de padrões comportamentais da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "behavioral_pattern_complete_msg_topic": (
+            "A análise de padrões comportamentais do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        "theme_analysis_complete_title": "Análise de Temas Concluída",
+        "theme_analysis_complete_msg_audience": (
+            "A análise de temas da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "theme_analysis_complete_msg_topic": (
+            "A análise de temas do tópico '{topic_name}' está pronta para visualização."
+        ),
+        "intent_classification_complete_title": "Classificação de Intenções Concluída",
+        "intent_classification_complete_msg_audience": (
+            "A classificação de intenções da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "intent_classification_complete_msg_topic": (
+            "A classificação de intenções do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        "theme_summary_complete_title": "Resumo de Temas Concluído",
+        "theme_summary_complete_msg_audience": (
+            "O resumo de temas da audiência '{audience_name}' "
+            "está pronto para visualização."
+        ),
+        "theme_summary_complete_msg_topic": (
+            "O resumo de temas do tópico '{topic_name}' está pronto para visualização."
+        ),
+        "youtube_validation_complete_title": "Validação do YouTube Concluída",
+        "youtube_validation_complete_msg_audience": (
+            "A validação do YouTube da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "youtube_validation_complete_msg_topic": (
+            "A validação do YouTube do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        "product_intelligence_complete_title": "Inteligência de Produto Concluída",
+        "product_intelligence_complete_msg_audience": (
+            "A análise de inteligência de produto da audiência '{audience_name}' "
+            "está pronta para visualização."
+        ),
+        "product_intelligence_complete_msg_topic": (
+            "A análise de inteligência de produto do tópico '{topic_name}' "
+            "está pronta para visualização."
+        ),
+        # --- Analysis failed ---
+        "topic_analysis_failed_title": "Falha na Análise de Tópicos",
+        "topic_analysis_failed_msg_audience": (
+            "A análise de tópicos da audiência '{audience_name}' falhou. "
+            "Tente novamente."
+        ),
+        "topic_analysis_failed_msg_topic": (
+            "A análise de tópicos do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "keyword_analysis_failed_title": "Falha na Análise de Keywords",
+        "keyword_analysis_failed_msg_audience": (
+            "A análise de keywords da audiência '{audience_name}' falhou. "
+            "Tente novamente."
+        ),
+        "keyword_analysis_failed_msg_topic": (
+            "A análise de keywords do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "deep_dive_failed_title": "Falha no Deep Dive",
+        "deep_dive_failed_msg_audience": (
+            "O deep dive da audiência '{audience_name}' falhou. Tente novamente."
+        ),
+        "deep_dive_failed_msg_topic": (
+            "O deep dive do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "pattern_analysis_failed_title": "Falha na Análise de Padrões",
+        "pattern_analysis_failed_msg_audience": (
+            "A análise de padrões da audiência '{audience_name}' falhou. "
+            "Tente novamente."
+        ),
+        "pattern_analysis_failed_msg_topic": (
+            "A análise de padrões do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "behavioral_pattern_failed_title": "Falha nos Padrões Comportamentais",
+        "behavioral_pattern_failed_msg_audience": (
+            "A análise de padrões comportamentais da audiência '{audience_name}' "
+            "falhou. Tente novamente."
+        ),
+        "behavioral_pattern_failed_msg_topic": (
+            "A análise de padrões comportamentais do tópico '{topic_name}' "
+            "falhou. Tente novamente."
+        ),
+        "theme_analysis_failed_title": "Falha na Análise de Temas",
+        "theme_analysis_failed_msg_audience": (
+            "A análise de temas da audiência '{audience_name}' falhou. Tente novamente."
+        ),
+        "theme_analysis_failed_msg_topic": (
+            "A análise de temas do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "intent_classification_failed_title": "Falha na Classificação de Intenções",
+        "intent_classification_failed_msg_audience": (
+            "A classificação de intenções da audiência '{audience_name}' falhou. "
+            "Tente novamente."
+        ),
+        "intent_classification_failed_msg_topic": (
+            "A classificação de intenções do tópico '{topic_name}' falhou. "
+            "Tente novamente."
+        ),
+        "theme_summary_failed_title": "Falha no Resumo de Temas",
+        "theme_summary_failed_msg_audience": (
+            "O resumo de temas da audiência '{audience_name}' falhou. Tente novamente."
+        ),
+        "theme_summary_failed_msg_topic": (
+            "O resumo de temas do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "youtube_validation_failed_title": "Falha na Validação do YouTube",
+        "youtube_validation_failed_msg_audience": (
+            "A validação do YouTube da audiência '{audience_name}' falhou. "
+            "Tente novamente."
+        ),
+        "youtube_validation_failed_msg_topic": (
+            "A validação do YouTube do tópico '{topic_name}' falhou. Tente novamente."
+        ),
+        "product_intelligence_failed_title": "Falha na Inteligência de Produto",
+        "product_intelligence_failed_msg_audience": (
+            "A análise de inteligência de produto da audiência '{audience_name}' "
+            "falhou. Tente novamente."
+        ),
+        "product_intelligence_failed_msg_topic": (
+            "A análise de inteligência de produto do tópico '{topic_name}' "
+            "falhou. Tente novamente."
+        ),
+        # --- Communities ---
+        "communities_updated_title": "Comunidades Atualizadas",
+        "communities_updated_msg": (
+            "As comunidades da audiência foram atualizadas: "
+            "{added} adicionadas, {removed} removidas."
+        ),
+        "communities_invalid_title": "Comunidades Inválidas Removidas",
+        "communities_invalid_msg": (
+            "As seguintes comunidades não foram encontradas no Reddit "
+            "e foram removidas: {names}"
+        ),
+        # --- Content suggestions ---
+        "content_suggestions_ready_title": "Sugestões de Conteúdo Prontas",
+        "content_suggestions_ready_msg": (
+            "{count} sugestões de conteúdo geradas para a audiência '{audience_name}'."
+        ),
+        "content_suggestions_failed_title": "Falha nas Sugestões de Conteúdo",
+        "content_suggestions_failed_msg": (
+            "Não foi possível gerar sugestões para a audiência "
+            "'{audience_name}'. Tente novamente."
+        ),
+        # --- Content production ---
+        "content_production_ready_title": "Conteúdo Pronto",
+        "content_production_ready_msg": (
+            "O conteúdo '{title}' está pronto para {platforms}."
+        ),
+        "content_production_failed_title": "Falha na Produção de Conteúdo",
+        "content_production_failed_msg": (
+            "Não foi possível produzir o conteúdo. Tente novamente."
+        ),
+    },
+}
+
+DEFAULT_LANGUAGE = "en"
+
+
+def t(key: str, language: str, **params: object) -> str:
+    """Retorna a mensagem traduzida para o idioma, com fallback para inglês.
+
+    Args:
+        key: Chave da mensagem no catálogo (ex: "topic_analysis_complete_title").
+        language: Código do idioma (ex: "pt-BR", "en").
+        **params: Valores para interpolação nos templates (ex: audience_name="Foo").
+
+    Returns:
+        Mensagem traduzida e interpolada. Retorna a chave se não encontrada.
+    """
+    catalog = _CATALOG.get(language, _CATALOG[DEFAULT_LANGUAGE])
+    template = catalog.get(key, _CATALOG[DEFAULT_LANGUAGE].get(key, key))
+    return template.format(**params) if params else template


### PR DESCRIPTION
## Summary
- Added centralized translation catalog (`notification_messages.py`) with en + pt-BR support for all system notification messages
- `NotificationEventService` now auto-detects user's `preferred_language` and sends translated, contextual notifications
- Replaced all hardcoded English notification strings across 5 use case files with translated equivalents
- Improved message clarity: notifications now include audience/topic names for better context (e.g., "A análise de tópicos da audiência 'Tech Startups' está pronta para visualização")

## Test plan
- [ ] Set user `preferred_language` to `pt-BR` via `PATCH /auth/me/language` and trigger any analysis — verify notification arrives in Portuguese
- [ ] Set user `preferred_language` to `en` and trigger same analysis — verify notification arrives in English
- [ ] Update audience communities and verify `communities_changed` notification is translated
- [ ] Add invalid community names and verify `communities_validation_failed` notification is translated
- [ ] Generate content suggestions and verify ready/failed notifications are translated
- [ ] Verify fallback: if language is unsupported or missing, notifications default to English